### PR TITLE
MOON-21: Document layout global CSS classes

### DIFF
--- a/src/components/GlobalStyle/GlobalStyle.stories.jsx
+++ b/src/components/GlobalStyle/GlobalStyle.stories.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {withKnobs, select} from '@storybook/addon-knobs';
+import {storiesOf} from '@storybook/react';
+import markdownNotes from './GlobalStyle_layout.md';
+import classnames from 'classnames';
+import '~/styles/shared/all.scss';
+
+const justifyOptions = [null, 'center', 'reverse', 'between', 'nowrap'];
+const alignOptions = ['start', 'center', 'end'];
+const directionOptions = ['row', 'column'];
+
+const cssWrap = {
+    border: '2px solid red',
+    height: '300px'
+};
+
+// Define an item container to provide flex context and play with positioning
+const ItemContainer = ({title, direction, justify, align}) => {
+    const cssDirection = direction === 'row' ? 'flexRow' : 'flexCol';
+    const cssJustify = justify ? `${cssDirection}_${justify}` : cssDirection;
+    const cssAlign = align ? `align${align.charAt(0).toUpperCase() + align.slice(1)}` : null;
+    let css = classnames(cssJustify, cssAlign);
+
+    return (
+        <section style={{marginBottom: '48px'}}>
+            <h2 className="flexRow alignCenter"style={{marginBottom: '24px'}}>{title}:
+                <code style={{fontFamily: 'monospace', fontSize: '12px', padding: '4px', marginLeft: '8px', background: '#eee', borderRadius: '4px', color: '#444'}}>
+                    {css}
+                </code>
+            </h2>
+            <div className={classnames(cssJustify, cssAlign)} style={cssWrap}>
+                <Item/>
+                <Item/>
+                <Item/>
+                <Item/>
+                <Item/>
+                <Item/>
+                <Item/>
+                <Item/>
+                <Item/>
+                <Item/>
+                <Item/>
+                <Item/>
+            </div>
+        </section>
+    );
+};
+
+// Just an item to positioning
+const Item = () => {
+    return (
+        <div style={{
+            width: '80px',
+            height: '80px',
+            backgroundColor: '#ccc',
+            border: '1px solid #000'
+        }}
+         />
+    );
+};
+
+ItemContainer.propTypes = {
+    title: PropTypes.string,
+    justify: PropTypes.oneOf(justifyOptions),
+    align: PropTypes.oneOf(alignOptions),
+    direction: PropTypes.oneOf(['row', 'col'])
+};
+
+function displayItems(direction, type) {
+    let display = [];
+    let arrayOptions = [];
+
+    if (type === 'justify') {
+        arrayOptions = justifyOptions;
+    } else if (type === 'align') {
+        arrayOptions = alignOptions;
+    }
+
+    for (let option of arrayOptions) {
+        display.push(
+            <ItemContainer
+                title={`${type} ${classnames(option)}`}
+                direction={direction}
+                justify={type === 'justify' ? option : 'center'}
+                align={type === 'align' ? option : 'center'}
+            />
+        );
+    }
+
+    return display;
+}
+
+storiesOf('Global CSS|Layout', module)
+    .addDecorator(withKnobs)
+    .addParameters({
+        componentSubtitle: 'Layout',
+        notes: {markdown: markdownNotes}
+    })
+    .add('Direction', () => (
+        <>
+            <ItemContainer
+                title="Horizontal flow"
+                direction="row"
+            />
+            <ItemContainer
+                title="Vertical flow"
+                direction="col"
+            />
+        </>
+    ))
+    .add('Justify', () => (
+        <>
+            {displayItems('row', 'justify')}
+        </>
+    ))
+    .add('Alignment', () => (
+        <>
+            {displayItems('row', 'align')}
+        </>
+    ))
+    .add('⚽️Playground', () => (
+        <ItemContainer
+            title="CSS Classes"
+            direction={select('Direction', directionOptions, 'row')}
+            justify={select('Justify', justifyOptions, 'center')}
+            align={select('Alignment', alignOptions, 'center')}
+        />
+    ));

--- a/src/components/GlobalStyle/GlobalStyle_layout.md
+++ b/src/components/GlobalStyle/GlobalStyle_layout.md
@@ -1,0 +1,45 @@
+# Layout CSS
+
+We provide some useful global classes with flex-box to help you to positionning elements.
+The classes should be added on container element to enable a flex context.
+The classnames try to fit to CSS flex properties.
+
+
+
+## Direction
+
+First you have to define the flex direction horizontal or vertical layout.
+
+| CSS        | Description         |
+| ---------- | ------------------- |
+| `.flexRow` | Horizontal **row**  |
+| `.flexCol` | Vertical **column** |
+
+Then you can add a modifier to justify content, the justification follow the direction flow. Modifiers extend the default class, for example you don't need to repeat `.flexRow.flexRow_center` you just have to write `.flexRow_center`.
+
+| CSS                                   | Description                                       |
+| ------------------------------------- | ------------------------------------------------- |
+| `.flexRow_reverse` `.flexCol_reverse` | Content is placed at the **end** of the container |
+| `.flexRow_center` `.flexCol_center`   | Content is placed at **center** of the container  |
+| `.flexRow_between` `.flexCol_between` | Content is **distributed** equally between items  |
+| `.flexRow_nowrap` `.flexCol_nowrap`   | Content is forced onto **one line**               |
+
+
+
+## Alignment
+
+To align items in the opposite axis of the flow. Under the wood this classes just add `align-items` property.
+
+| CSS           | Description                      |
+| ------------- | -------------------------------- |
+| `alignCenter` | Pack items around the **center** |
+| `alignStart`  | Pack items from the **start**    |
+| `alignEnd`    | Pack items from the **bottom**   |
+
+
+
+## Helpers
+
+| CSS          | Description                                                                                                           |
+| ------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `.flexFluid` | The Item take all the place disponible. You must use this classe under a flex context. This class just add `flex: 1`. |

--- a/src/icons/Icons.stories.jsx
+++ b/src/icons/Icons.stories.jsx
@@ -49,7 +49,7 @@ storiesOf('Tokens|Icons', module)
             {displayIcons()}
         </section>
     ))
-    .add('Playground', () => (
+    .add('⚽️Playground', () => (
         <IconWrapper
             iconName={select('Choose your icon', iconsName, 'Edit')}
             size={iconsSize()}

--- a/src/styles/global/_layout.scss
+++ b/src/styles/global/_layout.scss
@@ -4,7 +4,7 @@
 
 %flex-column {
     display: flex;
-    flex-direction: column;
+    flex-flow: column wrap;
 }
 
 %flex-row {
@@ -12,57 +12,84 @@
     flex-flow: row wrap;
 }
 
-// Horizontal layout
+// ---
+// Horizontal
+// ---
 :global(.flexRow) {
     @extend %flex-row;
-
-    &_nowrap {
-        display: flex;
-        flex-direction: row;
-    }
-
-    &_reverse {
-        @extend %flex-row;
-
-        justify-content: flex-end;
-    }
-
-    &_center {
-        @extend %flex-row;
-
-        justify-content: center;
-    }
-
-    &_between {
-        @extend %flex-row;
-
-        justify-content: space-between;
-    }
 }
 
-// Vertical layout
+:global(.flexRow_nowrap) {
+    display: flex;
+    flex-direction: row;
+}
+
+:global(.flexRow_reverse) {
+    @extend %flex-row;
+
+    justify-content: flex-end;
+}
+
+:global(.flexRow_center) {
+    @extend %flex-row;
+
+    justify-content: center;
+}
+
+:global(.flexRow_between) {
+    @extend %flex-row;
+
+    justify-content: space-between;
+}
+
+// ---
+// Vertical
+// ---
 :global(.flexCol) {
     @extend %flex-column;
-
-    &_reverse {
-        @extend %flex-column;
-
-        justify-content: flex-end;
-    }
 }
 
+:global(.flexCol_nowrap) {
+    display: flex;
+    flex-direction: column;
+}
+
+:global(.flexCol_reverse) {
+    @extend %flex-column;
+
+    justify-content: flex-end;
+}
+
+:global(.flexCol_center) {
+    @extend %flex-column;
+
+    justify-content: center;
+}
+
+:global(.flexCol_between) {
+    @extend %flex-column;
+
+    justify-content: space-between;
+}
+
+// ---
+// Alignment
+// ---
 :global(.alignCenter) {
     align-items: center;
 }
 
-:global(.alignTop) {
+:global(.alignStart) {
     align-items: flex-start;
 }
 
-:global(.alignBottom) {
+:global(.alignEnd) {
     align-items: flex-end;
 }
 
+// ---
+// Helpers
+// ---
 :global(.flexFluid) {
     flex: 1;
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-21

## Description

- Fix css generated with `:global` flag
- Add modifier for `.flexCol` to be consistant with `flexRow`
- Create a storybook with documentation for `style/global/layout.scss`

## Documentation

<!--
Indicate if you have been writing documentation has part of this change.
-->

- [X] README documentation
