### PR TITLE
MOON-38 : The children props of PrimaryNavItemGroup should accept one node

### DIFF
--- a/src/components/PrimaryNav/PrimaryNavItemsGroup/PrimaryNavItemsGroup.jsx
+++ b/src/components/PrimaryNav/PrimaryNavItemsGroup/PrimaryNavItemsGroup.jsx
@@ -39,5 +39,5 @@ PrimaryNavItemsGroup.propTypes = {
     /**
      * Items displayed inside the group
      */
-    children: PropTypes.arrayOf(PropTypes.node).isRequired
+    children: PropTypes.node.isRequired
 };


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-38

## Description

The children props of PrimaryNavItemGroup should accept one node
