### PR TITLE
MOON-50: Allow custom attributes in Chip component

### DIFF
--- a/src/components/Chip/Chip.jsx
+++ b/src/components/Chip/Chip.jsx
@@ -6,8 +6,8 @@ import classnames from 'clsx';
 
 export const colors = ['default', 'accent', 'success', 'warning', 'danger'];
 
-export const Chip = ({label, color, icon}) => (
-    <div className={classnames(styles.chip, styles[`color_${color}`])}>
+export const Chip = ({label, color, icon, ...props}) => (
+    <div className={classnames(styles.chip, styles[`color_${color}`])} {...props}>
         {icon && <>{icon}</>}{label && <Typography isNowrap component="span">{label}</Typography>}
     </div>
 );

--- a/src/components/Chip/Chip.spec.js
+++ b/src/components/Chip/Chip.spec.js
@@ -20,4 +20,9 @@ describe('Chip', () => {
         expect(wrapper.html()).toContain('Icon');
         expect(wrapper.html()).toContain('MyChip');
     });
+
+    it('should render custom attributes', () => {
+        const wrapper = shallow(<Chip label="test" role="myRole"/>);
+        expect(wrapper.querySelector('[role="myRole"]').exists()).toBeTruthy();
+    });
 });

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,5 @@
 export * from './Button';
+export * from './Chip';
 export * from './GlobalStyle';
 export * from './PrimaryNav';
 export * from './PrimaryNav/PrimaryNavItem';


### PR DESCRIPTION
## JIRA
https://jira.jahia.org/browse/MOON-50

## Description
- Chip component now accept and render custom properties as attributes
- Chip component has been added to component's index to be exported properly

