### PR TITLE
MOON-50: Allow CSS customization of Chip component

### DIFF
--- a/src/components/Chip/Chip.jsx
+++ b/src/components/Chip/Chip.jsx
@@ -6,8 +6,8 @@ import classnames from 'clsx';
 
 export const colors = ['default', 'accent', 'success', 'warning', 'danger'];
 
-export const Chip = ({label, color, icon, ...props}) => (
-    <div className={classnames(styles.chip, styles[`color_${color}`])} {...props}>
+export const Chip = ({label, color, icon, className, ...props}) => (
+    <div className={classnames(styles.chip, styles[`color_${color}`], className)} {...props}>
         {icon && <>{icon}</>}{label && <Typography isNowrap component="span">{label}</Typography>}
     </div>
 );
@@ -32,7 +32,12 @@ Chip.propTypes = {
     /**
      * Badge icon
      */
-    icon: PropTypes.node
+    icon: PropTypes.node,
+
+    /**
+     * Additional classname
+     */
+    className: PropTypes.string
 };
 
 Chip.displayName = 'Chip';

--- a/src/components/Chip/Chip.spec.js
+++ b/src/components/Chip/Chip.spec.js
@@ -25,4 +25,11 @@ describe('Chip', () => {
         const wrapper = shallow(<Chip label="test" role="myRole"/>);
         expect(wrapper.querySelector('[role="myRole"]').exists()).toBeTruthy();
     });
+
+    it('should support custom CSS class', () => {
+        const wrapper = shallow(<Chip label="test" className="stuff"/>);
+        const found = wrapper.html().match(/ class="([^"]*)"/);
+        const classNames = found ? found[1] : '';
+        expect(classNames.split(' ').includes('stuff')).toBeTruthy();
+    });
 });


### PR DESCRIPTION
Added a className property to be able to provide custom CSS classes.

## JIRA
https://jira.jahia.org/browse/MOON-50