### PR TITLE
MOON-48: Update API of Typography component

### DIFF
--- a/src/components/Accordion/AccordionItem/AccordionItem.jsx
+++ b/src/components/Accordion/AccordionItem/AccordionItem.jsx
@@ -47,7 +47,8 @@ export const AccordionItem = ({id, label, icon, onClick, children, className, ..
                     </div>}
                 <Typography
                     isNowrap
-                    variant={open ? 'strong' : 'regular'}
+                    variant="subheading"
+                    weight={open ? 'bold' : 'default'}
                     className={classnames('flexFluid')}
                 >
                     {label}

--- a/src/components/Chip/Chip.jsx
+++ b/src/components/Chip/Chip.jsx
@@ -8,7 +8,8 @@ export const colors = ['default', 'accent', 'success', 'warning', 'danger'];
 
 export const Chip = ({label, color, icon, className, ...props}) => (
     <div className={classnames(styles.chip, styles[`color_${color}`], className)} {...props}>
-        {icon && <>{icon}</>}{label && <Typography isNowrap component="span">{label}</Typography>}
+        {icon && <>{icon}</>}
+        {label && <Typography isNowrap component="span" variant="caption" weight="semiBold">{label}</Typography>}
     </div>
 );
 

--- a/src/components/PrimaryNav/PrimaryNavItem/PrimaryNavItem.jsx
+++ b/src/components/PrimaryNav/PrimaryNavItem/PrimaryNavItem.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './PrimaryNavItem.scss';
 import classnames from 'clsx';
-import {Typography, TypographyVariants} from '~/components/Typography';
+import {Typography, variants as typographyVariants} from '~/components/Typography';
 
 // Internal component
 const Item = ({icon, label, textVariant, subtitle, button}) => (
@@ -19,7 +19,7 @@ const Item = ({icon, label, textVariant, subtitle, button}) => (
                     {label}
                 </Typography>
                 {subtitle &&
-                <Typography isNowrap component="div" variant="subtitle" className={classnames(styles.primaryNavItem_label)}>
+                <Typography isNowrap component="div" variant="caption" className={classnames(styles.primaryNavItem_label, styles.subtitle)}>
                     {subtitle}
                 </Typography>}
             </div>
@@ -34,7 +34,7 @@ const Item = ({icon, label, textVariant, subtitle, button}) => (
 Item.propTypes = {
     label: PropTypes.string,
     icon: PropTypes.element,
-    textVariant: PropTypes.oneOf(TypographyVariants),
+    textVariant: PropTypes.oneOf(typographyVariants),
     subtitle: PropTypes.string,
     button: PropTypes.node
 };
@@ -44,13 +44,13 @@ const ItemTypeResolver = ({url, icon, label, subtitle, button}) => {
     if (url) {
         return (
             <a className={classnames(styles.primaryNavItem, styles.primaryNavItem_linkItem)} href={url} target="_blank" rel="noopener noreferrer">
-                <Item icon={icon} label={label} subtitle={subtitle} textVariant="caption" button={button}/>
+                <Item icon={icon} label={label} subtitle={subtitle} textVariant="body" button={button}/>
             </a>
         );
     }
 
     return (
-        <Item icon={icon} label={label} subtitle={subtitle} textVariant="regular" button={button}/>
+        <Item icon={icon} label={label} subtitle={subtitle} textVariant="subheading" weight="bold" button={button}/>
     );
 };
 

--- a/src/components/PrimaryNav/PrimaryNavItem/PrimaryNavItem.scss
+++ b/src/components/PrimaryNav/PrimaryNavItem/PrimaryNavItem.scss
@@ -48,6 +48,10 @@
 .primaryNavItem_label {
     color: inherit;
     text-decoration: none;
+
+    &.subtitle {
+        color: var(--color-light60);
+    }
 }
 
 .primaryNavItem_textContainer {

--- a/src/components/TreeView/ControlledTreeView.jsx
+++ b/src/components/TreeView/ControlledTreeView.jsx
@@ -110,14 +110,13 @@ export const ControlledTreeView = ({data, openedItems, selectedItems, onClickIte
                                 onDoubleClick={handleNodeDoubleClick}
                             >
                                 {displayIcon(node.iconStart, 'small', styles.treeView_itemIconStart)}
-
                                 <Typography isNowrap
                                             className={classnames('flexFluid')}
                                             component="span"
+                                            variant="body"
                                 >
                                     {node.label}
                                 </Typography>
-
                                 {displayIconOrLoading(node.iconEnd)}
                             </div>
                         </div>

--- a/src/components/Typography/Typography.jsx
+++ b/src/components/Typography/Typography.jsx
@@ -22,6 +22,7 @@ export const Typography = ({
     className,
     hasLineThrough,
     isItalic,
+    isUpperCase,
     isNowrap,
     ...props
 }) =>
@@ -36,6 +37,7 @@ export const Typography = ({
                 className,
                 {[styles.nowrap]: isNowrap},
                 {[styles.italic]: isItalic},
+                {[styles.upperCase]: isUpperCase},
                 {[styles.lineThrough]: hasLineThrough})
         },
         children
@@ -48,6 +50,7 @@ Typography.defaultProps = {
     variant: 'body',
     weight: 'default',
     isItalic: false,
+    isUpperCase: false,
     hasLineThrough: false,
     isHtml: false,
     isNowrap: false
@@ -98,6 +101,11 @@ Typography.propTypes = {
      * Should the text be displayed in italic
      */
     isItalic: PropTypes.bool,
+
+    /**
+     * Should the text be displayed in upper case
+     */
+    isUpperCase: PropTypes.bool,
 
     /**
      * Should the text be displayed with a line-through

--- a/src/components/Typography/Typography.jsx
+++ b/src/components/Typography/Typography.jsx
@@ -1,18 +1,10 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
 import styles from './Typography.scss';
 import classnames from 'clsx';
 
-export const TypographyVariants = [
-    'page',
-    'section',
-    'regular',
-    'caption',
-    'strong',
-    'button',
-    'subtitle'
-];
+export const variants = ['title', 'heading', 'subheading', 'body', 'caption', 'button'];
+export const weights = ['default', 'bold', 'semiBold', 'light'];
 
 const filterOutProps = function (props, out) {
     const newProps = {...props};
@@ -26,7 +18,10 @@ export const Typography = ({
     children,
     component,
     variant,
+    weight,
     className,
+    hasLineThrough,
+    isItalic,
     isNowrap,
     ...props
 }) =>
@@ -34,7 +29,14 @@ export const Typography = ({
         component,
         {
             ...filterOutProps(props, ['isHtml']),
-            className: classnames(styles.typography, styles[variant], className, {[styles.nowrap]: isNowrap})
+            className: classnames(
+                styles.typography,
+                styles[`variant_${variant}`],
+                styles[`weight_${weight}`],
+                className,
+                {[styles.nowrap]: isNowrap},
+                {[styles.italic]: isItalic},
+                {[styles.lineThrough]: hasLineThrough})
         },
         children
     );
@@ -43,7 +45,10 @@ Typography.defaultProps = {
     children: '',
     className: '',
     component: 'p',
-    variant: 'regular',
+    variant: 'body',
+    weight: 'default',
+    isItalic: false,
+    hasLineThrough: false,
     isHtml: false,
     isNowrap: false
 };
@@ -82,7 +87,22 @@ Typography.propTypes = {
     /**
      * Variant to use
      */
-    variant: PropTypes.oneOf(TypographyVariants),
+    variant: PropTypes.oneOf(variants),
+
+    /**
+     * The weight of the font to use
+     */
+    weight: PropTypes.oneOf(weights),
+
+    /**
+     * Should the text be displayed in italic
+     */
+    isItalic: PropTypes.bool,
+
+    /**
+     * Should the text be displayed with a line-through
+     */
+    hasLineThrough: PropTypes.bool,
 
     /**
      * Does the children contain HTML markup

--- a/src/components/Typography/Typography.scss
+++ b/src/components/Typography/Typography.scss
@@ -59,4 +59,8 @@
     &.lineThrough {
         text-decoration-line: line-through;
     }
+
+    &.upperCase {
+        text-transform: uppercase;
+    }
 }

--- a/src/components/Typography/Typography.scss
+++ b/src/components/Typography/Typography.scss
@@ -1,45 +1,62 @@
 @import '../../utils/index';
 
 .typography {
-    &.page {
-        font-weight: 400;
-        font-size: 28px;
-        line-height: 28px;
+    &.variant_title {
+        font-weight: 300;
+        font-size: 1.75rem; //28px
+        font-feature-settings: 'ordn' on, 'liga' off;
+        line-height: 2rem; //32px;
+        text-transform: capitalize;
     }
 
-    &.section {
+    &.variant_heading {
         font-weight: 600;
-        font-size: 20px;
-        line-height: 20px;
+        font-size: 1.25rem; //20px;
+        line-height: 1.5rem; //24px;
     }
 
-    &.regular {
-        font-weight: 400;
-        font-size: 16px;
-        line-height: 18px;
+    &.variant_subheading {
+        font-size: 1rem; //16px;
+        line-height: 1.125rem; //18px;
     }
 
-    &.caption {
-        font-weight: 400;
-        font-size: 14px;
-        line-height: 18px;
+    &.variant_body {
+        font-size: 0.875rem; //14px;
+        line-height: 1.1875rem; //19px;
     }
 
-    &.strong {
-        font-weight: 700;
-        font-size: 16px;
-        line-height: 18px;
+    &.variant_caption {
+        font-size: 0.75rem; //12px;
+        line-height: 1rem; //16px;
     }
 
-    &.subtitle {
-        font-weight: 400;
-        font-size: 11px;
-        line-height: 15px;
+    &.variant_button {
+        font-weight: 600;
+        font-size: 0.75rem; //12px;
+        line-height: 1rem; //16px;
+    }
 
-        opacity: 0.6;
+    &.weight_bold {
+        font-weight: bold;
+    }
+
+    &.weight_semiBold {
+        font-weight: 600;
+    }
+
+    &.weight_light {
+        font-weight: 300;
     }
 
     &.nowrap {
         @include truncate;
+    }
+
+    &.italic {
+        font-style: italic;
+    }
+
+    &.lineThrough {
+        text-decoration-line: line-through;
     }
 }

--- a/src/components/Typography/Typography.spec.js
+++ b/src/components/Typography/Typography.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Typography} from './index';
+import {Typography, variants, weights} from './index';
 import {shallow} from 'component-test-utils-react';
 
 describe('Typography', () => {
@@ -8,11 +8,48 @@ describe('Typography', () => {
         expect(wrapper.html()).toContain('Content children');
     });
 
-    it('should display a classname page', () => {
-        const wrapper = shallow(
-            <Typography variant="page">Content children</Typography>
-        );
-        expect(wrapper.props.className).toContain('typography page');
+    it('should display a body variant by default', () => {
+        const wrapper = shallow(<Typography>Content children</Typography>);
+        expect(wrapper.props.className).toContain('typography variant_body');
+    });
+
+    it('should display the specified variant', () => {
+        variants.forEach(variant => {
+            const wrapper = shallow(<Typography variant={variant}>Content children</Typography>);
+            expect(wrapper.props.className).toContain(`variant_${variant}`);
+        });
+    });
+
+    it('should use the default weight', () => {
+        const wrapper = shallow(<Typography>Test</Typography>);
+        expect(wrapper.props.className).toContain('weight_default');
+    });
+
+    it('should use the specified weight', () => {
+        weights.forEach(weight => {
+            const wrapper = shallow(<Typography weight={weight}>Test</Typography>);
+            expect(wrapper.props.className).toContain(`weight_${weight}`);
+        });
+    });
+
+    it('should display a text in italic', () => {
+        const wrapper = shallow(<Typography isItalic>Test</Typography>);
+        expect(wrapper.props.className).toContain('italic');
+    });
+
+    it('should not display a text in italic', () => {
+        const wrapper = shallow(<Typography>Test</Typography>);
+        expect(wrapper.props.className).not.toContain('italic');
+    });
+
+    it('should display a text with a line-through', () => {
+        const wrapper = shallow(<Typography hasLineThrough>Test</Typography>);
+        expect(wrapper.props.className).toContain('lineThrough');
+    });
+
+    it('should not display a text with a line-through', () => {
+        const wrapper = shallow(<Typography>Test</Typography>);
+        expect(wrapper.props.className).not.toContain('lineThrough');
     });
 
     it('should display a tag html p by default', () => {
@@ -20,15 +57,8 @@ describe('Typography', () => {
         expect(wrapper.html()).toContain('p');
     });
 
-    it('should display a regular variant by default', () => {
-        const wrapper = shallow(<Typography>Content children</Typography>);
-        expect(wrapper.props.className).toContain('typography regular');
-    });
-
     it('should display a tag html h1', () => {
-        const wrapper = shallow(
-            <Typography component="h1">Content children</Typography>
-        );
+        const wrapper = shallow(<Typography component="h1">Content children</Typography>);
         expect(wrapper.html()).toContain('h1');
     });
 

--- a/src/components/Typography/Typography.spec.js
+++ b/src/components/Typography/Typography.spec.js
@@ -42,6 +42,16 @@ describe('Typography', () => {
         expect(wrapper.props.className).not.toContain('italic');
     });
 
+    it('should display a text in upper case', () => {
+        const wrapper = shallow(<Typography isUpperCase>Test</Typography>);
+        expect(wrapper.props.className).toContain('upperCase');
+    });
+
+    it('should not display a text in upper case', () => {
+        const wrapper = shallow(<Typography>Test</Typography>);
+        expect(wrapper.props.className).not.toContain('upperCase');
+    });
+
     it('should display a text with a line-through', () => {
         const wrapper = shallow(<Typography hasLineThrough>Test</Typography>);
         expect(wrapper.props.className).toContain('lineThrough');

--- a/src/components/Typography/Typography.stories.jsx
+++ b/src/components/Typography/Typography.stories.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import classnames from 'classnames';
 import {storiesOf} from '@storybook/react';
-import {select, withKnobs} from '@storybook/addon-knobs';
+import {boolean, select, withKnobs} from '@storybook/addon-knobs';
 import storyStyles from '~/__storybook__/storybook.scss';
 
-import {Typography, TypographyVariants} from './index';
+import {Typography, variants, weights} from './index';
 import markdownNotes from './Typography.md';
 
 storiesOf('Components|Typography', module)
@@ -14,28 +14,35 @@ storiesOf('Components|Typography', module)
         notes: {markdown: markdownNotes}
     })
     .addDecorator(withKnobs)
-    .add('Default', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
-            <div className={classnames(storyStyles.storyItem)}>
-                <Typography variant="page">Page title</Typography>
-            </div>
-            <div className={classnames(storyStyles.storyItem)}>
-                <Typography variant="section">Section title</Typography>
-            </div>
-            <div className={classnames(storyStyles.storyItem)}>
-                <Typography>Regular (default)</Typography>
-            </div>
-            <div className={classnames(storyStyles.storyItem)}>
-                <Typography variant={select('Size', ['tiny', 'small', 'medium', 'large'], 'z')}>Caption</Typography>
-            </div>
-            <div className={classnames(storyStyles.storyItem)}>
-                <Typography variant="strong">Strong</Typography>
-            </div>
-        </section>
-    ))
-
+    .addDecorator(storyFn => <section className={classnames(storyStyles.storyWrapper)}>{storyFn()}</section>)
     .add('Variants', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
-            <Typography variant={select('Variant', TypographyVariants, 'regular')}>Text</Typography>
-        </section>
+        <>
+            <div className={classnames(storyStyles.storyItem)}>
+                <Typography variant="title">Title</Typography>
+            </div>
+            <div className={classnames(storyStyles.storyItem)}>
+                <Typography variant="heading">Heading</Typography>
+            </div>
+            <div className={classnames(storyStyles.storyItem)}>
+                <Typography variant="subheading">Subheading</Typography>
+            </div>
+            <div className={classnames(storyStyles.storyItem)}>
+                <Typography>Body (default)</Typography>
+            </div>
+            <div className={classnames(storyStyles.storyItem)}>
+                <Typography variant="caption">Caption</Typography>
+            </div>
+            <div className={classnames(storyStyles.storyItem)}>
+                <Typography variant="button">Button</Typography>
+            </div>
+        </>
+    ))
+    .add('Playground', () => (
+        <Typography variant={select('Variant', variants, 'body')}
+                    weight={select('Weight', weights, 'default')}
+                    isItalic={boolean('Italic', false)}
+                    hasLineThrough={boolean('LineThrough', false)}
+        >
+            Playground
+        </Typography>
     ));

--- a/src/components/Typography/Typography.stories.jsx
+++ b/src/components/Typography/Typography.stories.jsx
@@ -41,6 +41,7 @@ storiesOf('Components|Typography', module)
         <Typography variant={select('Variant', variants, 'body')}
                     weight={select('Weight', weights, 'default')}
                     isItalic={boolean('Italic', false)}
+                    isUpperCase={boolean('UpperCase', false)}
                     hasLineThrough={boolean('LineThrough', false)}
         >
             Playground


### PR DESCRIPTION
## JIRA
https://jira.jahia.org/browse/MOON-48

## Description
Updated API of Typography component according to https://www.figma.com/file/Hn0L5ZR1taHnTIqs3Vq61q/moonstone-tokens?node-id=467%3A0

- Supported variant are now: 'title', 'heading', 'subheading', 'body' (default), 'caption', 'button'
- Added a weight property to specify font weight
- Added a isItalic property to indicate that text should be displayed in italic
- Added a isUpperCase to indicate that text should be displayed in upper case
- Added a hasLineThrough property to indicate that text should be displayed with a line- through

