### PR TITLE
MOON-40: Remove the deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
         "build:lib": "webpack --mode production && yarn build-icons",
         "build:lib:dev": "webpack --mode development && yarn build-icons",
         "build:storybook": "build-storybook",
-        "deploy": "rsync -r ./storybook-static/ jahia@design.int.jahia.com:/var/www/vhosts/contenteditor.jahia.design/html/moonstone/",
         "auto": "auto",
         "auto-version": "npm version `auto version` -m 'Bump version to: %s [skip ci]'",
         "auto-publish": "npm publish && git push --follow-tags --set-upstream origin $branch",


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-40

## Description

As we deploy storybook with Gitgub actions to Github pages: https://jahia.github.io/moonstone
We can stop to deploy to `contenteditor.jahia.design/moonstone`