### PR TITLE
Moon 71: Update min/max width of SecondaryNav expanded

### DIFF
--- a/src/components/SecondaryNav/SecondaryNav.jsx
+++ b/src/components/SecondaryNav/SecondaryNav.jsx
@@ -27,8 +27,8 @@ export const SecondaryNav = ({header, children, isDefaultVisible, onToggled, cla
             }
             enable={['right']}
             size={isVisible ? null : {width: 0}}
-            minWidth={isVisible ? 120 : 0}
-            maxWidth="450"
+            minWidth={isVisible ? 245 : 0}
+            maxWidth="900"
             defaultSize={{
                 width: 245
             }}

--- a/src/components/TreeView/ControlledTreeView.jsx
+++ b/src/components/TreeView/ControlledTreeView.jsx
@@ -109,7 +109,7 @@ export const ControlledTreeView = ({data, openedItems, selectedItems, onClickIte
 
                             {/* TreeViewItem */}
                             <div
-                                className={classnames('flexRow', 'alignCenter', 'flexFluid', styles.treeView_itemLabel, node.className)}
+                                className={classnames('flexRow_nowrap', 'alignCenter', 'flexFluid', styles.treeView_itemLabel, node.className)}
                                 onClick={handleNodeClick}
                                 onDoubleClick={handleNodeDoubleClick}
                                 onContextMenu={handleNodeContextMenu}

--- a/src/components/TreeView/TreeView.scss
+++ b/src/components/TreeView/TreeView.scss
@@ -8,6 +8,8 @@
     --background-treeItem_selected: var(--color-accent);
     --background-treeItem_selected_hover: var(--color-accent);
 
+    flex-wrap: nowrap;
+
     height: 32px;
 
     color: var(--color-treeItem);

--- a/src/components/TreeView/TreeView.stories.jsx
+++ b/src/components/TreeView/TreeView.stories.jsx
@@ -4,78 +4,8 @@ import {object, withKnobs} from '@storybook/addon-knobs';
 import {action} from '@storybook/addon-actions';
 
 import markdownNotes from './TreeView.md';
+import {treeData} from '~/data';
 import {TreeView} from './index';
-import Love from '~/tokens/icons/asset/Love.svg';
-import NoCloud from '~/tokens/icons/asset/NoCloud.svg';
-import myStyles from './TreeView.stories.scss';
-
-const data = [
-    {
-        id: 'ROOT',
-        label: 'Root',
-        iconStart: 'https://image.flaticon.com/icons/svg/1973/1973617.svg',
-        isClosable: false,
-        children: [
-            {
-                id: 'A',
-                label: 'A level 1',
-                iconStart: 'https://image.flaticon.com/icons/svg/1973/1973617.svg',
-                iconEnd: <NoCloud/>,
-                children: [
-                    {
-                        id: 'A1',
-                        label: 'A-1 level2 with a very very very long laaaaaaaaaaaaaaaaaaabel with many many words',
-                        typographyOptions: {hasLineThrough: true},
-                        iconStart: 'https://image.flaticon.com/icons/svg/1973/1973617.svg',
-                        iconEnd: <NoCloud/>,
-                        children: [
-                            {
-                                id: 'A11',
-                                label: 'A-2 level2',
-                                typographyOptions: {isItalic: true},
-                                iconStart: 'https://image.flaticon.com/icons/svg/1973/1973617.svg'
-                            },
-                            {id: 'A12', label: 'A-3 level2', iconStart: <Love/>, className: myStyles.colorTest},
-                            {id: 'A13', label: 'A-4 level2'}
-                        ]
-                    },
-                    {id: 'A2', label: 'A-2 level2', iconStart: <Love/>, className: myStyles.colorTest},
-                    {id: 'A3', label: 'A-3 level2'},
-                    {id: 'A4', label: 'A-4 level2'}
-                ]
-            },
-            {
-                id: 'B',
-                label: 'B level1',
-                iconStart: <Love/>,
-                className: myStyles.colorTest,
-                children: [
-                    {id: 'B1', label: 'B-1 level2', iconStart: <Love/>, className: myStyles.colorTest},
-                    {id: 'B2', label: 'B-2 level2', iconStart: <Love/>, className: myStyles.colorTest},
-                    {id: 'B3', label: 'B-3 level2', iconStart: <Love/>, className: myStyles.colorTest},
-                    {
-                        id: 'B4', label: 'B-4 level2', iconStart: <Love/>, className: myStyles.colorTest, children: [
-                            {id: 'B11', label: 'B-1-1 level3', iconStart: <Love/>, className: myStyles.colorTest},
-                            {
-                                id: 'B22',
-                                label: 'B-2-2 level3',
-                                iconStart: 'https://image.flaticon.com/icons/svg/1973/1973617.svg'
-                            },
-                            {id: 'B33', label: 'B-3-3 level3', iconStart: <Love/>, className: myStyles.colorTest},
-                            {id: 'B44', label: 'B-4-4 level3', iconStart: <Love/>, className: myStyles.colorTest}
-                        ]
-                    }
-                ]
-            },
-            {
-                id: 'C',
-                label: 'C level1',
-                iconStart: 'https://image.flaticon.com/icons/svg/1973/1973617.svg',
-                children: []
-            }
-        ]
-    }
-];
 
 const css = {
     transform: 'scale(1)',
@@ -91,11 +21,11 @@ storiesOf('Components|TreeView', module)
     .addDecorator(withKnobs)
     .addDecorator(storyFn => <div style={css}>{storyFn()}</div>)
     .add('default', () => (
-        <TreeView data={data}/>
+        <TreeView data={treeData}/>
     ))
     .add('opened by default', () => (
         <TreeView defaultOpenedItems={['A']}
-                  data={data}
+                  data={treeData}
         />
     ))
     .add('data', () => (
@@ -119,7 +49,7 @@ storiesOf('Components|TreeView', module)
 
         return (
             <TreeView selectedItems={selectedItems}
-                      data={data}
+                      data={treeData}
                       onClickItem={handleClick}
             />
         );
@@ -128,14 +58,14 @@ storiesOf('Components|TreeView', module)
         return (
             <div style={{...css, background: '#000'}}>
                 <TreeView isReversed
-                          data={data}
+                          data={treeData}
                 />
             </div>
         );
     })
     .add('actions', () => (
         <TreeView
-            data={data}
+            data={treeData}
             onClickItem={action('onClickItem')}
             onDoubleClickItem={action('onDoubleClickItem')}
             onContextMenuItem={action('onContextMenuItem')}
@@ -161,7 +91,7 @@ storiesOf('Components|TreeView', module)
                     </button>
                 ))}
                 </span>
-                <TreeView data={data}
+                <TreeView data={treeData}
                           openedItems={openedItems}
                           onOpenItem={handleOpen}
                           onCloseItem={handleClose}
@@ -171,7 +101,7 @@ storiesOf('Components|TreeView', module)
     })
     .add('controlled with loading', () => {
         const [openedItems, setOpenedItems] = useState([]);
-        const [data, setData] = useState([
+        const [treeData, setData] = useState([
             {id: 'A1', label: 'A-1', hasChildren: true},
             {id: 'A2', label: 'A-2', hasChildren: true},
             {id: 'A3', label: 'A-3', hasChildren: true}
@@ -216,7 +146,7 @@ storiesOf('Components|TreeView', module)
                     </button>
                 ))}
                 </span>
-                <TreeView data={data}
+                <TreeView data={treeData}
                           openedItems={openedItems}
                           onOpenItem={handleOpen}
                           onCloseItem={handleClose}

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -1,0 +1,2 @@
+export * from './treeData';
+export * from './treeDataNested';

--- a/src/data/treeData.js
+++ b/src/data/treeData.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import {Love, NoCloud} from '~/tokens/icons';
+import myStyles from '~/components/TreeView/TreeView.stories.scss';
+
+export const treeData = [
+    {
+        id: 'ROOT',
+        label: 'Root',
+        iconStart: 'https://image.flaticon.com/icons/svg/1973/1973617.svg',
+        isClosable: false,
+        children: [
+            {
+                id: 'A',
+                label: 'A level 1',
+                iconStart: 'https://image.flaticon.com/icons/svg/1973/1973617.svg',
+                iconEnd: <NoCloud/>,
+                children: [
+                    {
+                        id: 'A1',
+                        label: 'A-1 level2 with a very very very long laaaaaaaaaaaaaaaaaaabel with many many words',
+                        typographyOptions: {hasLineThrough: true},
+                        iconStart: 'https://image.flaticon.com/icons/svg/1973/1973617.svg',
+                        iconEnd: <NoCloud/>,
+                        children: [
+                            {
+                                id: 'A11',
+                                label: 'A-2 level2',
+                                typographyOptions: {isItalic: true},
+                                iconStart: 'https://image.flaticon.com/icons/svg/1973/1973617.svg'
+                            },
+                            {id: 'A12', label: 'A-3 level2', iconStart: <Love/>, className: myStyles.colorTest},
+                            {id: 'A13', label: 'A-4 level2'}
+                        ]
+                    },
+                    {id: 'A2', label: 'A-2 level2', iconStart: <Love/>, className: myStyles.colorTest},
+                    {id: 'A3', label: 'A-3 level2'},
+                    {id: 'A4', label: 'A-4 level2'}
+                ]
+            },
+            {
+                id: 'B',
+                label: 'B level1',
+                iconStart: <Love/>,
+                className: myStyles.colorTest,
+                children: [
+                    {id: 'B1', label: 'B-1 level2', iconStart: <Love/>, className: myStyles.colorTest},
+                    {id: 'B2', label: 'B-2 level2', iconStart: <Love/>, className: myStyles.colorTest},
+                    {id: 'B3', label: 'B-3 level2', iconStart: <Love/>, className: myStyles.colorTest},
+                    {
+                        id: 'B4', label: 'B-4 level2', iconStart: <Love/>, className: myStyles.colorTest, children: [
+                            {id: 'B11', label: 'B-1-1 level3', iconStart: <Love/>, className: myStyles.colorTest},
+                            {
+                                id: 'B22',
+                                label: 'B-2-2 level3',
+                                iconStart: 'https://image.flaticon.com/icons/svg/1973/1973617.svg'
+                            },
+                            {id: 'B33', label: 'B-3-3 level3', iconStart: <Love/>, className: myStyles.colorTest},
+                            {id: 'B44', label: 'B-4-4 level3', iconStart: <Love/>, className: myStyles.colorTest}
+                        ]
+                    }
+                ]
+            },
+            {
+                id: 'C',
+                label: 'C level1',
+                iconStart: 'https://image.flaticon.com/icons/svg/1973/1973617.svg',
+                children: []
+            }
+        ]
+    }
+];

--- a/src/data/treeDataNested.js
+++ b/src/data/treeDataNested.js
@@ -1,0 +1,336 @@
+import React from 'react';
+import {Folder, File, NoCloud} from '~/tokens/icons';
+
+export const treeDataNested = [
+    {
+        id: 'ROOT',
+        label: 'Root',
+        iconStart: 'https://image.flaticon.com/icons/svg/1973/1973617.svg',
+        isClosable: false,
+        children: [
+            {
+                id: 'R1',
+                label: '01 - praesent tristique magna sit amet purus gravida quis',
+                iconStart: <Folder/>,
+                iconEnd: <NoCloud/>,
+                children: [
+                    {
+                        id: '02',
+                        label: '02 - phasellus vestibulum lorem sed risus ultricies tristique nulla',
+                        iconStart: <Folder/>,
+                        iconEnd: <NoCloud/>,
+                        children: [
+                            {
+                                id: '03',
+                                label: '03 - elit at imperdiet dui accumsan sit amet nulla',
+                                iconStart: <Folder/>,
+                                iconEnd: <NoCloud/>,
+                                children: [
+                                    {
+                                        id: '04',
+                                        label: '04 - lorem ipsum',
+                                        iconStart: <Folder/>,
+                                        iconEnd: <NoCloud/>,
+                                        children: [
+                                            {
+                                                id: '05',
+                                                label: '05 - lectus urna duis convallis convallis',
+                                                iconStart: <Folder/>,
+                                                iconEnd: <NoCloud/>,
+                                                children: [
+                                                    {
+                                                        id: '06',
+                                                        label: '06 - nisi porta lorem mollis aliquam',
+                                                        iconStart: <Folder/>,
+                                                        iconEnd: <NoCloud/>,
+                                                        children: [
+                                                            {
+                                                                id: '07',
+                                                                label: '07 - habitasse platea dictumst quisque sagittis purus sit amet volutpat consequat',
+                                                                iconStart: <Folder/>,
+                                                                iconEnd: <NoCloud/>,
+                                                                children: [
+                                                                    {
+                                                                        id: '08',
+                                                                        label: '08 - enim diam vulputate ut pharetra sit amet aliquam id diam',
+                                                                        iconStart: <Folder/>,
+                                                                        iconEnd: <NoCloud/>,
+                                                                        children: [
+                                                                            {
+                                                                                id: '09',
+                                                                                label: '09 - imperdiet nulla malesuada pellentesque elit eget gravida cum sociis natoque',
+                                                                                iconStart: <Folder/>,
+                                                                                iconEnd: <NoCloud/>,
+                                                                                children: [
+                                                                                    {
+                                                                                        id: '010',
+                                                                                        label: '010 - semper eget duis at tellus at urna condimentum mattis pellentesque id nibh tortor id aliquet lectus proin nibh',
+                                                                                        iconStart: <Folder/>,
+                                                                                        iconEnd: <NoCloud/>,
+                                                                                        children: [
+                                                                                            {
+                                                                                                id: '011',
+                                                                                                label: '011 - eget aliquet nibh praesent tristique magna sit amet purus gravida',
+                                                                                                iconStart: <Folder/>,
+                                                                                                iconEnd: <NoCloud/>,
+                                                                                                children: [
+                                                                                                    {
+                                                                                                        id: '012',
+                                                                                                        label: '012 - eget aliquet nibh praesent tristique magna sit amet purus gravida',
+                                                                                                        iconStart: <Folder/>,
+                                                                                                        iconEnd: <NoCloud/>,
+                                                                                                        children: [
+                                                                                                            {
+                                                                                                                id: '013',
+                                                                                                                label: '013 - eget aliquet nibh praesent tristique magna sit amet purus gravida',
+                                                                                                                iconStart: <Folder/>,
+                                                                                                                iconEnd: <NoCloud/>,
+                                                                                                                children: [
+                                                                                                                    {
+                                                                                                                        id: '014',
+                                                                                                                        label: '014 - eget magna fermentum iaculis eu non diam phasellus vestibulum lorem sed risus ultricies tristique nulla aliquet enim tortor',
+                                                                                                                        iconStart: <Folder/>,
+                                                                                                                        iconEnd: <NoCloud/>,
+                                                                                                                        children: [
+                                                                                                                            {
+                                                                                                                                id: '015',
+                                                                                                                                label: '015 - eget aliquet nibh praesent tristique magna sit amet purus gravida',
+                                                                                                                                iconStart: <Folder/>,
+                                                                                                                                iconEnd: <NoCloud/>,
+                                                                                                                                children: [
+                                                                                                                                    {
+                                                                                                                                        id: '016',
+                                                                                                                                        label: '016 - habitasse platea dictumst quisque sagittis purus sit amet volutpat consequat',
+                                                                                                                                        iconStart: <Folder/>,
+                                                                                                                                        iconEnd: <NoCloud/>,
+                                                                                                                                        children: [
+                                                                                                                                            {
+                                                                                                                                                id: '017',
+                                                                                                                                                label: '017 - habitasse platea dictumst quisque sagittis purus sit amet volutpat consequat',
+                                                                                                                                                iconStart: <Folder/>,
+                                                                                                                                                iconEnd: <NoCloud/>,
+                                                                                                                                                children: [
+                                                                                                                                                    {
+                                                                                                                                                        id: '018',
+                                                                                                                                                        label: '018 - lorem ipsum ipsum ipsum',
+                                                                                                                                                        iconStart: <Folder/>,
+                                                                                                                                                        iconEnd: <NoCloud/>,
+                                                                                                                                                        children: [
+                                                                                                                                                            {
+                                                                                                                                                                id: '019',
+                                                                                                                                                                label: '019 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                iconStart: <Folder/>,
+                                                                                                                                                                iconEnd: <NoCloud/>,
+                                                                                                                                                                children: [
+                                                                                                                                                                    {
+                                                                                                                                                                        id: '020',
+                                                                                                                                                                        label: '020 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                        iconStart: <Folder/>,
+                                                                                                                                                                        iconEnd: <NoCloud/>,
+                                                                                                                                                                        children: [
+                                                                                                                                                                            {
+                                                                                                                                                                                id: '021',
+                                                                                                                                                                                label: '021 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                iconStart: <Folder/>,
+                                                                                                                                                                                iconEnd: <NoCloud/>,
+                                                                                                                                                                                children: [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        id: '022',
+                                                                                                                                                                                        label: '022 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                        iconStart: <Folder/>,
+                                                                                                                                                                                        iconEnd: <NoCloud/>,
+                                                                                                                                                                                        children: [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                id: '023',
+                                                                                                                                                                                                label: '023 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                iconStart: <Folder/>,
+                                                                                                                                                                                                iconEnd: <NoCloud/>,
+                                                                                                                                                                                                children: [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        id: '024',
+                                                                                                                                                                                                        label: '024 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                        iconStart: <Folder/>,
+                                                                                                                                                                                                        iconEnd: <NoCloud/>,
+                                                                                                                                                                                                        children: [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                id: '025',
+                                                                                                                                                                                                                label: '025 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                iconStart: <Folder/>,
+                                                                                                                                                                                                                iconEnd: <NoCloud/>,
+                                                                                                                                                                                                                children: [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        id: '026',
+                                                                                                                                                                                                                        label: '026 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                        iconStart: <Folder/>,
+                                                                                                                                                                                                                        iconEnd: <NoCloud/>,
+                                                                                                                                                                                                                        children: [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                id: '027',
+                                                                                                                                                                                                                                label: '027 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                                iconStart: <Folder/>,
+                                                                                                                                                                                                                                iconEnd: <NoCloud/>,
+                                                                                                                                                                                                                                children: [
+                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                        id: '028',
+                                                                                                                                                                                                                                        label: '028 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                                        iconStart: <Folder/>,
+                                                                                                                                                                                                                                        iconEnd: <NoCloud/>,
+                                                                                                                                                                                                                                        children: [
+                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                id: '029',
+                                                                                                                                                                                                                                                label: '029 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                                                iconStart: <Folder/>,
+                                                                                                                                                                                                                                                iconEnd: <NoCloud/>,
+                                                                                                                                                                                                                                                children: [
+                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                        id: '030',
+                                                                                                                                                                                                                                                        label: '030 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                                                        iconStart: <Folder/>,
+                                                                                                                                                                                                                                                        iconEnd: <NoCloud/>,
+                                                                                                                                                                                                                                                        children: [
+                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                id: '031',
+                                                                                                                                                                                                                                                                label: '031 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                                                                iconStart: <Folder/>,
+                                                                                                                                                                                                                                                                iconEnd: <NoCloud/>,
+                                                                                                                                                                                                                                                                children: [
+                                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                                        id: '032',
+                                                                                                                                                                                                                                                                        label: '032 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                                                                        iconStart: <Folder/>,
+                                                                                                                                                                                                                                                                        iconEnd: <NoCloud/>,
+                                                                                                                                                                                                                                                                        children: [
+                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                id: '033',
+                                                                                                                                                                                                                                                                                label: '033 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                                                                                iconStart: <Folder/>,
+                                                                                                                                                                                                                                                                                iconEnd: <NoCloud/>,
+                                                                                                                                                                                                                                                                                children: [
+                                                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                                                        id: '034',
+                                                                                                                                                                                                                                                                                        label: '034 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                                                                                        iconStart: <Folder/>,
+                                                                                                                                                                                                                                                                                        iconEnd: <NoCloud/>,
+                                                                                                                                                                                                                                                                                        children: [
+                                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                                id: '035',
+                                                                                                                                                                                                                                                                                                label: '035 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                                                                                                iconStart: <Folder/>,
+                                                                                                                                                                                                                                                                                                iconEnd: <NoCloud/>,
+                                                                                                                                                                                                                                                                                                children: [
+                                                                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                                                                        id: '036',
+                                                                                                                                                                                                                                                                                                        label: '036 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                                                                                                        iconStart: <Folder/>,
+                                                                                                                                                                                                                                                                                                        iconEnd: <NoCloud/>,
+                                                                                                                                                                                                                                                                                                        children: [
+                                                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                                                id: '037',
+                                                                                                                                                                                                                                                                                                                label: '037 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                                                                                                                iconStart: <Folder/>,
+                                                                                                                                                                                                                                                                                                                iconEnd: <NoCloud/>,
+                                                                                                                                                                                                                                                                                                                children: [
+                                                                                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                                                                                        id: '038',
+                                                                                                                                                                                                                                                                                                                        label: '038 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                                                                                                                        iconStart: <Folder/>,
+                                                                                                                                                                                                                                                                                                                        iconEnd: <NoCloud/>,
+                                                                                                                                                                                                                                                                                                                        children: [
+                                                                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                                                                id: '039',
+                                                                                                                                                                                                                                                                                                                                label: '039 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                                                                                                                                iconStart: <Folder/>,
+                                                                                                                                                                                                                                                                                                                                iconEnd: <NoCloud/>,
+                                                                                                                                                                                                                                                                                                                                children: [
+                                                                                                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                                                                                                        id: '040',
+                                                                                                                                                                                                                                                                                                                                        label: '040 - quisque sagittis purus sit amet volutpat',
+                                                                                                                                                                                                                                                                                                                                        iconStart: <File/>,
+                                                                                                                                                                                                                                                                                                                                        iconEnd: <NoCloud/>
+                                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {id: '11', label: 'label', iconStart: <File/>},
+                            {id: '12', label: 'another label', iconStart: <File/>}
+                        ]
+                    }
+                ]
+            },
+            {id: 'R2', label: '0-2 level2', iconStart: <File/>, iconEnd: <NoCloud/>},
+            {id: 'R3', label: '0-3 level2', iconStart: <File/>, iconEnd: <NoCloud/>},
+            {id: 'R4', label: '0-4 level2', iconStart: <File/>, iconEnd: <NoCloud/>}
+        ]
+    }
+];

--- a/src/layouts/Layouts.stories.jsx
+++ b/src/layouts/Layouts.stories.jsx
@@ -1,41 +1,88 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {storiesOf} from '@storybook/react';
-import {withKnobs, number, text, boolean} from '@storybook/addon-knobs';
+import {withKnobs, text, boolean} from '@storybook/addon-knobs';
 
 import {LayoutApp} from './app';
 import {LayoutModule} from './module';
-import {PrimaryNav} from '~/components/PrimaryNav';
-import {SecondaryNav} from '~/components/SecondaryNav';
+import {treeData, treeDataNested} from '~/data';
+import {PrimaryNav, SecondaryNav, SecondaryNavHeader, Accordion, AccordionItem, TreeView} from '~/components';
+import {Bug, Love} from '~/tokens/icons';
 
-const resizeWidth = () => number('Set width to resize', 245, {min: 120, max: 496, step: 20}, 'Level 2');
+const accordionIds = ['01', '02', '03'];
 
 storiesOf('Layouts|Demos', module)
     .addDecorator(withKnobs)
-    .add('Default', () => (
-        <div style={{transform: 'scale(1)'}}>
-            <LayoutApp
-                navigation={
-                    <PrimaryNav isExpanded={boolean('Expand', false, 'Level 1')}>
-                        level 1
-                    </PrimaryNav>
-                }
-                content={
-                    <LayoutModule
-                        navigation={
-                            <SecondaryNav resizeWidth={resizeWidth()}>
-                                level 2
-                            </SecondaryNav>
-                        }
-                        content={
-                            <div style={{padding: '20px'}}>
-                                {text('Content', 'My module content', 'Content')}
-                            </div>
-                        }
-                    />
-                }
-            />
-        </div>
-    ))
+    .add('Default', () => {
+        const [selectedItems1, setSelectedItems1] = useState([]);
+        const [selectedItems2, setSelectedItems2] = useState([]);
+
+        const handleSelectItem1 = node => {
+            if (selectedItems1.includes(node.id)) {
+                setSelectedItems1(selectedItems1.filter(item => item !== node.id));
+            } else {
+                setSelectedItems1([node.id]);
+            }
+        };
+
+        const handleSelectItem2 = node => {
+            if (selectedItems2.includes(node.id)) {
+                setSelectedItems2(selectedItems2.filter(item => item !== node.id));
+            } else {
+                setSelectedItems2([node.id]);
+            }
+        };
+
+        return (
+            <div style={{transform: 'scale(1)'}}>
+                <LayoutApp
+                    navigation={
+                        <PrimaryNav>
+                            level 1
+                        </PrimaryNav>
+                    }
+                    content={
+                        <LayoutModule
+                            navigation={
+                                <SecondaryNav header={<SecondaryNavHeader>Header</SecondaryNavHeader>}>
+                                    <Accordion isReversed defaultOpenedItem={accordionIds[1]}>
+                                        <AccordionItem
+                                            id={accordionIds[0]}
+                                            icon={<Love size="big"/>}
+                                            label="Accordion 01"
+                                        >
+                                            <TreeView
+                                                isReversed
+                                                data={treeData}
+                                                selectedItems={selectedItems1}
+                                                onClickItem={handleSelectItem1}
+                                            />
+                                        </AccordionItem>
+                                        <AccordionItem
+                                            id={accordionIds[1]}
+                                            icon={<Bug size="big"/>}
+                                            label="Accordion 02"
+                                        >
+                                            <TreeView
+                                                isReversed
+                                                data={treeDataNested}
+                                                selectedItems={selectedItems2}
+                                                onClickItem={handleSelectItem2}
+                                            />
+                                        </AccordionItem>
+                                    </Accordion>
+                                </SecondaryNav>
+                            }
+                            content={
+                                <div style={{padding: '20px'}}>
+                                    {text('Content', 'My module content', 'Content')}
+                                </div>
+                            }
+                        />
+                    }
+                />
+            </div>
+        );
+    })
 
     .add('Without level 2', () => (
         <div style={{transform: 'scale(1)'}}>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-71

## Description

- Set the minimum width of the SecondaryNav to 245px (as the default size)
- Increase the maximum width of the SecondaryNav to 900px
- Avoid icon's tree to overlaps with small SecondaryNav
- Add a complete story example of the SecondaryNav in `Layout/Demos`

## Tests

The following are included in this PR

- [ ] Unit Test skeleton

## Checklist

<!--
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics.
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

- [ ] All files present ( component - md - scss - spec - stories )
- [ ] Are all props ok and documented
- [ ] Required props and default values
- [X] Example in storybook

## Documentation

<!--
Indicate if you have been writing documentation has part of this change.
-->

- [ ] README documentation
