### PR TITLE
QA-12658: Remove height:100% to the vertical separator

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,3 +1,8 @@
 {
-    "extends": ["@jahia/stylelint-config"]
+    "extends": ["@jahia/stylelint-config"],
+    "rules": {
+        "declaration-property-unit-blacklist": {
+            "height": ["%"]
+        }
+    }
 }

--- a/src/components/Separator/Separator.scss
+++ b/src/components/Separator/Separator.scss
@@ -34,31 +34,38 @@
 }
 
 .separator_vertical {
+    align-self: stretch;
     width: 1px;
 
     // Size's Separator
     &.size_medium {
-        height: calc(100% - var(--spacing-huge));
+        margin-top: var(--spacing-small);
+        margin-bottom: var(--spacing-small);
     }
 
     &.size_large {
-        height: calc(100% - var(--spacing-medium));
+        margin-top: var(--spacing-nano);
+        margin-bottom: var(--spacing-nano);
     }
 
     &.size_full {
-        height: 100%;
+        margin-top: 0;
+        margin-bottom: 0;
     }
 
     // Spacing's Separator
     &.spacing_small {
-        margin: auto var(--spacing-small);
+        margin-right: var(--spacing-small);
+        margin-left: var(--spacing-small);
     }
 
     &.spacing_medium {
-        margin: auto var(--spacing-medium);
+        margin-right: var(--spacing-medium);
+        margin-left: var(--spacing-medium);
     }
 
     &.spacing_big {
-        margin: auto var(--spacing-big);
+        margin-right: var(--spacing-big);
+        margin-left: var(--spacing-big);
     }
 }

--- a/src/components/Separator/Separator.stories.jsx
+++ b/src/components/Separator/Separator.stories.jsx
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {withKnobs, select} from '@storybook/addon-knobs';
 import {optionsFromArray} from '~/__storybook__/utils';
 
-import {Separator, SeparatorSizes, SeparatorSpacings} from '~/components';
+import {Separator, SeparatorSizes, SeparatorSpacings, Typography} from '~/components';
 import markdownNotes from './Separator.md';
 
 storiesOf('Components|Separator', module)
@@ -14,23 +14,24 @@ storiesOf('Components|Separator', module)
     .addDecorator(withKnobs)
     .add('Horizontal', () => (
         <>
-            <div>Content before a separator</div>
+            <Typography variant="heading">Content before a separator</Typography>
             <Separator
                 variant="horizontal"
                 size={select('Size', optionsFromArray(SeparatorSizes), 'full')}
                 spacing={select('Spacing', optionsFromArray(SeparatorSpacings), 'medium')}
             />
-            <div>Content after a separator</div>
+            <Typography variant="heading">Content after a separator</Typography>
         </>
     ))
     .add('Vertical', () => (
-        <div className="flexRow alignCenter" style={{height: '80px'}}>
-            <div>Before</div>
+        <div className="flexRow alignCenter">
+            <Typography variant="heading">Before</Typography>
+
             <Separator
                 variant="vertical"
                 size={select('Size', optionsFromArray(SeparatorSizes), 'full')}
                 spacing={select('Spacing', optionsFromArray(SeparatorSpacings), 'medium')}
             />
-            <div>After</div>
+            <Typography variant="heading">After</Typography>
         </div>
     ));

--- a/src/layouts/app/LayoutApp.stories.jsx
+++ b/src/layouts/app/LayoutApp.stories.jsx
@@ -10,7 +10,7 @@ const FakeNavigation = () => {
     return (
         <div style={{
             width: '100%',
-            height: '100%',
+            height: '100vh',
             border: '5px solid gray',
             display: 'flex',
             alignItems: 'center',
@@ -25,7 +25,7 @@ const FakeContent = () => {
     return (
         <div style={{
             width: '100%',
-            height: '100%',
+            height: '100vh',
             border: '5px solid lightgray',
             display: 'flex',
             alignItems: 'center',

--- a/src/layouts/module/LayoutModule.stories.jsx
+++ b/src/layouts/module/LayoutModule.stories.jsx
@@ -10,7 +10,7 @@ const FakeNavigation = () => {
     return (
         <div style={{
             width: '245px',
-            height: '100%',
+            height: '100vh',
             border: '5px solid gray',
             display: 'flex',
             alignItems: 'center',
@@ -25,7 +25,7 @@ const FakeContent = () => {
     return (
         <div style={{
             width: '100%',
-            height: '100%',
+            height: '100vh',
             border: '5px solid lightgray',
             display: 'flex',
             alignItems: 'center',

--- a/src/utils/_helpers.scss
+++ b/src/utils/_helpers.scss
@@ -6,5 +6,5 @@
     left: 0;
 
     width: 100vw;
-    height: 100%;
+    height: 100vh;
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-12658

## Description

- Remove height based on 100%
- Add a stylelint rule to forbid using percentage unit with a height

## Tests

The following are included in this PR

- [ ] Unit Test skeleton

## Checklist

<!--
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics.
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

- [ ] All files present ( component - md - scss - spec - stories )
- [ ] Are all props ok and documented
- [ ] Required props and default values
- [ ] Example in storybook

## Documentation

<!--
Indicate if you have been writing documentation has part of this change.
-->

- [ ] README documentation
