### PR TITLE
MOON-95: Add component props to LayoutModule

### DIFF
--- a/src/layouts/module/LayoutModule.jsx
+++ b/src/layouts/module/LayoutModule.jsx
@@ -2,21 +2,26 @@ import React from 'react';
 import classnames from 'clsx';
 import PropTypes from 'prop-types';
 
-export const LayoutModule = ({navigation, content}) => {
+export const LayoutModule = ({navigation, content, component}) => {
     return (
         <>
             <div className={classnames('flexCol')}>
                 {navigation}
             </div>
-            <main className={classnames('flexFluid', 'flexCol')}>
-                {content}
-            </main>
+            {
+                React.createElement(
+                    component,
+                    {className: classnames('flexFluid', 'flexCol')},
+                    content
+                )
+            }
         </>
     );
 };
 
 LayoutModule.defaultProps = {
     navigation: null,
+    component: 'main',
     content: null
 };
 
@@ -29,7 +34,12 @@ LayoutModule.propTypes = {
     /**
      * Slot for the module's content
      */
-    content: PropTypes.node
+    content: PropTypes.node,
+
+    /**
+     * The HTML markup used for the content node
+     */
+    component: PropTypes.string
 };
 
 LayoutModule.displayName = 'LayoutModule';

--- a/src/layouts/module/LayoutModule.spec.jsx
+++ b/src/layouts/module/LayoutModule.spec.jsx
@@ -8,4 +8,9 @@ describe('LayoutModule', () => {
 
         expect(wrapper.html()).toContain('test-navigation');
     });
+
+    it('should display a specific HTML markup', () => {
+        const wrapper = shallow(<LayoutModule component="h1"/>);
+        expect(wrapper.html()).toContain('h1');
+    });
 });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-95

## Description

Add a `component` props to the `LayoutModule` to choose the render HTML  to avoid rendering several `main` HTML elements when we nest layout.

## Tests

The following are included in this PR

- [X] Unit Test skeleton
