### PR TITLE
MOON-96: Fix displaying one button inside a ButtonGroup

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.scss
+++ b/src/components/ButtonGroup/ButtonGroup.scss
@@ -14,6 +14,10 @@
         border-radius: 0 4px 4px 0;
     }
 
+    > *:only-child {
+        border-radius: 4px;
+    }
+
     // Manage separator
     .variant_default {
         &:hover,

--- a/src/components/ButtonGroup/ButtonGroup.stories.jsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.jsx
@@ -45,4 +45,14 @@ storiesOf('Components|ButtonGroup', module)
                 <Button icon={<ChevronDown/>} onClick={() => {}}/>
             </ButtonGroup>
         </section>
+    ))
+    .add('ButtonGroup with 1 button', () => (
+        <section className={classnames(storyStyles.storyWrapper)}>
+            <ButtonGroup
+                color="accent"
+                size="big"
+            >
+                <Button label="Actions" onClick={() => {}}/>
+            </ButtonGroup>
+        </section>
     ));


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-96

## Description

Fix displaying one button inside a ButtonGroup

## Tests

The following are included in this PR

- [ ] Unit Test skeleton

## Checklist

<!--
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics.
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

- [ ] All files present ( component - md - scss - spec - stories )
- [ ] Are all props ok and documented
- [ ] Required props and default values
- [X] Example in storybook

## Documentation

<!--
Indicate if you have been writing documentation has part of this change.
-->

- [ ] README documentation
