### PR TITLE
BACKLOG-12710 add property invisible to the Separator so that we can hide it it is the first-child, last-child or only-child

### DIFF
--- a/src/components/Separator/Separator.jsx
+++ b/src/components/Separator/Separator.jsx
@@ -6,7 +6,7 @@ import styles from './Separator.scss';
 export const SeparatorSpacings = ['small', 'medium', 'big'];
 export const SeparatorSizes = ['medium', 'large', 'full'];
 export const SeparatorVariants = ['horizontal', 'vertical'];
-export const SeparatorInvisible = ['first-child', 'last-child', 'only-child'];
+export const SeparatorInvisible = ['firstChild', 'lastChild', 'onlyChild'];
 
 export const Separator = ({size, spacing, variant, className, invisible, ...props}) => {
     return (
@@ -47,7 +47,7 @@ Separator.propTypes = {
     size: PropTypes.oneOf(SeparatorSizes),
 
     /**
-     * Hide the separator if it is the first-child, last-child or only-child
+     * Hide the separator if it is the firstChild, lastChild or onlyChild
      * If you don't pass this property then the separator will always be visible
      */
     invisible: PropTypes.oneOf(SeparatorInvisible),

--- a/src/components/Separator/Separator.jsx
+++ b/src/components/Separator/Separator.jsx
@@ -6,8 +6,9 @@ import styles from './Separator.scss';
 export const SeparatorSpacings = ['small', 'medium', 'big'];
 export const SeparatorSizes = ['medium', 'large', 'full'];
 export const SeparatorVariants = ['horizontal', 'vertical'];
+export const SeparatorInvisible = ['first-child', 'last-child', 'only-child'];
 
-export const Separator = ({size, spacing, variant, className, ...props}) => {
+export const Separator = ({size, spacing, variant, className, invisible, ...props}) => {
     return (
         <hr {...props}
             className={classnames(
@@ -15,6 +16,7 @@ export const Separator = ({size, spacing, variant, className, ...props}) => {
                 styles[`separator_${variant}`],
                 styles[`size_${size}`],
                 styles[`spacing_${spacing}`],
+                invisible && styles[`invisible_${invisible}`],
                 className
             )}
         />
@@ -24,7 +26,8 @@ export const Separator = ({size, spacing, variant, className, ...props}) => {
 Separator.defaultProps = {
     variant: 'horizontal',
     size: 'full',
-    spacing: 'small'
+    spacing: 'small',
+    invisible: null
 };
 
 Separator.propTypes = {
@@ -42,6 +45,12 @@ Separator.propTypes = {
      * Size
      */
     size: PropTypes.oneOf(SeparatorSizes),
+
+    /**
+     * Hide the separator if it is the first-child, last-child or only-child
+     * If you don't pass this property then the separator will always be visible
+     */
+    invisible: PropTypes.oneOf(SeparatorInvisible),
 
     /**
      * Additional classname

--- a/src/components/Separator/Separator.scss
+++ b/src/components/Separator/Separator.scss
@@ -1,6 +1,18 @@
 .separator {
     border: 0;
     background: var(--color-gray40);
+
+    &.invisible_first-child:first-child {
+        display: none;
+    }
+
+    &.invisible_last-child:last-child {
+        display: none;
+    }
+
+    &.invisible_only-child:only-child {
+        display: none;
+    }
 }
 
 .separator_horizontal {

--- a/src/components/Separator/Separator.scss
+++ b/src/components/Separator/Separator.scss
@@ -2,15 +2,15 @@
     border: 0;
     background: var(--color-gray40);
 
-    &.invisible_first-child:first-child {
+    &.invisible_firstChild:first-child {
         display: none;
     }
 
-    &.invisible_last-child:last-child {
+    &.invisible_lastChild:last-child {
         display: none;
     }
 
-    &.invisible_only-child:only-child {
+    &.invisible_onlyChild:only-child {
         display: none;
     }
 }

--- a/src/components/Separator/Separator.spec.js
+++ b/src/components/Separator/Separator.spec.js
@@ -52,18 +52,18 @@ describe('Separator', () => {
         expect(wrapper.html()).toContain('test');
     });
 
-    it('should have the class invisible_first-child', () => {
-        const wrapper = shallow(<Separator variant="vertical" size="medium" invisible="first-child"/>);
-        expect(wrapper.html()).toContain('invisible_first-child');
+    it('should have the class invisible_firstChild', () => {
+        const wrapper = shallow(<Separator variant="vertical" size="medium" invisible="firstChild"/>);
+        expect(wrapper.html()).toContain('invisible_firstChild');
     });
 
-    it('should have the class invisible_last-child', () => {
-        const wrapper = shallow(<Separator variant="vertical" size="medium" invisible="last-child"/>);
-        expect(wrapper.html()).toContain('invisible_last-child');
+    it('should have the class invisible_lastChild', () => {
+        const wrapper = shallow(<Separator variant="vertical" size="medium" invisible="lastChild"/>);
+        expect(wrapper.html()).toContain('invisible_lastChild');
     });
 
-    it('should have the class invisible_only-child', () => {
-        const wrapper = shallow(<Separator variant="vertical" size="medium" invisible="only-child"/>);
-        expect(wrapper.html()).toContain('invisible_only-child');
+    it('should have the class invisible_onlyChild', () => {
+        const wrapper = shallow(<Separator variant="vertical" size="medium" invisible="onlyChild"/>);
+        expect(wrapper.html()).toContain('invisible_onlyChild');
     });
 });

--- a/src/components/Separator/Separator.spec.js
+++ b/src/components/Separator/Separator.spec.js
@@ -9,12 +9,14 @@ describe('Separator', () => {
         );
         expect(wrapper.html());
     });
+
     it('should display horizontal separator by default', () => {
         const wrapper = shallow(
             <Separator size="medium"/>
         );
         expect(wrapper.html()).toContain('separator_horizontal');
     });
+
     it('should display vertical separator', () => {
         const wrapper = shallow(
             <Separator variant="vertical" size="medium"/>
@@ -48,5 +50,20 @@ describe('Separator', () => {
             <Separator className="test" size="medium"/>
         );
         expect(wrapper.html()).toContain('test');
+    });
+
+    it('should have the class invisible_first-child', () => {
+        const wrapper = shallow(<Separator variant="vertical" size="medium" invisible="first-child"/>);
+        expect(wrapper.html()).toContain('invisible_first-child');
+    });
+
+    it('should have the class invisible_last-child', () => {
+        const wrapper = shallow(<Separator variant="vertical" size="medium" invisible="last-child"/>);
+        expect(wrapper.html()).toContain('invisible_last-child');
+    });
+
+    it('should have the class invisible_only-child', () => {
+        const wrapper = shallow(<Separator variant="vertical" size="medium" invisible="only-child"/>);
+        expect(wrapper.html()).toContain('invisible_only-child');
     });
 });

--- a/src/components/Separator/Separator.stories.jsx
+++ b/src/components/Separator/Separator.stories.jsx
@@ -2,9 +2,13 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withKnobs, select} from '@storybook/addon-knobs';
 import {optionsFromArray} from '~/__storybook__/utils';
+import classnames from 'classnames';
+import storyStyles from '~/__storybook__/storybook.scss';
 
-import {Separator, SeparatorSizes, SeparatorSpacings, Typography} from '~/components';
+import {Separator, SeparatorSizes, SeparatorSpacings, SeparatorInvisible, Typography} from '~/components';
 import markdownNotes from './Separator.md';
+
+const separatorInvisibleValue = () => select('invisible', optionsFromArray(SeparatorInvisible), 'first-child');
 
 storiesOf('Components|Separator', module)
     .addParameters({
@@ -34,4 +38,47 @@ storiesOf('Components|Separator', module)
             />
             <Typography variant="heading">After</Typography>
         </div>
+    ))
+    .add('Hide', () => (
+        <section className={classnames(storyStyles.storyColumn)}>
+            <div className={classnames(storyStyles.storyItem)}>
+                <Typography variant="heading">Before</Typography>
+                <Separator
+                    variant="vertical"
+                    size="full"
+                    spacing="big"
+                    invisible={separatorInvisibleValue()}
+                />
+                <Typography variant="heading">After</Typography>
+            </div>
+            <Separator variant="horizontal"/>
+            <div className={classnames(storyStyles.storyItem)}>
+                <Typography variant="heading">Before</Typography>
+                <Separator
+                    variant="vertical"
+                    size="full"
+                    spacing="big"
+                    invisible={separatorInvisibleValue()}
+                />
+            </div>
+            <Separator variant="horizontal"/>
+            <div className={classnames(storyStyles.storyItem)}>
+                <Separator
+                    variant="vertical"
+                    size="full"
+                    spacing="big"
+                    invisible={separatorInvisibleValue()}
+                />
+                <Typography variant="heading">After</Typography>
+            </div>
+            <Separator variant="horizontal"/>
+            <div className={classnames(storyStyles.storyItem)}>
+                <Separator
+                    variant="vertical"
+                    size="full"
+                    spacing="big"
+                    invisible={separatorInvisibleValue()}
+                />
+            </div>
+        </section>
     ));

--- a/src/components/Separator/Separator.stories.jsx
+++ b/src/components/Separator/Separator.stories.jsx
@@ -8,7 +8,7 @@ import storyStyles from '~/__storybook__/storybook.scss';
 import {Separator, SeparatorSizes, SeparatorSpacings, SeparatorInvisible, Typography} from '~/components';
 import markdownNotes from './Separator.md';
 
-const separatorInvisibleValue = () => select('invisible', optionsFromArray(SeparatorInvisible), 'first-child');
+const separatorInvisibleValue = () => select('invisible', optionsFromArray(SeparatorInvisible), 'firstChild');
 
 storiesOf('Components|Separator', module)
     .addParameters({

--- a/src/components/Separator/Separator.stories.jsx
+++ b/src/components/Separator/Separator.stories.jsx
@@ -39,7 +39,7 @@ storiesOf('Components|Separator', module)
             <Typography variant="heading">After</Typography>
         </div>
     ))
-    .add('Hide', () => (
+    .add('Invisible', () => (
         <section className={classnames(storyStyles.storyColumn)}>
             <div className={classnames(storyStyles.storyItem)}>
                 <Typography variant="heading">Before</Typography>


### PR DESCRIPTION
## JIRA
https://jira.jahia.org/browse/BACKLOG-12710

## Description
add property invisible to the Separator so that we can hide it it is the first-child, last-child or only-child

## Tests

The following are included in this PR

- [x] Unit Test skeleton

## Checklist
- [x] All files present ( component - md - scss - spec - stories )
- [x] Are all props ok and documented
- [x] Required props and default values
- [x] Example in storybook

## Documentation
- [ ] README documentation
