### PR TITLE
BACKLOG-12710 add fourth option to hide the separator if it's the first OR last child

### DIFF
--- a/src/components/Separator/Separator.jsx
+++ b/src/components/Separator/Separator.jsx
@@ -6,7 +6,7 @@ import styles from './Separator.scss';
 export const SeparatorSpacings = ['small', 'medium', 'big'];
 export const SeparatorSizes = ['medium', 'large', 'full'];
 export const SeparatorVariants = ['horizontal', 'vertical'];
-export const SeparatorInvisible = ['firstChild', 'lastChild', 'onlyChild'];
+export const SeparatorInvisible = ['firstChild', 'lastChild', 'onlyChild', 'firstOrLastChild'];
 
 export const Separator = ({size, spacing, variant, className, invisible, ...props}) => {
     return (
@@ -47,7 +47,7 @@ Separator.propTypes = {
     size: PropTypes.oneOf(SeparatorSizes),
 
     /**
-     * Hide the separator if it is the firstChild, lastChild or onlyChild
+     * Hide the separator if it is the firstChild, lastChild, onlyChild or firstOrLastChild
      * If you don't pass this property then the separator will always be visible
      */
     invisible: PropTypes.oneOf(SeparatorInvisible),

--- a/src/components/Separator/Separator.scss
+++ b/src/components/Separator/Separator.scss
@@ -2,15 +2,11 @@
     border: 0;
     background: var(--color-gray40);
 
-    &.invisible_firstChild:first-child {
-        display: none;
-    }
-
-    &.invisible_lastChild:last-child {
-        display: none;
-    }
-
-    &.invisible_onlyChild:only-child {
+    &.invisible_firstChild:first-child,
+    &.invisible_lastChild:last-child,
+    &.invisible_onlyChild:only-child,
+    &.invisible_firstOrLastChild:first-child,
+    &.invisible_firstOrLastChild:last-child {
         display: none;
     }
 }

--- a/src/components/Separator/Separator.spec.js
+++ b/src/components/Separator/Separator.spec.js
@@ -66,4 +66,9 @@ describe('Separator', () => {
         const wrapper = shallow(<Separator variant="vertical" size="medium" invisible="onlyChild"/>);
         expect(wrapper.html()).toContain('invisible_onlyChild');
     });
+
+    it('should have the class invisible_firstOrLastChild', () => {
+        const wrapper = shallow(<Separator variant="vertical" size="medium" invisible="firstOrLastChild"/>);
+        expect(wrapper.html()).toContain('invisible_firstOrLastChild');
+    });
 });


### PR DESCRIPTION
## JIRA
https://jira.jahia.org/browse/BACKLOG-12710

## Description
add fourth option to hide the separator if it's the first OR last child

## Tests

The following are included in this PR

- [x] Unit Test skeleton

## Checklist

- [x] All files present ( component - md - scss - spec - stories )
- [x] Are all props ok and documented
- [x] Required props and default values
- [x] Example in storybook

## Documentation

- [ ] README documentation
