### PR TITLE
BACKLOG-12798 pass icon props to the icons so if we are using some mandatory attribute like src, the icon will be displayed correctly

### DIFF
--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -142,7 +142,7 @@ export const Dropdown = (
             >
                 {
                     icon &&
-                    <icon.type size="small" className={classnames(styles.dropdown_icon)}/>
+                    <icon.type {...icon.props} size="small" className={classnames(styles.dropdown_icon)}/>
                 }
 
                 <Typography


### PR DESCRIPTION
## JIRA
https://jira.jahia.org/browse/BACKLOG-12798

## Description
pass icon props to the icons so if we are using some mandatory attribute like src, the icon will be displayed correctly
