### PR TITLE
MOON-113: Fix the key of Breadcrumb

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.jsx
+++ b/src/components/Breadcrumb/Breadcrumb.jsx
@@ -17,13 +17,13 @@ export const Breadcrumb = ({children, className, ...props}) => {
             <ol className={classnames('flexRow_nowrap', 'alignCenter')}>
                 {
                     allItems.map((item, index) => (
-                        <Fragment key={`child-${item.props.label}`}>
+                        <Fragment key={item.key}>
                             {item}
 
                             {index < allItems.length - 1 &&
-                                <li className={classnames(styles.breadcrumb_separator, 'flexRow_center', 'alignCenter')}>
-                                    <ChevronRight aria-hidden/>
-                                </li>}
+                            <li className={classnames(styles.breadcrumb_separator, 'flexRow_center', 'alignCenter')}>
+                                <ChevronRight aria-hidden/>
+                            </li>}
                         </Fragment>
                     ))
                 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-113

## Description

Don't' use the BreadcrumbItem's label to generate the value of the key

## Tests

The following are included in this PR

- [ ] Unit Test skeleton

## Checklist

<!--
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics.
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

- [ ] All files present ( component - md - scss - spec - stories )
- [ ] Are all props ok and documented
- [ ] Required props and default values
- [ ] Example in storybook

## Documentation

<!--
Indicate if you have been writing documentation has part of this change.
-->

- [ ] README documentation
