### PR TITLE
MOON-98: Allow expanding a tree node by clicking on the label

### DIFF
--- a/src/components/TreeView/ControlledTreeView.jsx
+++ b/src/components/TreeView/ControlledTreeView.jsx
@@ -28,6 +28,10 @@ export const ControlledTreeView = ({data, openedItems, selectedItems, onClickIte
             };
 
             const handleNodeClick = e => {
+                if (onClickItem.length === 0) {
+                    toggleNode(e);
+                }
+
                 onClickItem(node, e);
             };
 

--- a/src/components/TreeView/TreeView.spec.js
+++ b/src/components/TreeView/TreeView.spec.js
@@ -58,6 +58,15 @@ describe('TreeView', () => {
         expect(wrapper.html()).toContain('A-1 level2');
     });
 
+    it('should open a node by clicking on an item when no onClickItem is provided', () => {
+        const wrapper = shallow(
+            <UncontrolledTreeView data={tree}/>, {mocks: {ControlledTreeView: true}}
+        );
+
+        wrapper.querySelector('.treeView_itemLabel').dispatchEvent('click');
+        expect(wrapper.html()).toContain('A-1 level2');
+    });
+
     it('should display icon provide by an external source', () => {
         const wrapper = shallow(
             <ControlledTreeView data={tree}/>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-98

## Description

Allow expanding a tree node by clicking on the label when no `onClickItem` isn't provided

## Tests

The following are included in this PR

- [X] Unit Test