### PR TITLE
MOON-96: Fix styling issue on ButtonGroup hover

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.scss
+++ b/src/components/ButtonGroup/ButtonGroup.scss
@@ -20,14 +20,6 @@
 
     // Manage separator
     .variant_default {
-        .color_default {
-            &:hover,
-            &:active,
-            &:focus {
-                border-left-color: currentColor !important;
-            }
-        }
-
         & + .variant_default {
             border-left-color: transparent;
         }
@@ -42,12 +34,6 @@
     }
 
     .variant_outlined {
-        &:hover,
-        &:active,
-        &:focus {
-            border-left-color: currentColor !important;
-        }
-
         & + .variant_outlined {
             border-left-color: transparent;
         }

--- a/src/components/ButtonGroup/ButtonGroup.scss
+++ b/src/components/ButtonGroup/ButtonGroup.scss
@@ -20,10 +20,12 @@
 
     // Manage separator
     .variant_default {
-        &:hover,
-        &:active,
-        &:focus {
-            border-left-color: currentColor !important;
+        .color_default {
+            &:hover,
+            &:active,
+            &:focus {
+                border-left-color: currentColor !important;
+            }
         }
 
         & + .variant_default {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-96

## Description

Fix styling issue on hovering a ButtonGroup with a default variant and an accent color (a double border was displayed).