### PR TITLE
BACKLOG-12940: Add the possibility to extend tab cmp and fix his padding

### DIFF
--- a/src/components/Tab/Tab.jsx
+++ b/src/components/Tab/Tab.jsx
@@ -3,13 +3,15 @@ import PropTypes from 'prop-types';
 import styles from './Tab.scss';
 import classnames from 'clsx';
 
-export const Tab = ({children}) => {
+export const Tab = ({children, className, ...props}) => {
     return (
         <div
+            {...props}
             className={classnames(
                 styles.tab,
                 'flexRow_center',
-                'alignCenter'
+                'alignCenter',
+                className
             )}
         >
             {children}
@@ -17,11 +19,20 @@ export const Tab = ({children}) => {
     );
 };
 
+Tab.defaultProps = {
+    className: ''
+};
+
 Tab.propTypes = {
     /**
      * Content of Tab component
      */
-    children: PropTypes.node.isRequired
+    children: PropTypes.node.isRequired,
+
+    /**
+     * Additional classname
+     */
+    className: PropTypes.string
 };
 
 Tab.displayName = 'Tab';

--- a/src/components/Tab/Tab.scss
+++ b/src/components/Tab/Tab.scss
@@ -2,5 +2,5 @@
     display: flex;
     flex-direction: row;
     width: max-content;
-    padding: var(--spacing-nano) var(--spacing-small);
+    padding: var(--spacing-nano) var(--spacing-small) 0 var(--spacing-small);
 }

--- a/src/components/Tab/Tab.spec.js
+++ b/src/components/Tab/Tab.spec.js
@@ -3,8 +3,18 @@ import {shallow} from 'component-test-utils-react';
 import {Tab} from './index';
 
 describe('Tab', () => {
-    it('should render', () => {
+    it('should render the children', () => {
         const tab = shallow(<Tab>toto</Tab>);
-        expect(tab.html()).toEqual('<div class="tab flexRow_center alignCenter">toto</div>');
+        expect(tab.html()).toContain('toto');
+    });
+
+    it('should pass props to the element', () => {
+        const tab = shallow(<Tab title="tabulation">toto</Tab>);
+        expect(tab.html()).toContain('title="tabulation"');
+    });
+
+    it('should pass className to the element', () => {
+        const tab = shallow(<Tab className="customization">toto</Tab>);
+        expect(tab.html()).toContain('customization');
     });
 });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12940

## Description

Add the possibility to extend tab cmp and fix his padding

## Tests

The following are included in this PR

- [x] Unit Test skeleton

## Checklist

<!--
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics.
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

- [x] All files present ( component - md - scss - spec - stories )
- [x] Are all props ok and documented
- [x] Required props and default values
- [x] Example in storybook

## Documentation

<!--
Indicate if you have been writing documentation has part of this change.
-->

- [x] README documentation
