### PR TITLE
BACKLOG-12731: Fix for logo appearing in collapsed PrimaryNav bar in Safari

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.scss
+++ b/src/components/PrimaryNav/PrimaryNav.scss
@@ -3,6 +3,15 @@
 $primaryNavExpanded: 300px;
 $primaryNav: 56px;
 
+.logoCaptionGroup {
+    padding-right: 2.5rem;
+
+    visibility: hidden;
+    opacity: 0;
+
+    transition: visibility 0.15s, opacity 0.2s;
+}
+
 .primaryNav {
     position: fixed;
     top: 0;
@@ -25,6 +34,11 @@ $primaryNav: 56px;
         width: $primaryNavExpanded;
 
         box-shadow: 8px 0 16px 0 var(--color-gray_dark60);
+
+        .logoCaptionGroup {
+            visibility: visible;
+            opacity: 1;
+        }
     }
 }
 
@@ -39,10 +53,6 @@ $primaryNav: 56px;
     opacity: 0.6;
 }
 
-.logoCaptionGroup {
-    padding-right: 2.5rem;
-}
-
 .navHeader {
     height: $primaryNav;
 }
@@ -53,6 +63,8 @@ $primaryNav: 56px;
 }
 
 .navButton {
+    z-index: 9000;
+
     width: 40px;
     height: 40px;
     padding: 0;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12731

## Description

Style changes to PrimaryNav to fix the issue where the logo was overlapping with the collapsed navbar in Safari - flexbox was behaving differently in Safari vs Chrome and Firefox.
