### PR TITLE
Revert Moonstone version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@
 
 ---
 
+# v0.16.0 (Fri Jun 05 2020)
+
+#### 🚀  Enhancement
+
+- MOON-53: Code Completion [#154](https://github.com/Jahia/moonstone/pull/154) ([@tdraier](https://github.com/tdraier) [@vindhya](https://github.com/vindhya))
+
+#### Authors: 2
+
+- Thomas Draier ([@tdraier](https://github.com/tdraier))
+- Vindhya ([@vindhya](https://github.com/vindhya))
+
+---
+
 # v0.15.11 (Mon Apr 27 2020)
 
 #### 🐛  Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@
 
 ---
 
+# v0.16.0 (Fri Jun 05 2020)
+
+#### 🚀  Enhancement
+
+- MOON-53: Code Completion [#154](https://github.com/Jahia/moonstone/pull/154) ([@tdraier](https://github.com/tdraier) [@vindhya](https://github.com/vindhya))
+
+#### Authors: 2
+
+- Thomas Draier ([@tdraier](https://github.com/tdraier))
+- Vindhya ([@vindhya](https://github.com/vindhya))
+
+---
+
 # v0.15.11 (Mon Apr 27 2020)
 
 #### 🐛  Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,32 +11,6 @@
 
 ---
 
-# v0.16.0 (Fri Jun 05 2020)
-
-#### 🚀  Enhancement
-
-- MOON-53: Code Completion [#154](https://github.com/Jahia/moonstone/pull/154) ([@tdraier](https://github.com/tdraier) [@vindhya](https://github.com/vindhya))
-
-#### Authors: 2
-
-- Thomas Draier ([@tdraier](https://github.com/tdraier))
-- Vindhya ([@vindhya](https://github.com/vindhya))
-
----
-
-# v0.16.0 (Fri Jun 05 2020)
-
-#### 🚀  Enhancement
-
-- MOON-53: Code Completion [#154](https://github.com/Jahia/moonstone/pull/154) ([@tdraier](https://github.com/tdraier) [@vindhya](https://github.com/vindhya))
-
-#### Authors: 2
-
-- Thomas Draier ([@tdraier](https://github.com/tdraier))
-- Vindhya ([@vindhya](https://github.com/vindhya))
-
----
-
 # v0.15.11 (Mon Apr 27 2020)
 
 #### 🐛  Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v0.16.0 (Fri Jun 05 2020)
+
+#### 🚀  Enhancement
+
+- MOON-53: Code Completion [#154](https://github.com/Jahia/moonstone/pull/154) ([@tdraier](https://github.com/tdraier) [@vindhya](https://github.com/vindhya))
+
+#### Authors: 2
+
+- Thomas Draier ([@tdraier](https://github.com/tdraier))
+- Vindhya ([@vindhya](https://github.com/vindhya))
+
+---
+
 # v0.15.11 (Mon Apr 27 2020)
 
 #### 🐛  Bug Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jahia/moonstone",
-    "version": "0.18.0",
+    "version": "0.16.0",
     "dependencies": {
         "clsx": "^1.0.4",
         "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jahia/moonstone",
-    "version": "0.17.0",
+    "version": "0.18.0",
     "dependencies": {
         "clsx": "^1.0.4",
         "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jahia/moonstone",
-    "version": "0.16.0",
+    "version": "0.17.0",
     "dependencies": {
         "clsx": "^1.0.4",
         "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jahia/moonstone",
-    "version": "0.15.11",
+    "version": "0.16.0",
     "dependencies": {
         "clsx": "^1.0.4",
         "prop-types": "^15.7.2",


### PR DESCRIPTION
## Description

Reverted Moonstone version to 0.16.0 due to unnecessary version bumps and removed duplicate CHANGELOG.md updates.