### PR TITLE
BACKLOG-14310: Fixes font bug for Button, ButtonGroup, Breadcrumb, TabItem

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -15,6 +15,8 @@ $button-size_big: 32px;
     height: $button-size_medium;
     padding: 0 var(--spacing-small);
 
+    font-family: inherit;
+
     border-radius: 4px;
 
     outline: none;

--- a/src/components/TabItem/TabItem.scss
+++ b/src/components/TabItem/TabItem.scss
@@ -9,6 +9,8 @@
     margin: 0 var(--spacing-nano);
     padding: var(--spacing-nano) var(--spacing-small);
 
+    font-family: inherit;
+
     border-radius: 4px;
 
     outline: none;


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-14310

## Description

Buttons and Tab Items were not inheriting the font-family as per the css reset so I specifically added `font-family: inherit` to their scss files. It also fixed the issue for the ButtonGroup and Breadcrumb components.