### PR TITLE
MOON-169: Adds Menu Variants for Small and Big Images

### DIFF
--- a/src/components/Menu/Menu.scss
+++ b/src/components/Menu/Menu.scss
@@ -13,7 +13,7 @@
 
     list-style: none;
     background-color: var(--color-light);
-    box-shadow: 0 4px 8px var(--color-gray_dark60);
+    box-shadow: 0 var(--spacing-nano) var(--spacing-small) var(--color-gray_dark60);
     overflow-x: hidden; // Shorten property doesn't work with Safari
     overflow-y: auto;
 
@@ -21,6 +21,16 @@
         opacity: 0;
 
         pointer-events: none;
+    }
+
+    &.moonstone-menu_smallImages {
+        width: 264px;
+        max-height: 320px;
+    }
+
+    &.moonstone-menu_bigImages {
+        width: 400px;
+        max-height: 440px;
     }
 }
 

--- a/src/components/Menu/Menu.stories.jsx
+++ b/src/components/Menu/Menu.stories.jsx
@@ -114,15 +114,14 @@ storiesOf('Components|Menu', module)
             </div>
         );
     })
-    .add('Big Image MenuItems', () => (
+    .add('Big Image Menu Items', () => (
         <div style={{transform: 'scale(1)', height: '100vh'}}>
             <Menu
+                variant="bigImages"
                 isDisplayed={boolean('display', true)}
-                maxHeight={text('Max-height', '500px')}
-                maxWidth={text('Max-width', '400px')}
                 style={{zIndex: 10000}}
             >
-                <MenuItem label="Menu Items with Big Images" variant="title"/>
+                <MenuItem label="Menu Items with Big Images Title" variant="title"/>
                 <MenuItem
                     label="Big image MenuItem"
                     image={<img src="https://via.placeholder.com/500x500?text=MenuItemImage"/>}
@@ -152,15 +151,14 @@ storiesOf('Components|Menu', module)
             </Menu>
         </div>
     ))
-    .add('Small Image MenuItems', () => (
+    .add('Small Image Menu Items', () => (
         <div style={{transform: 'scale(1)', height: '100vh'}}>
             <Menu
+                variant="smallImages"
                 isDisplayed={boolean('display', true)}
-                maxHeight={text('Max-height', '500px')}
-                maxWidth={text('Max-width', '264px')}
                 style={{zIndex: 10000}}
             >
-                <MenuItem label="Menu Items with Small Images" variant="title"/>
+                <MenuItem label="Menu Items with Small Images Title" variant="title"/>
                 <MenuItem
                     label="Small image MenuItem"
                     image={<img src="https://via.placeholder.com/500x500?text=MenuItemImage"/>}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -23,8 +23,19 @@ type TStyleMenu =  {
     maxWidth?: string;
     maxHeight?: string;
 };
+type TMenuVariant = 'default' | 'smallImages' | 'bigImages';
+enum MenuVariant {
+    DEFAULT = 'default',
+    SMALL_IMAGES = 'smallImages',
+    BIG_IMAGES = 'bigImages'
+}
 
 interface IMenuProps {
+    /**
+     * Variant of the Menu
+     */
+    variant?: TMenuVariant;
+
     /**
      * Max-width available
      */
@@ -124,6 +135,7 @@ interface IMenuProps {
 export const Menu: React.FC<IMenuProps> = (
     {
         children,
+        variant,
         isDisplayed,
         minWidth,
         maxWidth,
@@ -173,6 +185,10 @@ export const Menu: React.FC<IMenuProps> = (
                 style={styleMenu}
                 className={classnames(
                     'moonstone-menu',
+                    {
+                        'moonstone-menu_smallImages': variant === MenuVariant.SMALL_IMAGES,
+                        'moonstone-menu_bigImages': variant === MenuVariant.BIG_IMAGES
+                    },
                     className,
                     {'moonstone-hidden': !isDisplayed || !stylePosition}
                 )}
@@ -197,6 +213,7 @@ export const Menu: React.FC<IMenuProps> = (
 
 // Kept defaultProps here because of unnecessary re-rendering when provided as default parameters to the function component
 Menu.defaultProps = {
+    variant: MenuVariant.DEFAULT,
     hasOverlay: true,
     anchorEl: null,
     anchorPosition: {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-169

## Description

* Adds new Menu variants: `smallImages` and `bigImages` which control the width and height of the Menu