### PR TITLE
MOON-160: Adds ability to have image dropdown options

### DIFF
--- a/src/components/Dropdown/Dropdown.md
+++ b/src/components/Dropdown/Dropdown.md
@@ -11,6 +11,6 @@ The selected item has a specific design
 Items can be grouped with a title
 
 ## Dropdown Options with Images
-To use image dropdown options, ensure that the data has an `image` property and `imageSize` property in addition to the `label` and any other properties you which to pass in.
+To use image dropdown options, ensure that the data passed into the Dropdown has an `image` property and `imageSize` property in addition to the `label` and any other properties you wish.
 
 The value of the `image` property should be an `img` HTML element.

--- a/src/components/Dropdown/Dropdown.md
+++ b/src/components/Dropdown/Dropdown.md
@@ -9,3 +9,8 @@ Allow user to validate a value by pressing `Enter`
 To hide the menu click on an item of the list or click outside to it
 The selected item has a specific design
 Items can be grouped with a title
+
+## Dropdown Options with Images
+To use image dropdown options, ensure that the data has an `image` property and `imageSize` property in addition to the `label` and any other properties you which to pass in.
+
+The value of the `image` property should be an `img` HTML element.

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -30,7 +30,14 @@
     }
 
     // ---
-    // Manage size variants
+    // Manage variants
+    // ---
+    &.moonstone-outlined {
+        border: 0.5px solid var(--color-gray40);
+    }
+
+    // ---
+    // Manage sizes
     // ---
     &.moonstone-small {
         padding-top: var(--spacing-nano);

--- a/src/components/Dropdown/Dropdown.stories.jsx
+++ b/src/components/Dropdown/Dropdown.stories.jsx
@@ -122,6 +122,146 @@ const dataGrouped = [
     }
 ];
 
+const dataBigImages = [
+    {
+        label: 'option 1',
+        value: '1',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'big'
+    },
+    {
+        label: 'option 2',
+        value: '2',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'big'
+    },
+    {
+        label: 'option 3 with very long long label label label label label label label label',
+        value: '3',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'big'
+    },
+    {
+        label: 'option 4',
+        value: '4',
+        isDisabled: true,
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'big'
+    },
+    {
+        label: 'option 5',
+        value: '5',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'big'
+    },
+    {
+        label: 'option 6',
+        value: '6',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'big'
+    },
+    {
+        label: 'option 7',
+        value: '7',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'big'
+    },
+    {
+        label: 'option 8',
+        value: '8',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'big'
+    },
+    {
+        label: 'option 9',
+        value: '9',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'big'
+    },
+    {
+        label: 'option 10',
+        value: '10',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'big'
+    },
+    {
+        label: 'option 11',
+        value: '11',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'big'
+    }
+];
+
+const dataSmallImages = [
+    {
+        label: 'option 1',
+        value: '1',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'small'
+    },
+    {
+        label: 'option 2',
+        value: '2',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'small'
+    },
+    {
+        label: 'option 3 with very long long label label label label label label label label',
+        value: '3',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'small'
+    },
+    {
+        label: 'option 4',
+        value: '4',
+        isDisabled: true,
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'small'
+    },
+    {
+        label: 'option 5',
+        value: '5',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'small'
+    },
+    {
+        label: 'option 6',
+        value: '6',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'small'
+    },
+    {
+        label: 'option 7',
+        value: '7',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'small'
+    },
+    {
+        label: 'option 8',
+        value: '8',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'small'
+    },
+    {
+        label: 'option 9',
+        value: '9',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'small'
+    },
+    {
+        label: 'option 10',
+        value: '10',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'small'
+    },
+    {
+        label: 'option 11',
+        value: '11',
+        image: <img src="https://via.placeholder.com/500x500?text=DropdownOptionImage"/>,
+        imageSize: 'small'
+    }
+];
+
 storiesOf('Components|Dropdown', module)
     .addParameters({
         component: Dropdown,
@@ -197,7 +337,7 @@ storiesOf('Components|Dropdown', module)
             </div>
         );
     })
-    .add('Outlined Variant', () => {
+    .add('Outlined Variant with Search', () => {
         const [currentOption, setCurrentOption] = useState({label: 'Select something', value: null});
 
         const handleOnChange = (e, item) => {
@@ -209,12 +349,60 @@ storiesOf('Components|Dropdown', module)
         return (
             <div style={{transform: 'scale(1)', height: '100vh', padding: '90px'}}>
                 <Dropdown
+                    hasSearch
                     variant="outlined"
                     label={currentOption.label}
                     value={currentOption.value}
                     size="medium"
-                    isDisabled={false}
                     data={data}
+                    onChange={(e, item) => handleOnChange(e, item)}
+                />
+            </div>
+        );
+    })
+    .add('Outlined Variant with Search and Big Images', () => {
+        const [currentOption, setCurrentOption] = useState({label: 'Select something', value: null});
+
+        const handleOnChange = (e, item) => {
+            setCurrentOption(item);
+            action('onChange');
+            return true;
+        };
+
+        return (
+            <div style={{transform: 'scale(1)', height: '100vh', padding: '90px'}}>
+                <Dropdown
+                    hasSearch
+                    variant="outlined"
+                    imageSize="big"
+                    label={currentOption.label}
+                    value={currentOption.value}
+                    size="medium"
+                    data={dataBigImages}
+                    onChange={(e, item) => handleOnChange(e, item)}
+                />
+            </div>
+        );
+    })
+    .add('Outlined Variant with Search and Small Images', () => {
+        const [currentOption, setCurrentOption] = useState({label: 'Select something', value: null});
+
+        const handleOnChange = (e, item) => {
+            setCurrentOption(item);
+            action('onChange');
+            return true;
+        };
+
+        return (
+            <div style={{transform: 'scale(1)', height: '100vh', padding: '90px'}}>
+                <Dropdown
+                    hasSearch
+                    variant="outlined"
+                    imageSize="small"
+                    label={currentOption.label}
+                    value={currentOption.value}
+                    size="medium"
+                    data={dataSmallImages}
                     onChange={(e, item) => handleOnChange(e, item)}
                 />
             </div>

--- a/src/components/Dropdown/Dropdown.stories.jsx
+++ b/src/components/Dropdown/Dropdown.stories.jsx
@@ -152,7 +152,7 @@ storiesOf('Components|Dropdown', module)
             </div>
         );
     })
-    .add('with default value', () => {
+    .add('With Default Value', () => {
         const [currentOption, setCurrentOption] = useState({label: dataLanguages[1].label, value: dataLanguages[1].value});
 
         const handleOnChange = (e, item) => {
@@ -192,6 +192,29 @@ storiesOf('Components|Dropdown', module)
                     size={select('Size', DropdownSizes, DropdownSizes.SMALL)}
                     maxWidth={text('Max width', '120px')}
                     data={dataGrouped}
+                    onChange={(e, item) => handleOnChange(e, item)}
+                />
+            </div>
+        );
+    })
+    .add('Outlined Variant', () => {
+        const [currentOption, setCurrentOption] = useState({label: 'Select something', value: null});
+
+        const handleOnChange = (e, item) => {
+            setCurrentOption(item);
+            action('onChange');
+            return true;
+        };
+
+        return (
+            <div style={{transform: 'scale(1)', height: '100vh', padding: '90px'}}>
+                <Dropdown
+                    variant="outlined"
+                    label={currentOption.label}
+                    value={currentOption.value}
+                    size="medium"
+                    isDisabled={false}
+                    data={data}
                     onChange={(e, item) => handleOnChange(e, item)}
                 />
             </div>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -8,9 +8,8 @@ import {Typography} from '~/components/Typography';
 import {Separator} from '~/components/Separator';
 import {ChevronDown} from '~/icons';
 
-type TDropdownVariant = 'default' | 'ghost' | 'outlined';
+type TDropdownVariant = 'ghost' | 'outlined';
 enum DropdownVariants {
-    DEFAULT = 'default',
     GHOST = 'ghost',
     OUTLINED = 'outlined'
 }
@@ -21,6 +20,12 @@ export enum DropdownSizes {
     MEDIUM = 'medium'
 }
 
+type TDropdownImageSize = 'small' | 'big';
+enum DropdownImageSize {
+    SMALL = 'small',
+    BIG = 'big'
+}
+
 type TDropdownDataOptions = {
     label?: string;
     value?: string;
@@ -28,6 +33,8 @@ type TDropdownDataOptions = {
     iconStart?: React.ReactElement;
     iconEnd?: React.ReactElement;
     attributes?: {};
+    image?: HTMLImageElement;
+    imageSize?: TDropdownImageSize;
 }
 
 type TDropdownData = {
@@ -67,6 +74,11 @@ interface IDropdownProps {
      * Dropdown's sizes
      */
     size?: TDropdownSize;
+
+    /**
+     * Size of images to show in the Dropdown
+     */
+    imageSize?: TDropdownImageSize;
 
     /**
      * Max width of the dropdown
@@ -114,6 +126,7 @@ export const Dropdown: React.FC<IDropdownProps> = (
         icon,
         hasSearch,
         searchEmptyText,
+        imageSize,
         onChange,
         className,
         ...props
@@ -122,11 +135,28 @@ export const Dropdown: React.FC<IDropdownProps> = (
     const [anchorEl, setAnchorEl] = useState(null);
     const [minWidth, setMinWith] = useState(null);
     const isGrouped = typeof data[0].options !== 'undefined';
+    let menuMaxWidth;
+    let menuMaxHeight;
 
     const anchorPosition = {
         top: Number(spacings.spacingNano.slice(0, -2)),
         left: 0
     };
+
+    switch (imageSize) {
+        case DropdownImageSize.BIG:
+            menuMaxWidth = '400px';
+            menuMaxHeight = '440px';
+            break;
+        case DropdownImageSize.SMALL:
+            menuMaxWidth = '264px';
+            menuMaxHeight = '320px';
+            break;
+        default:
+            // Default menu size for the dropdown when no image size is provided
+            menuMaxWidth = '250px';
+            menuMaxHeight = '270px';
+    }
 
     // ---
     // Functions to handle events
@@ -193,8 +223,8 @@ export const Dropdown: React.FC<IDropdownProps> = (
             iconEnd={item.iconEnd}
             isDisabled={item.isDisabled}
             isSelected={value === item.value}
-            hasSearch={hasSearch}
-            searchEmptyText={searchEmptyText}
+            image={item.image}
+            imageSize={item.imageSize}
             onClick={e => handleSelect(e, item)}
             onKeyPress={e => handleKeyPress(e, item)}
             {...item.attributes}
@@ -257,10 +287,12 @@ export const Dropdown: React.FC<IDropdownProps> = (
             <Menu
                 isDisplayed={isOpened}
                 anchorPosition={anchorPosition}
-                maxHeight="270px"
-                maxWidth="250px"
                 minWidth={minWidth}
+                maxWidth={menuMaxWidth}
+                maxHeight={menuMaxHeight}
                 anchorEl={anchorEl}
+                hasSearch={hasSearch}
+                searchEmptyText={searchEmptyText}
                 onClose={handleCloseMenu}
             >
                 {
@@ -282,12 +314,12 @@ export const Dropdown: React.FC<IDropdownProps> = (
 
 Dropdown.defaultProps = {
     icon: null,
-    variant: 'default',
-    size: 'medium',
+    variant: DropdownVariants.GHOST,
+    size: DropdownSizes.MEDIUM,
     maxWidth: '300px',
     isDisabled: false,
     hasSearch: false,
-    searchEmptyText: ''
+    searchEmptyText: 'No results found.'
 };
 
 Dropdown.displayName = 'Dropdown';

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -8,10 +8,11 @@ import {Typography} from '~/components/Typography';
 import {Separator} from '~/components/Separator';
 import {ChevronDown} from '~/icons';
 
-type TDropdownVariant = 'default' | 'ghost';
+type TDropdownVariant = 'default' | 'ghost' | 'outlined';
 enum DropdownVariants {
     DEFAULT = 'default',
-    GHOST = 'ghost'
+    GHOST = 'ghost',
+    OUTLINED = 'outlined'
 }
 
 type TDropdownSize = 'small' | 'medium';
@@ -78,6 +79,16 @@ interface IDropdownProps {
     isDisabled?: boolean;
 
     /**
+     * Whether the Menu within the Dropdown has a search input
+     */
+    hasSearch?: boolean;
+
+    /**
+     * The text to display if the Dropdown Menu has a search input and the search doesn't have any results
+     */
+    searchEmptyText?: string;
+
+    /**
      * Additional classname
      */
     className?: string;
@@ -101,6 +112,8 @@ export const Dropdown: React.FC<IDropdownProps> = (
         variant,
         size,
         icon,
+        hasSearch,
+        searchEmptyText,
         onChange,
         className,
         ...props
@@ -165,7 +178,7 @@ export const Dropdown: React.FC<IDropdownProps> = (
         'alignCenter',
         'moonstone-dropdown_label',
         `moonstone-${size}`,
-        variant
+        `moonstone-${variant}`
     );
 
     // ---
@@ -180,6 +193,8 @@ export const Dropdown: React.FC<IDropdownProps> = (
             iconEnd={item.iconEnd}
             isDisabled={item.isDisabled}
             isSelected={value === item.value}
+            hasSearch={hasSearch}
+            searchEmptyText={searchEmptyText}
             onClick={e => handleSelect(e, item)}
             onKeyPress={e => handleKeyPress(e, item)}
             {...item.attributes}
@@ -270,7 +285,9 @@ Dropdown.defaultProps = {
     variant: 'default',
     size: 'medium',
     maxWidth: '300px',
-    isDisabled: false
+    isDisabled: false,
+    hasSearch: false,
+    searchEmptyText: ''
 };
 
 Dropdown.displayName = 'Dropdown';

--- a/src/components/Menu/Menu.scss
+++ b/src/components/Menu/Menu.scss
@@ -23,16 +23,6 @@
         pointer-events: none;
     }
 
-    &.moonstone-menu_smallImages {
-        width: 264px;
-        max-height: 320px;
-    }
-
-    &.moonstone-menu_bigImages {
-        width: 400px;
-        max-height: 440px;
-    }
-
     .moonstone-menu_searchInput {
         margin: var(--spacing-small) var(--spacing-medium);
     }

--- a/src/components/Menu/Menu.stories.jsx
+++ b/src/components/Menu/Menu.stories.jsx
@@ -119,6 +119,8 @@ storiesOf('Components|Menu', module)
             <Menu
                 variant="bigImages"
                 isDisplayed={boolean('display', true)}
+                width="400px"
+                maxHeight="440px"
                 style={{zIndex: 10000}}
             >
                 <MenuItem label="Menu Items with Big Images Title" variant="title"/>
@@ -156,6 +158,8 @@ storiesOf('Components|Menu', module)
             <Menu
                 variant="smallImages"
                 isDisplayed={boolean('display', true)}
+                width="264px"
+                maxHeight="320px"
                 style={{zIndex: 10000}}
             >
                 <MenuItem label="Menu Items with Small Images Title" variant="title"/>
@@ -194,7 +198,7 @@ storiesOf('Components|Menu', module)
                 hasSearch
                 isDisplayed={boolean('display', true)}
                 searchEmptyText="Oh no! It seems like that doesn't exist."
-                maxHeight={text('Max-height', '250px')}
+                maxHeight="250px"
                 style={{zIndex: 10000}}
             >
                 <MenuItem label="Base items" variant="title"/>

--- a/src/components/Menu/Menu.stories.jsx
+++ b/src/components/Menu/Menu.stories.jsx
@@ -117,7 +117,6 @@ storiesOf('Components|Menu', module)
     .add('Big Image Menu Items', () => (
         <div style={{transform: 'scale(1)', height: '100vh'}}>
             <Menu
-                variant="bigImages"
                 isDisplayed={boolean('display', true)}
                 maxWidth="400px"
                 maxHeight="440px"
@@ -156,7 +155,6 @@ storiesOf('Components|Menu', module)
     .add('Small Image Menu Items', () => (
         <div style={{transform: 'scale(1)', height: '100vh'}}>
             <Menu
-                variant="smallImages"
                 isDisplayed={boolean('display', true)}
                 maxWidth="264px"
                 maxHeight="320px"

--- a/src/components/Menu/Menu.stories.jsx
+++ b/src/components/Menu/Menu.stories.jsx
@@ -119,7 +119,7 @@ storiesOf('Components|Menu', module)
             <Menu
                 variant="bigImages"
                 isDisplayed={boolean('display', true)}
-                width="400px"
+                maxWidth="400px"
                 maxHeight="440px"
                 style={{zIndex: 10000}}
             >
@@ -158,7 +158,7 @@ storiesOf('Components|Menu', module)
             <Menu
                 variant="smallImages"
                 isDisplayed={boolean('display', true)}
-                width="264px"
+                maxWidth="264px"
                 maxHeight="320px"
                 style={{zIndex: 10000}}
             >

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -22,34 +22,29 @@ type TStyleMenu =  {
     top?: string | number;
     left?: string | number;
     minWidth?: string;
+    width?: string;
     maxWidth?: string;
     maxHeight?: string;
 };
-type TMenuVariant = 'default' | 'smallImages' | 'bigImages';
-enum MenuVariant {
-    DEFAULT = 'default',
-    SMALL_IMAGES = 'smallImages',
-    BIG_IMAGES = 'bigImages'
-}
 
 interface IMenuProps {
     /**
-     * Variant of the Menu
-     */
-    variant?: TMenuVariant;
-
-    /**
-     * Max-width available
+     * Maximum height of the Menu
      */
     maxHeight?: string;
 
     /**
-     * Max-width available
+     * Maximum width of the Menu
      */
     maxWidth?: string;
 
     /**
-     * Min-width available
+     * Explicit width of the Menu
+     */
+    width?: string;
+
+    /**
+     * Minimum width of the Menu
      */
     minWidth?: string;
 
@@ -147,9 +142,9 @@ interface IMenuProps {
 export const Menu: React.FC<IMenuProps> = (
     {
         children,
-        variant,
         isDisplayed,
         minWidth,
+        width,
         maxWidth,
         maxHeight,
         className,
@@ -206,6 +201,10 @@ export const Menu: React.FC<IMenuProps> = (
         styleMenu.minWidth = minWidth;
     }
 
+    if (width) {
+        styleMenu.width = width;
+    }
+
     if (maxWidth) {
         styleMenu.maxWidth = maxWidth;
     }
@@ -224,10 +223,6 @@ export const Menu: React.FC<IMenuProps> = (
                 style={styleMenu}
                 className={classnames(
                     'moonstone-menu',
-                    {
-                        'moonstone-menu_smallImages': variant === MenuVariant.SMALL_IMAGES,
-                        'moonstone-menu_bigImages': variant === MenuVariant.BIG_IMAGES
-                    },
                     className,
                     {'moonstone-hidden': !isDisplayed || !stylePosition}
                 )}
@@ -270,7 +265,6 @@ export const Menu: React.FC<IMenuProps> = (
 
 // Kept defaultProps here because of unnecessary re-rendering when provided as default parameters to the function component
 Menu.defaultProps = {
-    variant: MenuVariant.DEFAULT,
     hasOverlay: true,
     hasSearch: false,
     searchEmptyText: 'No results found.',

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -22,7 +22,6 @@ type TStyleMenu =  {
     top?: string | number;
     left?: string | number;
     minWidth?: string;
-    width?: string;
     maxWidth?: string;
     maxHeight?: string;
 };
@@ -37,11 +36,6 @@ interface IMenuProps {
      * Maximum width of the Menu
      */
     maxWidth?: string;
-
-    /**
-     * Explicit width of the Menu
-     */
-    width?: string;
 
     /**
      * Minimum width of the Menu
@@ -144,7 +138,6 @@ export const Menu: React.FC<IMenuProps> = (
         children,
         isDisplayed,
         minWidth,
-        width,
         maxWidth,
         maxHeight,
         className,
@@ -199,10 +192,6 @@ export const Menu: React.FC<IMenuProps> = (
     const styleMenu: TStyleMenu = {...stylePosition as TStyleMenu, ...style};
     if (minWidth) {
         styleMenu.minWidth = minWidth;
-    }
-
-    if (width) {
-        styleMenu.width = width;
     }
 
     if (maxWidth) {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-160

## Description

* Adds the ability to have image dropdown options
* Assigns  the appropriate`maxWidth` and `maxHeight` to the Dropdown Menu when the `imageSize` prop is passed into the Dropdown
* Simplifies the Menu component so that it doesn't need its own `imageSize` property. It's now managed on the MenuItem/LisItem level and the Dropdown level
* Complete styling to come in the next PR

## Checklist

<!--
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics.
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

- [x] All files present (component - md - scss - spec - stories)
- [x] All props ok and documented (propTypes or typescript types)
- [x] Example in storybook

## Documentation

<!--
Indicate if you have been writing documentation has part of this change.
-->

- [x] README documentation (specification of the component, responsiveness, dependencies on other components, states, behaviours, animations, accessibility)
