### PR TITLE
Adds NODE_OPTIONS to Storybook Build Command

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -16,7 +16,7 @@ jobs:
       run: yarn install --frozen-lockfile
 
     - name: Build
-      run: yarn build:storybook
+      run: NODE_OPTIONS=--max_old_space_size=4096 yarn build:storybook
 
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v2


### PR DESCRIPTION
* Adds NODE_OPTIONS setting to storybook build during workflow to deploy storybook to github pages
* Once storybook has been updated to the latest version, hopefully, this will not be necessary with the newer typescript optimizations