### PR TITLE
MOON-216: Fixes menu truncation issue in Firefox and Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "react": "^16.11.0"
     },
     "scripts": {
-        "start": "NODE_OPTIONS=--max_old_space_size=4096 start-storybook -p 6006",
+        "start": "start-storybook -p 6006",
         "test": "jest --ci --runInBand --coverage",
         "tdd": "jest --watch",
         "lint:js": "eslint --ext js,jsx,json .",
@@ -35,7 +35,7 @@
         "build": "yarn build:storybook && yarn build:lib && yarn webpack",
         "prebuild:lib": "rimraf dist/",
         "build:lib": "yarn tsc && yarn compilejs",
-        "build:storybook": "NODE_OPTIONS=--max_old_space_size=6144 build-storybook",
+        "build:storybook": "build-storybook",
         "auto": "auto",
         "auto-changelog": "auto changelog",
         "auto-version": "npm version `auto version` -m 'Bump version to: %s [skip ci]'",

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -256,7 +256,7 @@ export const Dropdown: React.FC<DropdownProps> = (
     return (
         <div
             className={classnames(className)}
-            style={{maxWidth: maxWidth}}
+            style={{maxWidth}}
             {...props}
             onKeyPress={e => {
                 if (e.key === 'Enter') {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -101,6 +101,13 @@ interface DropdownProps {
     searchEmptyText?: string;
 
     /**
+     * Use this property if you notice that the text within the menu that opens is getting truncated.
+     * When true, the size of the Menu will be increased so that the scrollbar is added to the minimum width.
+     * This is to solve for issues with rendering in Firefox and Safari (Chrome automatically makes the fix)
+     */
+    alignSmallSpaceBrowserScrollbarRendering?: boolean;
+
+    /**
      * Additional classname
      */
     className?: string;
@@ -127,6 +134,7 @@ export const Dropdown: React.FC<DropdownProps> = (
         hasSearch,
         searchEmptyText,
         imageSize,
+        alignSmallSpaceBrowserScrollbarRendering,
         onChange,
         className,
         ...props
@@ -248,7 +256,7 @@ export const Dropdown: React.FC<DropdownProps> = (
     return (
         <div
             className={classnames(className)}
-            style={{maxWidth}}
+            style={{maxWidth: maxWidth}}
             {...props}
             onKeyPress={e => {
                 if (e.key === 'Enter') {
@@ -291,6 +299,7 @@ export const Dropdown: React.FC<DropdownProps> = (
                 anchorEl={anchorEl}
                 hasSearch={hasSearch}
                 searchEmptyText={searchEmptyText}
+                alignSmallSpaceBrowserScrollbarRendering={alignSmallSpaceBrowserScrollbarRendering}
                 onClose={handleCloseMenu}
             >
                 {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -101,13 +101,6 @@ interface DropdownProps {
     searchEmptyText?: string;
 
     /**
-     * Use this property if you notice that the text within the menu that opens is getting truncated.
-     * When true, the size of the Menu will be increased so that the scrollbar is added to the minimum width.
-     * This is to solve for issues with rendering in Firefox and Safari (Chrome automatically makes the fix)
-     */
-    alignSmallSpaceBrowserScrollbarRendering?: boolean;
-
-    /**
      * Additional classname
      */
     className?: string;
@@ -134,7 +127,6 @@ export const Dropdown: React.FC<DropdownProps> = (
         hasSearch,
         searchEmptyText,
         imageSize,
-        alignSmallSpaceBrowserScrollbarRendering,
         onChange,
         className,
         ...props
@@ -143,6 +135,7 @@ export const Dropdown: React.FC<DropdownProps> = (
     const [anchorEl, setAnchorEl] = useState(null);
     const [minWidth, setMinWith] = useState(null);
     const isGrouped = typeof data[0].options !== 'undefined';
+    const menuMinWidth = 70;
     let menuMaxWidth;
     let menuMaxHeight;
 
@@ -170,7 +163,8 @@ export const Dropdown: React.FC<DropdownProps> = (
     // Functions to handle events
     // ---
     const handleOpenMenu = (e: React.MouseEvent | React.KeyboardEvent) => {
-        setMinWith(`${(e.currentTarget as HTMLElement).offsetWidth}px`);
+        const dropdownWidth = (e.currentTarget as HTMLElement).offsetWidth;
+        setMinWith(`${dropdownWidth < menuMinWidth ? menuMinWidth : dropdownWidth}px`);
         setAnchorEl(e.currentTarget);
         setIsOpened(true);
     };
@@ -299,7 +293,6 @@ export const Dropdown: React.FC<DropdownProps> = (
                 anchorEl={anchorEl}
                 hasSearch={hasSearch}
                 searchEmptyText={searchEmptyText}
-                alignSmallSpaceBrowserScrollbarRendering={alignSmallSpaceBrowserScrollbarRendering}
                 onClose={handleCloseMenu}
             >
                 {

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -93,6 +93,13 @@ interface MenuProps {
     searchEmptyText?: string;
 
     /**
+     * Use this property if you notice that the text within the menu is getting truncated.
+     * When true, the size of the Menu will be increased so that the scrollbar is added to the minimum width.
+     * This is to solve for issues with rendering in Firefox and Safari (Chrome automatically makes the fix)
+     */
+    alignSmallSpaceBrowserScrollbarRendering?: boolean;
+
+    /**
      * Function triggered when the mouse pointer hovering the menu
      */
     onMouseEnter?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
@@ -165,6 +172,7 @@ export const Menu: React.FC<MenuProps> = (
         hasOverlay,
         hasSearch,
         searchEmptyText,
+        alignSmallSpaceBrowserScrollbarRendering,
         ...props
     }) => {
     const [stylePosition, itemRef] = usePositioning(isDisplayed, anchorPosition, anchorEl, anchorElOrigin, transformElOrigin);
@@ -172,6 +180,7 @@ export const Menu: React.FC<MenuProps> = (
     const [inputValue, setInputValue] = useState('');
     const [filteredChildren, setFilteredChildren] = useState(children);
     const [isEmptySearch, setIsEmptySearch] = useState(false);
+    const [browserAlignedMinWidth, setBrowserAlignedMinWidth] = useState(minWidth);
 
     useEffect(() => {
         if (inputValue !== '') {
@@ -198,12 +207,18 @@ export const Menu: React.FC<MenuProps> = (
         }
     }, [inputValue, children]);
 
+    useEffect(() => {
+        // Add the min width + the width of the scrollbar
+        const widthInclScrollbar = parseInt(minWidth, 10) + (itemRef.current.offsetWidth - itemRef.current.clientWidth) + 'px';
+        setBrowserAlignedMinWidth(widthInclScrollbar);
+    }, [minWidth])
+
     // ---
     // Styling
     // ---
     const styleMenu: StyleMenu = {...stylePosition as StyleMenu, ...style};
     if (minWidth) {
-        styleMenu.minWidth = minWidth;
+        styleMenu.minWidth = alignSmallSpaceBrowserScrollbarRendering ? browserAlignedMinWidth : minWidth;
     }
 
     if (maxWidth) {

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -93,13 +93,6 @@ interface MenuProps {
     searchEmptyText?: string;
 
     /**
-     * Use this property if you notice that the text within the menu is getting truncated.
-     * When true, the size of the Menu will be increased so that the scrollbar is added to the minimum width.
-     * This is to solve for issues with rendering in Firefox and Safari (Chrome automatically makes the fix)
-     */
-    alignSmallSpaceBrowserScrollbarRendering?: boolean;
-
-    /**
      * Function triggered when the mouse pointer hovering the menu
      */
     onMouseEnter?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
@@ -172,7 +165,6 @@ export const Menu: React.FC<MenuProps> = (
         hasOverlay,
         hasSearch,
         searchEmptyText,
-        alignSmallSpaceBrowserScrollbarRendering,
         ...props
     }) => {
     const [stylePosition, itemRef] = usePositioning(isDisplayed, anchorPosition, anchorEl, anchorElOrigin, transformElOrigin);
@@ -180,7 +172,6 @@ export const Menu: React.FC<MenuProps> = (
     const [inputValue, setInputValue] = useState('');
     const [filteredChildren, setFilteredChildren] = useState(children);
     const [isEmptySearch, setIsEmptySearch] = useState(false);
-    const [browserAlignedMinWidth, setBrowserAlignedMinWidth] = useState(minWidth);
 
     useEffect(() => {
         if (inputValue !== '') {
@@ -207,18 +198,12 @@ export const Menu: React.FC<MenuProps> = (
         }
     }, [inputValue, children]);
 
-    useEffect(() => {
-        // Add the min width + the width of the scrollbar
-        const widthInclScrollbar = parseInt(minWidth, 10) + (itemRef.current.offsetWidth - itemRef.current.clientWidth) + 'px';
-        setBrowserAlignedMinWidth(widthInclScrollbar);
-    }, [minWidth])
-
     // ---
     // Styling
     // ---
     const styleMenu: StyleMenu = {...stylePosition as StyleMenu, ...style};
     if (minWidth) {
-        styleMenu.minWidth = alignSmallSpaceBrowserScrollbarRendering ? browserAlignedMinWidth : minWidth;
+        styleMenu.minWidth = minWidth;
     }
 
     if (maxWidth) {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-216

## Description

* The `Menu` opened by `Dropdown` will have a width which is no smaller than 70px
* Removed the node options to increase memory for node as they're no longer necessary with the storybook 6 update