### PR TITLE
MOON-218: Skip CI for gh-pages branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,11 +104,7 @@ workflows:
   version: 2
   on-code-change:
     jobs:
-      - lint-test:
-          filters:
-            branches:
-              ignore:
-                - gh-pages
+      - lint-test
       - build:
           requires:
             - lint-test

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v2
       env:
-        ACTIONS_DEPLOY_KEY: ${{ secrets.DEPLOY_STORYBOOK }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: 'storybook-static'
+        deploy_key: ${{ secrets.DEPLOY_STORYBOOK }}
+        publish_branch: gh-pages
+        publish_dir: 'storybook-static'
+        commit_message: 'Automated deployment [skip ci]'

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -19,7 +19,7 @@ jobs:
       run: yarn build:storybook
 
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v2
+      uses: peaceiris/actions-gh-pages@v3
       env:
         deploy_key: ${{ secrets.DEPLOY_STORYBOOK }}
         publish_branch: gh-pages


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-218

## Description

Added a custom commit message with `[skip ci]` for the commit generated by the storybook deployment github action so that CircleCI isn't triggers on the `gh-pages` branch.

