### PR TITLE
MOON-216: Adds webpack publicPath to fix test issues

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,8 @@ const ComponentsConfig = {
     output: {
         filename: 'main.js',
         path: path.resolve(__dirname, 'dist/lib'),
-        libraryTarget: 'commonjs'
+        libraryTarget: 'commonjs',
+        publicPath: '/'
     },
     mode: 'development',
     devtool: 'source-map',


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-216

## Description

Added webpack output.publicPath to fix errors in moonstone-alpha tests.