### PR TITLE
MOON-219: Fix error when an empty array is used as data on dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.spec.js
+++ b/src/components/Dropdown/Dropdown.spec.js
@@ -88,4 +88,14 @@ describe('Dropdown', () => {
         expect(screen.queryByText('option 3')).not.toBeInTheDocument();
         expect(screen.getByText('option 4')).toBeInTheDocument();
     });
+
+    it('shouldn\'t display if data isn\'t an array', () => {
+        const {queryByTestId} = render(<Dropdown data="test" data-testid="moonstone-dropdown" onChange={() => 'testing'}/>);
+        expect(queryByTestId('moonstone-dropdown')).not.toBeInTheDocument();
+    });
+
+    it('shouldn\'t display if data is empty', () => {
+        const {queryByTestId} = render(<Dropdown data={[]} data-testid="moonstone-dropdown" onChange={() => 'testing'}/>);
+        expect(queryByTestId('moonstone-dropdown')).not.toBeInTheDocument();
+    });
 });

--- a/src/components/Dropdown/Dropdown.stories.jsx
+++ b/src/components/Dropdown/Dropdown.stories.jsx
@@ -217,7 +217,7 @@ storiesOf('Components/Dropdown', module)
                     size={select('Size', DropdownSizes, DropdownSizes.Small)}
                     isDisabled={boolean('Disabled', false)}
                     maxWidth={text('Max width', '120px')}
-                    data={data}
+                    data="test"
                     onChange={(e, item) => handleOnChange(e, item)}
                 />
             </div>

--- a/src/components/Dropdown/Dropdown.stories.jsx
+++ b/src/components/Dropdown/Dropdown.stories.jsx
@@ -217,7 +217,7 @@ storiesOf('Components/Dropdown', module)
                     size={select('Size', DropdownSizes, DropdownSizes.Small)}
                     isDisabled={boolean('Disabled', false)}
                     maxWidth={text('Max width', '120px')}
-                    data="test"
+                    data={data}
                     onChange={(e, item) => handleOnChange(e, item)}
                 />
             </div>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -131,6 +131,12 @@ export const Dropdown: React.FC<DropdownProps> = (
         className,
         ...props
     }) => {
+
+    // Return nothing if `data` isn't an array or data is empty
+    if (!Array.isArray(data) || data.length === 0) {
+        return null;
+    }
+
     const [isOpened, setIsOpened] = useState(false);
     const [anchorEl, setAnchorEl] = useState(null);
     const [minWidth, setMinWith] = useState(null);

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -150,7 +150,7 @@ export const Dropdown: React.FC<DropdownProps> = (
         left: 0
     };
 
-    switch(imageSize) {
+    switch (imageSize) {
         case DropdownImageSizes.Big:
             menuMaxWidth = '400px';
             menuMaxHeight = '440px';
@@ -176,14 +176,14 @@ export const Dropdown: React.FC<DropdownProps> = (
     };
 
     const handleSelect: HandleSelect = (e, item) => {
-        if(item) {
+        if (item) {
             let canClose: boolean | void = !item.isDisabled;
-            if(!item.isDisabled && item.value !== value) {
+            if (!item.isDisabled && item.value !== value) {
                 e.stopPropagation();
                 canClose = (onChange as (e: React.MouseEvent | React.KeyboardEvent, item: DropdownDataOptions) => void)(e, item);
             }
 
-            if(canClose !== false) {
+            if (canClose !== false) {
                 setIsOpened(false);
             }
         }
@@ -195,7 +195,7 @@ export const Dropdown: React.FC<DropdownProps> = (
     };
 
     const handleKeyPress = (e: React.KeyboardEvent, item: DropdownDataOptions) => {
-        if(e.key === 'Enter') {
+        if (e.key === 'Enter') {
             handleSelect(e, item);
         }
     };
@@ -241,10 +241,10 @@ export const Dropdown: React.FC<DropdownProps> = (
         return (
             <div key={`${groupLabel}-${index}`} data-option-type="group">
                 {index > 0 && (
-                    <Separator />
+                    <Separator/>
                 )}
 
-                <MenuItem variant="title" label={groupLabel} />
+                <MenuItem variant="title" label={groupLabel}/>
 
                 {children.map(item => {
                     return dropdownOption(item);
@@ -259,7 +259,7 @@ export const Dropdown: React.FC<DropdownProps> = (
             style={{maxWidth}}
             {...props}
             onKeyPress={e => {
-                if(e.key === 'Enter') {
+                if (e.key === 'Enter') {
                     handleOpenMenu(e);
                 }
             }}
@@ -269,14 +269,14 @@ export const Dropdown: React.FC<DropdownProps> = (
                 tabIndex={0}
                 onClick={handleOpenMenu}
                 onKeyPress={(e: React.KeyboardEvent) => {
-                    if(e.key === 'Enter') {
+                    if (e.key === 'Enter') {
                         handleSelect(e);
                     }
                 }}
             >
                 {
                     icon &&
-                    <icon.type {...icon.props} size="small" className={classnames('moonstone-dropdown_icon')} />
+                    <icon.type {...icon.props} size="small" className={classnames('moonstone-dropdown_icon')}/>
                 }
 
                 <Typography
@@ -287,7 +287,7 @@ export const Dropdown: React.FC<DropdownProps> = (
                 >
                     {label}
                 </Typography>
-                <ChevronDown className="moonstone-dropdown_chevronDown" />
+                <ChevronDown className="moonstone-dropdown_chevronDown"/>
             </div>
 
             <Menu
@@ -303,7 +303,7 @@ export const Dropdown: React.FC<DropdownProps> = (
             >
                 {
                     data.map((item, index) => {
-                        if(isGrouped) {
+                        if (isGrouped) {
                             item.options.map(o => {
                                 return dropdownOption(o);
                             });

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -133,7 +133,7 @@ export const Dropdown: React.FC<DropdownProps> = (
     }) => {
 
     // Return nothing if `data` isn't an array or data is empty
-    if (!Array.isArray(data) || data.length === 0) {
+    if (!Array.isArray(data) || data.length < 1) {
         return null;
     }
 
@@ -150,7 +150,7 @@ export const Dropdown: React.FC<DropdownProps> = (
         left: 0
     };
 
-    switch (imageSize) {
+    switch(imageSize) {
         case DropdownImageSizes.Big:
             menuMaxWidth = '400px';
             menuMaxHeight = '440px';
@@ -176,14 +176,14 @@ export const Dropdown: React.FC<DropdownProps> = (
     };
 
     const handleSelect: HandleSelect = (e, item) => {
-        if (item) {
+        if(item) {
             let canClose: boolean | void = !item.isDisabled;
-            if (!item.isDisabled && item.value !== value) {
+            if(!item.isDisabled && item.value !== value) {
                 e.stopPropagation();
                 canClose = (onChange as (e: React.MouseEvent | React.KeyboardEvent, item: DropdownDataOptions) => void)(e, item);
             }
 
-            if (canClose !== false) {
+            if(canClose !== false) {
                 setIsOpened(false);
             }
         }
@@ -195,7 +195,7 @@ export const Dropdown: React.FC<DropdownProps> = (
     };
 
     const handleKeyPress = (e: React.KeyboardEvent, item: DropdownDataOptions) => {
-        if (e.key === 'Enter') {
+        if(e.key === 'Enter') {
             handleSelect(e, item);
         }
     };
@@ -241,10 +241,10 @@ export const Dropdown: React.FC<DropdownProps> = (
         return (
             <div key={`${groupLabel}-${index}`} data-option-type="group">
                 {index > 0 && (
-                    <Separator/>
+                    <Separator />
                 )}
 
-                <MenuItem variant="title" label={groupLabel}/>
+                <MenuItem variant="title" label={groupLabel} />
 
                 {children.map(item => {
                     return dropdownOption(item);
@@ -259,7 +259,7 @@ export const Dropdown: React.FC<DropdownProps> = (
             style={{maxWidth}}
             {...props}
             onKeyPress={e => {
-                if (e.key === 'Enter') {
+                if(e.key === 'Enter') {
                     handleOpenMenu(e);
                 }
             }}
@@ -269,14 +269,14 @@ export const Dropdown: React.FC<DropdownProps> = (
                 tabIndex={0}
                 onClick={handleOpenMenu}
                 onKeyPress={(e: React.KeyboardEvent) => {
-                    if (e.key === 'Enter') {
+                    if(e.key === 'Enter') {
                         handleSelect(e);
                     }
                 }}
             >
                 {
                     icon &&
-                    <icon.type {...icon.props} size="small" className={classnames('moonstone-dropdown_icon')}/>
+                    <icon.type {...icon.props} size="small" className={classnames('moonstone-dropdown_icon')} />
                 }
 
                 <Typography
@@ -287,7 +287,7 @@ export const Dropdown: React.FC<DropdownProps> = (
                 >
                     {label}
                 </Typography>
-                <ChevronDown className="moonstone-dropdown_chevronDown"/>
+                <ChevronDown className="moonstone-dropdown_chevronDown" />
             </div>
 
             <Menu
@@ -303,7 +303,7 @@ export const Dropdown: React.FC<DropdownProps> = (
             >
                 {
                     data.map((item, index) => {
-                        if (isGrouped) {
+                        if(isGrouped) {
                             item.options.map(o => {
                                 return dropdownOption(o);
                             });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-219

## Description

Don't display the dropdown component when no array or an empty array is used as data.


## Tests

The following are included in this PR

- [x] Unit Test skeleton

## Checklist

<!--
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics.
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

- [ ] All files present (component - md - scss - spec - stories)
- [ ] All props ok and documented (propTypes or typescript types)
- [ ] Required props, default values, variants and colors
- [ ] Example in storybook
- [ ] Reversed style (light/dark mode)
- [ ] Allows custom props

## Documentation

<!--
Indicate if you have been writing documentation has part of this change.
-->

- [ ] README documentation (specification of the component, responsiveness, dependencies on other components, states, behaviours, animations, accessibility)
- [ ] Design mockups (figma - where/when/how the component should be used)
