### PR TITLE
Add babel-helpers

### DIFF
--- a/babel.build.config.js
+++ b/babel.build.config.js
@@ -10,6 +10,7 @@ module.exports = {
                 '~': './src'
             }
         }],
-        ['transform-rename-import', {original: '^(.+?)\\.scss$', replacement: '$1.css'}]
+        ['transform-rename-import', {original: '^(.+?)\\.scss$', replacement: '$1.css'}],
+        ['@babel/plugin-transform-runtime']
     ]
 };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "types": "dist/index.d.ts",
     "sideEffects": false,
     "dependencies": {
+        "@babel/runtime": "^7.12.5",
         "clsx": "^1.1.1",
         "prop-types": "^15.7.2",
         "re-resizable": "^6.9.0",
@@ -58,6 +59,7 @@
     "devDependencies": {
         "@babel/cli": "^7.12.8",
         "@babel/core": "^7.12.9",
+        "@babel/plugin-transform-runtime": "^7.12.10",
         "@babel/preset-env": "^7.12.7",
         "@babel/preset-react": "^7.12.7",
         "@babel/preset-typescript": "^7.12.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -883,6 +883,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-runtime@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.10.tgz#af0fded4e846c4b37078e8e5d06deac6cd848562"
+  integrity sha512-xOrUfzPxw7+WDm9igMgQCbO3cJKymX7dFdsgRr1eu9n3KjjyU4pptIXbXPseQDquw+W+RuJEJMHKHNsPNNm3CA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.5"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz#0bf9cac5550fce0cfdf043420f661d645fdc75e3"
@@ -12302,7 +12311,7 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==


### PR DESCRIPTION
## Description

Add usage of babel-helper-runtime to reduce file size, especially on icons which were getting huge (more than half of the size of each js file was due to babel helpers)

Result of `wc dist/**/*.js` :

Before :  
`    9961   84312  728940 total`

After :    
`    9015   47904  481670 total`
