### PR TITLE
MOON-228: Allow displaying dropdown with an empty array

### DIFF
--- a/src/components/Dropdown/Dropdown.spec.js
+++ b/src/components/Dropdown/Dropdown.spec.js
@@ -89,13 +89,18 @@ describe('Dropdown', () => {
         expect(screen.getByText('option 4')).toBeInTheDocument();
     });
 
-    it('shouldn\'t display if data isn\'t an array', () => {
-        const {queryByTestId} = render(<Dropdown data="test" data-testid="moonstone-dropdown" onChange={() => 'testing'}/>);
-        expect(queryByTestId('moonstone-dropdown')).not.toBeInTheDocument();
+    it('should display nothing if data is not an array', () => {
+        render(<Dropdown data="not an array" data-testid="moonstone-dropdown" onChange={() => 'testing'}/>);
+        expect(screen.queryByTestId('moonstone-dropdown')).not.toBeInTheDocument();
     });
 
-    it('shouldn\'t display if data is empty', () => {
-        const {queryByTestId} = render(<Dropdown data={[]} data-testid="moonstone-dropdown" onChange={() => 'testing'}/>);
-        expect(queryByTestId('moonstone-dropdown')).not.toBeInTheDocument();
+    it('should add "dropdown-disabled" class if data is empty', () => {
+        render(<Dropdown data={[]} data-testid="moonstone-dropdown" onChange={() => 'testing'}/>);
+        expect(screen.queryByTestId('moonstone-dropdown').firstChild).toHaveClass('moonstone-disabled');
+    });
+
+    it('should not add "dropdown-disabled" class if data is empty when "isDisabled=false" ', () => {
+        render(<Dropdown data={[]} isDisabled={false} data-testid="moonstone-dropdown" onChange={() => 'testing'}/>);
+        expect(screen.queryByTestId('moonstone-dropdown').firstChild).not.toHaveClass('moonstone-disabled');
     });
 });

--- a/src/components/Dropdown/Dropdown.stories.jsx
+++ b/src/components/Dropdown/Dropdown.stories.jsx
@@ -223,6 +223,27 @@ storiesOf('Components/Dropdown', module)
             </div>
         );
     })
+    .add('Empty', () => {
+        const [currentOption, setCurrentOption] = useState({label: 'Select something', value: null});
+
+        const handleOnChange = (e, item) => {
+            setCurrentOption(item);
+            action('onChange');
+            return true;
+        };
+
+        return (
+            <div style={{transform: 'scale(1)', height: '100vh', padding: '90px'}}>
+                <Dropdown
+                    icon={<Love/>}
+                    label={currentOption.label}
+                    value={currentOption.value}
+                    data={[]}
+                    onChange={(e, item) => handleOnChange(e, item)}
+                />
+            </div>
+        );
+    })
     .add('With Default Value', () => {
         const [currentOption, setCurrentOption] = useState({label: dataLanguages[1].label, value: dataLanguages[1].value});
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -132,15 +132,16 @@ export const Dropdown: React.FC<DropdownProps> = (
         ...props
     }) => {
 
-    // Return nothing if `data` isn't an array or data is empty
-    if (!Array.isArray(data) || data.length < 1) {
+    // Return nothing if `data` isn't an array
+    if (!Array.isArray(data)) {
         return null;
     }
 
     const [isOpened, setIsOpened] = useState(false);
     const [anchorEl, setAnchorEl] = useState(null);
     const [minWidth, setMinWith] = useState(null);
-    const isGrouped = typeof data[0].options !== 'undefined';
+    const isEmpty = data.length < 1;
+    const isGrouped = !isEmpty && typeof data[0].options !== 'undefined';
     const menuMinWidth = 80;
     let menuMaxWidth;
     let menuMaxHeight;
@@ -211,7 +212,7 @@ export const Dropdown: React.FC<DropdownProps> = (
         `moonstone-${size}`,
         `moonstone-dropdown_${variant}`,
         {
-            'moonstone-disabled': isDisabled,
+            'moonstone-disabled': (typeof isDisabled === 'undefined' && isEmpty) ? true : isDisabled,
             'moonstone-filled': value,
             'moonstone-opened': isOpened
         }
@@ -323,7 +324,6 @@ Dropdown.defaultProps = {
     variant: DropdownVariants.Ghost,
     size: DropdownSizes.Medium,
     maxWidth: '300px',
-    isDisabled: false,
     hasSearch: false,
     searchEmptyText: 'No results found.'
 };


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-228

## Description

- Allow displaying dropdown with an empty array
- Set dropdown as disabled if `data` is empty and `isDisabled` isn't set
- Remove default value for `isDisabled`

## Tests

The following are included in this PR

- [X] Unit Test skeleton

## Checklist

<!--
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics.
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

- [X] Example in storybook


## Documentation

<!--
Indicate if you have been writing documentation has part of this change.
-->

- [ ] README documentation (specification of the component, responsiveness, dependencies on other components, states, behaviours, animations, accessibility)
- [ ] Design mockups (figma - where/when/how the component should be used)
