### PR TITLE
MOON-223: Fix Dropdown Menu positioning in modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,29 @@ function App() {
 export default App
 ```
 
+## Test changes with Jahia using yalc
+First, build moonstone:
+```sh
+yarn build
+```
+
+Then, publish locally:
+```sh
+yalc publish
+```
+
+Next, add the local package to app-shell:
+```sh
+yalc add @jahia/moonstone
+```
+
+Install any additional dependencies that may now be required:
+```sh
+yarn
+```
+
+Now, you can deploy app-shell via docker or to the local installation as you usually do.
+
 ## Author
 
 👤 **Jahia**

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -8,6 +8,10 @@ $border-width: 1px;
     background-color: var(--color-accent);
 }
 
+.moonstone-dropdown_container {
+    position: relative;
+}
+
 .moonstone-dropdown_icon {
     display: flex;
     margin-right: var(--spacing-nano);

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -292,8 +292,8 @@ export const Dropdown: React.FC<DropdownProps> = (
             </div>
 
             <Menu
-                relativelyPositionedParent
                 isDisplayed={isOpened}
+                position="absolute"
                 anchorPosition={anchorPosition}
                 minWidth={minWidth}
                 maxWidth={menuMaxWidth}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -147,7 +147,7 @@ export const Dropdown: React.FC<DropdownProps> = (
     let menuMaxHeight;
 
     const anchorPosition = {
-        top: Number(spacings.spacingNano.slice(0, -2)),
+        top: parseInt(spacings.spacingNano, 10),
         left: 0
     };
 
@@ -256,7 +256,7 @@ export const Dropdown: React.FC<DropdownProps> = (
 
     return (
         <div
-            className={classnames(className)}
+            className={classnames('moonstone-dropdown_container', className)}
             style={{maxWidth}}
             {...props}
             onKeyPress={e => {
@@ -292,6 +292,7 @@ export const Dropdown: React.FC<DropdownProps> = (
             </div>
 
             <Menu
+                relativelyPositionedParent
                 isDisplayed={isOpened}
                 anchorPosition={anchorPosition}
                 minWidth={minWidth}

--- a/src/components/Menu/Menu.md
+++ b/src/components/Menu/Menu.md
@@ -12,9 +12,11 @@ A type of widget that offers a list of choices or actions to the user.
 
 `anchorEl` is the reference element to posioning the menu
 `anchorPosition` Position of the menu
+`position` determines whether the menu is `position: fixed` (the default) or `position: absolute`
 
 - if `anchorEl` is provided the position is relative to the bottom left corner to this element.
-- if `anchorEl` is not set the position is relative to the top left corner of the viewport
+- if `anchorEl` is not set the position is relative to the top left corner of the viewport.
+- if `position="absolute"` is provided to the menu component, the menu will be positioned relatively to the first positioned ancestor and if an `anchorEl` was passed in, it will be ignored.
 
 ## Search
 Use the `hasSearch` boolean prop to display the search input at the top of the menu.

--- a/src/components/Menu/Menu.scss
+++ b/src/components/Menu/Menu.scss
@@ -1,7 +1,7 @@
 @import '../../utils/index';
 
 .moonstone-menu {
-    position: fixed;
+    position: absolute;
 
     z-index: 9000;
 

--- a/src/components/Menu/Menu.scss
+++ b/src/components/Menu/Menu.scss
@@ -1,8 +1,6 @@
 @import '../../utils/index';
 
 .moonstone-menu {
-    position: absolute;
-
     z-index: 9000;
 
     width: fit-content;

--- a/src/components/Menu/Menu.stories.jsx
+++ b/src/components/Menu/Menu.stories.jsx
@@ -114,6 +114,36 @@ storiesOf('Components/Menu', module)
             </div>
         );
     })
+    .add('Position Absolute', () => {
+        return (
+            <div style={{transform: 'scale(1)', height: '100vh'}}>
+                <div style={{position: 'relative', transform: 'translate(90px, 90px)', width: '100px', height: '100px'}}>
+                    <div
+                        style={{height: '100%', width: '100%', backgroundColor: 'var(--color-accent)', cursor: 'pointer', padding: '10px'}}
+                    >
+                        Parent div is position: relative.
+                    </div>
+                    <Menu
+                        isDisplayed={boolean('display', true)}
+                        position={select('position', ['absolute', 'fixed'], 'absolute')}
+                        anchorPosition={{top: number('top', 4), left: number('left', 0)}}
+                        anchorElOrigin={{
+                            vertical: select('anchor-vertical', ['top', 'bottom', 'center'], 'bottom'),
+                            horizontal: select('anchor-horizontal', ['left', 'right', 'center'], 'left')
+                        }}
+                        transformElOrigin={{
+                            vertical: select('transform-vertical', ['top', 'bottom'], 'top'),
+                            horizontal: select('transform-horizontal', ['left', 'right'], 'left')
+                        }}
+                    >
+                        <MenuItem label="Item1"/>
+                        <MenuItem label="Item2"/>
+                        <MenuItem label="Item3"/>
+                    </Menu>
+                </div>
+            </div>
+        );
+    })
     .add('Big Image Menu Items', () => (
         <div style={{transform: 'scale(1)', height: '100vh'}}>
             <Menu

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -74,7 +74,7 @@ interface MenuProps {
     /**
      * Additional styles
      */
-    style?: {};
+    style?: React.CSSProperties;
 
     /**
      * Whether the Menu displays a search input at the top
@@ -142,37 +142,36 @@ const getChildrenToFilter = (children: [React.ReactElement]) => {
     return children;
 };
 
-export const Menu: React.FC<MenuProps> = (
-    {
-        children,
-        isDisplayed,
-        position,
-        minWidth,
-        maxWidth,
-        maxHeight,
-        className,
-        style,
-        onMouseEnter,
-        onMouseLeave,
-        anchorEl,
-        anchorElOrigin,
-        transformElOrigin,
-        anchorPosition,
-        onClose,
-        onEntering,
-        onEntered,
-        onExiting,
-        onExited,
-        hasOverlay,
-        hasSearch,
-        searchEmptyText,
-        ...props
-    }) => {
-        const [stylePosition, itemRef] = usePositioning(isDisplayed, anchorPosition, anchorEl, anchorElOrigin, transformElOrigin, position);
-        useEnterExitCallbacks(isDisplayed, onExiting, onExited, onEntering, onEntered);
-        const [inputValue, setInputValue] = useState('');
-        const [filteredChildren, setFilteredChildren] = useState(children);
-        const [isEmptySearch, setIsEmptySearch] = useState(false);
+export const Menu: React.FC<MenuProps> = ({
+    children,
+    isDisplayed,
+    position,
+    minWidth,
+    maxWidth,
+    maxHeight,
+    className,
+    style,
+    onMouseEnter,
+    onMouseLeave,
+    anchorEl,
+    anchorElOrigin,
+    transformElOrigin,
+    anchorPosition,
+    onClose,
+    onEntering,
+    onEntered,
+    onExiting,
+    onExited,
+    hasOverlay,
+    hasSearch,
+    searchEmptyText,
+    ...props
+}) => {
+    const [stylePosition, itemRef] = usePositioning(isDisplayed, anchorPosition, anchorEl, anchorElOrigin, transformElOrigin, position);
+    useEnterExitCallbacks(isDisplayed, onExiting, onExited, onEntering, onEntered);
+    const [inputValue, setInputValue] = useState('');
+    const [filteredChildren, setFilteredChildren] = useState(children);
+    const [isEmptySearch, setIsEmptySearch] = useState(false);
 
     // useEffect hook to filter the search results and determine whether to show the no search results text
     useEffect(() => {

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -25,6 +25,7 @@ type StyleMenu =  {
     maxWidth?: string;
     maxHeight?: string;
 };
+type PositioningType = 'fixed' | 'absolute';
 
 interface MenuProps {
     /**
@@ -93,9 +94,10 @@ interface MenuProps {
     searchEmptyText?: string;
 
     /**
-     * Use this prop when the parent element has position: relative so that the appropriate method of positioning is used
+     * If 'absolute' is passed in for the position, the component will checked for the closest relatively
+     * positioned parent to position against. Position is 'fixed' by default
      */
-    relativelyPositionedParent?: boolean;
+    position?: PositioningType;
 
     /**
      * Function triggered when the mouse pointer hovering the menu
@@ -155,6 +157,7 @@ export const Menu: React.FC<MenuProps> = (
         maxWidth,
         maxHeight,
         className,
+        position,
         style,
         onMouseEnter,
         onMouseLeave,
@@ -170,10 +173,9 @@ export const Menu: React.FC<MenuProps> = (
         hasOverlay,
         hasSearch,
         searchEmptyText,
-        relativelyPositionedParent,
         ...props
     }) => {
-    const [stylePosition, itemRef] = usePositioning(isDisplayed, anchorPosition, anchorEl, anchorElOrigin, transformElOrigin, relativelyPositionedParent);
+    const [stylePosition, itemRef] = usePositioning(isDisplayed, anchorPosition, anchorEl, anchorElOrigin, transformElOrigin, position);
     useEnterExitCallbacks(isDisplayed, onExiting, onExited, onEntering, onEntered);
     const [inputValue, setInputValue] = useState('');
     const [filteredChildren, setFilteredChildren] = useState(children);
@@ -208,7 +210,7 @@ export const Menu: React.FC<MenuProps> = (
     // ---
     // Styling
     // ---
-    const styleMenu: StyleMenu = {...stylePosition as StyleMenu, ...style};
+    const styleMenu = {position, ...stylePosition as StyleMenu, ...style};
     if (minWidth) {
         styleMenu.minWidth = minWidth;
     }
@@ -276,7 +278,7 @@ Menu.defaultProps = {
     hasOverlay: true,
     hasSearch: false,
     searchEmptyText: 'No results found.',
-    relativelyPositionedParent: false,
+    position: 'fixed',
     anchorEl: null,
     anchorPosition: {
         top: 0,

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -18,13 +18,6 @@ type TransformElOrigin = {
     horizontal: 'left' | 'right';
     vertical: 'top' | 'bottom';
 };
-type StyleMenu =  {
-    top?: string | number;
-    left?: string | number;
-    minWidth?: string;
-    maxWidth?: string;
-    maxHeight?: string;
-};
 type PositioningType = 'fixed' | 'absolute';
 
 interface MenuProps {
@@ -94,8 +87,8 @@ interface MenuProps {
     searchEmptyText?: string;
 
     /**
-     * If 'absolute' is passed in for the position, the component will checked for the closest relatively
-     * positioned parent to position against. Position is 'fixed' by default
+     * If 'absolute' is passed in for the position, the component will be positioned as per normal
+     * CSS rules (i.e., positioned against the closest positioned ancestor). Position is 'fixed' by default
      */
     position?: PositioningType;
 
@@ -153,11 +146,11 @@ export const Menu: React.FC<MenuProps> = (
     {
         children,
         isDisplayed,
+        position,
         minWidth,
         maxWidth,
         maxHeight,
         className,
-        position,
         style,
         onMouseEnter,
         onMouseLeave,
@@ -175,11 +168,11 @@ export const Menu: React.FC<MenuProps> = (
         searchEmptyText,
         ...props
     }) => {
-    const [stylePosition, itemRef] = usePositioning(isDisplayed, anchorPosition, anchorEl, anchorElOrigin, transformElOrigin, position);
-    useEnterExitCallbacks(isDisplayed, onExiting, onExited, onEntering, onEntered);
-    const [inputValue, setInputValue] = useState('');
-    const [filteredChildren, setFilteredChildren] = useState(children);
-    const [isEmptySearch, setIsEmptySearch] = useState(false);
+        const [stylePosition, itemRef] = usePositioning(isDisplayed, anchorPosition, anchorEl, anchorElOrigin, transformElOrigin, position);
+        useEnterExitCallbacks(isDisplayed, onExiting, onExited, onEntering, onEntered);
+        const [inputValue, setInputValue] = useState('');
+        const [filteredChildren, setFilteredChildren] = useState(children);
+        const [isEmptySearch, setIsEmptySearch] = useState(false);
 
     // useEffect hook to filter the search results and determine whether to show the no search results text
     useEffect(() => {
@@ -210,15 +203,18 @@ export const Menu: React.FC<MenuProps> = (
     // ---
     // Styling
     // ---
-    const styleMenu = {position, ...stylePosition as StyleMenu, ...style};
+    const styleMenu: React.CSSProperties = {
+        position,
+        ...stylePosition as React.CSSProperties,
+        ...style
+    };
+
     if (minWidth) {
         styleMenu.minWidth = minWidth;
     }
-
     if (maxWidth) {
         styleMenu.maxWidth = maxWidth;
     }
-
     if (maxHeight) {
         styleMenu.maxHeight = maxHeight;
     }

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -93,6 +93,11 @@ interface MenuProps {
     searchEmptyText?: string;
 
     /**
+     * Use this prop when the parent element has position: relative so that the appropriate method of positioning is used
+     */
+    relativelyPositionedParent?: boolean;
+
+    /**
      * Function triggered when the mouse pointer hovering the menu
      */
     onMouseEnter?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
@@ -165,14 +170,16 @@ export const Menu: React.FC<MenuProps> = (
         hasOverlay,
         hasSearch,
         searchEmptyText,
+        relativelyPositionedParent,
         ...props
     }) => {
-    const [stylePosition, itemRef] = usePositioning(isDisplayed, anchorPosition, anchorEl, anchorElOrigin, transformElOrigin);
+    const [stylePosition, itemRef] = usePositioning(isDisplayed, anchorPosition, anchorEl, anchorElOrigin, transformElOrigin, relativelyPositionedParent);
     useEnterExitCallbacks(isDisplayed, onExiting, onExited, onEntering, onEntered);
     const [inputValue, setInputValue] = useState('');
     const [filteredChildren, setFilteredChildren] = useState(children);
     const [isEmptySearch, setIsEmptySearch] = useState(false);
 
+    // useEffect hook to filter the search results and determine whether to show the no search results text
     useEffect(() => {
         if (inputValue !== '') {
             if (Array.isArray(children)) {
@@ -269,6 +276,7 @@ Menu.defaultProps = {
     hasOverlay: true,
     hasSearch: false,
     searchEmptyText: 'No results found.',
+    relativelyPositionedParent: false,
     anchorEl: null,
     anchorPosition: {
         top: 0,

--- a/src/hooks/usePositioning.tsx
+++ b/src/hooks/usePositioning.tsx
@@ -1,4 +1,4 @@
-import {ElementRef, MutableRefObject, useEffect, useRef, useState} from 'react';
+import {MutableRefObject, useEffect, useRef, useState} from 'react';
 import toPX from 'to-px';
 
 type TPosition = {
@@ -32,28 +32,32 @@ function getPositionRelativeToEl(
     resolvedAnchorEl: HTMLDivElement,
     anchorElOrigin: TAnchorElOrigin,
     transformElOrigin: TTransformElOrigin,
-    anchorPosition: TPosition
+    anchorPosition: TPosition,
+    relativelyPositionedParent: boolean = false
 ) {
     const anchorElRectangle = resolvedAnchorEl.getBoundingClientRect();
-
-    const point: {top?: number, left?: number} = {};
+    const point: TPosition = {};
 
     // Set vertical origin position
     if (anchorElOrigin.vertical === 'top') {
-        point.top = anchorElRectangle.top;
+        point.top = relativelyPositionedParent ? 0 : anchorElRectangle.top;
     } else if (anchorElOrigin.vertical === 'center') {
-        point.top = anchorElRectangle.top + (anchorElRectangle.height / 2);
+        point.top = relativelyPositionedParent
+            ? anchorElRectangle.height / 2
+            : anchorElRectangle.top + (anchorElRectangle.height / 2);
     } else if (anchorElOrigin.vertical === 'bottom') {
-        point.top = anchorElRectangle.bottom;
+        point.top = relativelyPositionedParent ? anchorElRectangle.height : anchorElRectangle.bottom;
     }
 
     // Set horizontal origin position
     if (anchorElOrigin.horizontal === 'left') {
-        point.left = anchorElRectangle.left;
+        point.left = relativelyPositionedParent ? 0 : anchorElRectangle.left;
     } else if (anchorElOrigin.horizontal === 'center') {
-        point.left = anchorElRectangle.left + (anchorElRectangle.width / 2);
+        point.left = relativelyPositionedParent
+            ? anchorElRectangle.width / 2
+            : anchorElRectangle.left + (anchorElRectangle.width / 2);
     } else if (anchorElOrigin.horizontal === 'right') {
-        point.left = anchorElRectangle.right;
+        point.left = relativelyPositionedParent ? anchorElRectangle.width : anchorElRectangle.right;
     }
 
     const stylePosition = getPosition(anchorPosition);
@@ -61,14 +65,18 @@ function getPositionRelativeToEl(
     if (!transformElOrigin || transformElOrigin.vertical === 'top') {
         stylePosition.top += point.top;
     } else if (transformElOrigin.vertical === 'bottom') {
-        stylePosition.bottom = window.document.body.clientHeight - point.top - stylePosition.top;
+        stylePosition.bottom = relativelyPositionedParent
+            ? stylePosition.top
+            : window.document.body.clientHeight - point.top - stylePosition.top;
         delete stylePosition.top;
     }
 
     if (!transformElOrigin || transformElOrigin.horizontal === 'left') {
         stylePosition.left += point.left;
     } else if (transformElOrigin.horizontal === 'right') {
-        stylePosition.right = window.document.body.clientWidth - point.left - stylePosition.left;
+        stylePosition.right = relativelyPositionedParent
+            ? anchorElRectangle.width + point.left
+            : window.document.body.clientWidth - point.left - stylePosition.left;
         delete stylePosition.left;
     }
 
@@ -80,7 +88,8 @@ export const usePositioning = (
     anchorPosition: TPosition,
     anchorEl: React.MutableRefObject<HTMLDivElement>,
     anchorElOrigin: TAnchorElOrigin,
-    transformElOrigin: TTransformElOrigin
+    transformElOrigin: TTransformElOrigin,
+    relativelyPositionedParent: boolean = false
 ): [TPosition, React.MutableRefObject<HTMLDivElement>] => {
     const [stylePosition, setStylePosition] = useState(initialPosition);
     const itemRef = useRef(null);
@@ -88,7 +97,6 @@ export const usePositioning = (
     useEffect(() => {
         if (isDisplayed) {
             const menuRectangle = itemRef.current.getBoundingClientRect();
-
             const resolvedAnchorEl = anchorEl && anchorEl.current ? anchorEl.current : anchorEl;
 
             let _stylePosition;
@@ -97,7 +105,8 @@ export const usePositioning = (
                     resolvedAnchorEl as HTMLDivElement,
                     anchorElOrigin,
                     transformElOrigin,
-                    anchorPosition
+                    anchorPosition,
+                    relativelyPositionedParent
                 );
                 if (
                     _stylePosition.left &&
@@ -108,7 +117,8 @@ export const usePositioning = (
                         resolvedAnchorEl as HTMLDivElement,
                         {...anchorElOrigin, horizontal: 'left'},
                         {...transformElOrigin, horizontal: 'right'},
-                        anchorPosition
+                        anchorPosition,
+                        relativelyPositionedParent
                     );
                 }
 
@@ -121,7 +131,8 @@ export const usePositioning = (
                         resolvedAnchorEl as HTMLDivElement,
                         {...anchorElOrigin, vertical: 'top'},
                         {...transformElOrigin, vertical: 'bottom'},
-                        anchorPosition
+                        anchorPosition,
+                        relativelyPositionedParent
                     );
                 }
             } else {
@@ -140,7 +151,17 @@ export const usePositioning = (
         } else {
             setStylePosition(initialPosition);
         }
-    }, [anchorEl, anchorPosition, anchorElOrigin.vertical, anchorElOrigin.horizontal, isDisplayed, itemRef, anchorElOrigin, transformElOrigin]);
+    }, [
+        anchorEl,
+        anchorPosition,
+        anchorElOrigin.vertical,
+        anchorElOrigin.horizontal,
+        isDisplayed,
+        itemRef,
+        anchorElOrigin,
+        transformElOrigin,
+        relativelyPositionedParent
+    ]);
 
     return [stylePosition, itemRef];
 };


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-223

## Description

* Adds the prop `position` to the Menu which can be `absolute` or `fixed` (it's `fixed by default). This fixes the issue where Dropdown Menus were incorrectly placed in modals as it allows the Menu to be, optionally, absolutely positioned against a relative ancestor and, therefore, not affected by ancestors that may have transform, filter, or perspective properties.
* When `position="absolute"` is passed into the Menu component, `anchorEl` is ignored.
   * Modifies the `usePositioning` custom hook to support the new prop
* Updates the Dropdown component to have `position: relative` and to specify `position="absolute"` to the Menu component within it
