### PR TITLE
MOON-268: Add a loading state to LayoutModule

### DIFF
--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -10,7 +10,7 @@ export const Loader: React.FC<LoaderProps> = ({
     ...props
 }: LoaderProps) => {
     return (
-        <svg className={clsx('moonstone-loader', `moonstone-loader_${size}`, className)}
+        <svg role="status" className={clsx('moonstone-loader', `moonstone-loader_${size}`, className)}
             {...props}
         >
             <circle

--- a/src/layouts/module/LayoutModule.spec.jsx
+++ b/src/layouts/module/LayoutModule.spec.jsx
@@ -1,16 +1,21 @@
 import React from 'react';
-import {shallow} from 'component-test-utils-react';
+import {render, screen} from '@testing-library/react';
 import {LayoutModule} from './index';
 
 describe('LayoutModule', () => {
-    it('should display navigation in the right slot', () => {
-        const wrapper = shallow(<LayoutModule navigation="test-navigation"/>);
-
-        expect(wrapper.html()).toContain('test-navigation');
+    it('should display navigation', () => {
+        render(<LayoutModule navigation="test-navigation"/>);
+        expect(screen.getByText('test-navigation')).toBeInTheDocument();
     });
 
     it('should display a specific HTML markup', () => {
-        const wrapper = shallow(<LayoutModule component="h1"/>);
-        expect(wrapper.html()).toContain('h1');
+        const {container} = render(<LayoutModule component="section"/>);
+        expect(container.querySelector('section')).toBeInTheDocument();
+    });
+
+    it('should display the loader and not the content when LayoutModule is loading', () => {
+        render(<LayoutModule isLoading content="my content"/>);
+        expect(screen.getByRole('status')).toBeInTheDocument();
+        expect(screen.queryByText('my content')).not.toBeInTheDocument();
     });
 });

--- a/src/layouts/module/LayoutModule.stories.jsx
+++ b/src/layouts/module/LayoutModule.stories.jsx
@@ -55,4 +55,18 @@ storiesOf('Layouts/LayoutModule', module)
                 content={<FakeContent/>}
             />
         </div>
+    ))
+    .add('Loading', () => (
+        <div style={{
+            width: '100vw',
+            height: '100vh',
+            display: 'flex'
+        }}
+        >
+            <LayoutModule
+                isLoading
+                navigation={<FakeNavigation/>}
+                content={<FakeContent/>}
+            />
+        </div>
     ));

--- a/src/layouts/module/LayoutModule.tsx
+++ b/src/layouts/module/LayoutModule.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import classnames from 'clsx';
 import {LayoutModuleProps} from './LayoutModule.types';
+import {Loader} from '~/components/Loader';
 
 export const LayoutModule: React.FC<LayoutModuleProps> = ({
     navigation = null,
     content = null,
+    isLoading = false,
     component = 'main'
 }) => {
+
+    const classNameProps = classnames(
+        'flexFluid',
+        isLoading ? ['flexCol_center', 'alignCenter'] : 'flexCol'
+    );
+
     return (
         <>
             <div className={classnames('flexCol')}>
@@ -15,8 +23,8 @@ export const LayoutModule: React.FC<LayoutModuleProps> = ({
             {
                 React.createElement(
                     component,
-                    {className: classnames('flexFluid', 'flexCol')},
-                    content
+                    {className: classnames(classNameProps), 'role-busy': isLoading},
+                    isLoading ? <Loader size="big"/> : content
                 )
             }
         </>

--- a/src/layouts/module/LayoutModule.types.ts
+++ b/src/layouts/module/LayoutModule.types.ts
@@ -5,10 +5,17 @@ export type LayoutModuleProps = {
      * Slot for the module's navigation
      */
     navigation?: React.ReactNode;
+
     /**
      * Slot for the module's content
      */
     content?: React.ReactNode;
+
+    /**
+     * Replace the content by a loader
+     */
+    isLoading?: boolean;
+
     /**
      * The HTML markup used for the content node
      */


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-268

## Description

- Add a new prop `isLoading` to LayoutModule: replace the content by a loader
- Add a story for LayoutModule with `isLoading`
- Add the attribute `role="status"` to the Loader component for accessibility purpose
- Rewrite LayoutModule tests with testing-library
