### PR TITLE
MOON-270: Rename classnames to clsx

### DIFF
--- a/src/components/Accordion/AccordionItem/AccordionItem.jsx
+++ b/src/components/Accordion/AccordionItem/AccordionItem.jsx
@@ -1,6 +1,6 @@
 import React, {useContext} from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './AccordionItem.scss';
 import {Typography} from '~/components/Typography';
 import {AccordionContext} from '~/components/Accordion/Accordion.context';
@@ -17,7 +17,7 @@ export const AccordionItem = ({id, label, icon, onClick, children, className, ..
     return (
         <section
             {...props}
-            className={classnames(
+            className={clsx(
                 'moonstone-accordionItem',
                 {'moonstone-reversed': context.isReversed},
                 'flexCol',
@@ -26,7 +26,7 @@ export const AccordionItem = ({id, label, icon, onClick, children, className, ..
             )}
         >
             <header
-                className={classnames(
+                className={clsx(
                     'moonstone-accordionItem_header',
                     {
                         'moonstone-selected': open,
@@ -41,7 +41,7 @@ export const AccordionItem = ({id, label, icon, onClick, children, className, ..
                 onClick={e => handleClick(e, open)}
             >
                 {icon &&
-                    <div className={classnames(
+                    <div className={clsx(
                         'moonstone-accordionItem_iconContainer',
                         'flexRow_center',
                         'alignCenter'
@@ -53,7 +53,7 @@ export const AccordionItem = ({id, label, icon, onClick, children, className, ..
                     isNowrap
                     variant="subheading"
                     weight={open ? 'bold' : 'default'}
-                    className={classnames('flexFluid')}
+                    className={clsx('flexFluid')}
                 >
                     {label}
                 </Typography>
@@ -61,7 +61,7 @@ export const AccordionItem = ({id, label, icon, onClick, children, className, ..
 
             {/* Accordion content */}
             {open &&
-                <div className={classnames(
+                <div className={clsx(
                         'moonstone-accordionItem_content',
                         'flexFluid'
                     )}

--- a/src/components/Accordion/ControlledAccordion.jsx
+++ b/src/components/Accordion/ControlledAccordion.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import {AccordionContext} from './Accordion.context';
 import {AccordionItem} from './AccordionItem';
 import './Accordion.scss';
@@ -15,7 +15,7 @@ export const ControlledAccordion = ({children, openedItem, isReversed, className
     return (
         <AccordionContext.Provider value={provider}>
             <div className={
-                    classnames(
+                    clsx(
                         className,
                         'flexFluid',
                         'moonstone-accordion',

--- a/src/components/Badge/Badge.stories.jsx
+++ b/src/components/Badge/Badge.stories.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {select, text, withKnobs} from '@storybook/addon-knobs';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import storyStyles from '~/__storybook__/storybook.module.scss';
 
 import markdownNotes from './Badge.md';
@@ -15,7 +15,7 @@ storiesOf('Components/Badge', module)
     })
     .addDecorator(withKnobs)
     .add('Accent', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
             <Badge
                 label={text('Label', '3')}
                 color="accent"
@@ -24,7 +24,7 @@ storiesOf('Components/Badge', module)
 
     ))
     .add('Success', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
             <Badge
                 label={text('Label', '3')}
                 color="success"
@@ -33,7 +33,7 @@ storiesOf('Components/Badge', module)
 
     ))
     .add('Danger', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
             <Badge
                 label={text('Label', '3')}
                 color="danger"
@@ -42,7 +42,7 @@ storiesOf('Components/Badge', module)
 
     ))
     .add('Playground', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
             <Badge
                 label={text('Label', '3')}
                 color={select('Color', badgeColors, 'accent')}

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,7 +1,7 @@
 import React, {FunctionComponent} from 'react';
 import './Badge.scss';
 import {Typography} from '~/components/Typography';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import {BadgeProps} from './Badge.types';
 
 export const Badge: FunctionComponent<BadgeProps> = ({
@@ -10,7 +10,7 @@ export const Badge: FunctionComponent<BadgeProps> = ({
     className,
     ...other
 }) => {
-    const classNameProps = classnames(
+    const classNameProps = clsx(
         'moonstone-badge',
         `moonstone-badge_round`,
         `moonstone-badge_${color}`,

--- a/src/components/Breadcrumb/Breadcrumb.stories.jsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withKnobs, number, text} from '@storybook/addon-knobs';
 import {action} from '@storybook/addon-actions';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import storyStyles from '~/__storybook__/storybook.module.scss';
 import markdownNotes from './Breadcrumb.md';
 
@@ -19,7 +19,7 @@ storiesOf('Components/Breadcrumb', module)
     })
     .addDecorator(withKnobs)
     .add('Default', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
             <Breadcrumb>
                 <BreadcrumbItem label={label()} onClick={action('onClick')}/>
                 <BreadcrumbItem label={label()} onClick={action('onClick')}/>
@@ -30,7 +30,7 @@ storiesOf('Components/Breadcrumb', module)
         </section>
     ))
     .add('Long labels', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
             <div style={{maxWidth: '100%'}}>
                 <Breadcrumb>
                     <BreadcrumbItem label="Very long long long long long long long long long long label 1" onClick={action('onClick')}/>
@@ -43,7 +43,7 @@ storiesOf('Components/Breadcrumb', module)
         </section>
     ))
     .add('With icons', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
             <Breadcrumb>
                 <BreadcrumbItem icon={<Love/>} label="item 1" onClick={action('onClick')}/>
                 <BreadcrumbItem icon={<Love/>} label="item 2" onClick={action('onClick')}/>
@@ -68,7 +68,7 @@ storiesOf('Components/Breadcrumb', module)
         };
 
         return (
-            <section className={classnames(storyStyles.storyWrapper)}>
+            <section className={clsx(storyStyles.storyWrapper)}>
                 <Breadcrumb>
                     {items(numberItems)}
                 </Breadcrumb>

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,11 +1,11 @@
 import React, {Fragment} from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './Breadcrumb.scss';
 import {BreadcrumbProps} from './Breadcrumb.types';
 import {ChevronRight} from '~/icons';
 
 export const Breadcrumb: React.FC<BreadcrumbProps> = ({children, className, ...props}: BreadcrumbProps) => {
-    const classNames = classnames(className);
+    const classNames = clsx(className);
 
     const allItems = React.Children.toArray(children);
 
@@ -15,7 +15,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({children, className, ...p
 
     return (
         <nav className={classNames} aria-label="breadcrumb" {...props}>
-            <ol className={classnames('flexRow_nowrap', 'alignCenter')}>
+            <ol className={clsx('flexRow_nowrap', 'alignCenter')}>
                 {
                     allItems.map((item: React.ReactElement, index) => (
                         <Fragment key={item.key}>
@@ -24,7 +24,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({children, className, ...p
                             {index < allItems.length - 1 && (
                                 <li
                                     className={
-                                        classnames(
+                                        clsx(
                                             'moonstone-breadcrumb_separator',
                                             'flexRow_center',
                                             'alignCenter'

--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './BreadcrumbItem.scss';
 import {Button} from '~/components/Button';
 import {BreadcrumbItemProps} from './BreadcrumbItem.types';
 
 export const BreadcrumbItem: React.FC<BreadcrumbItemProps> = ({className = '', ...props}: BreadcrumbItemProps) => (
-    <li className={classnames('moonstone-breadcrumbItem', 'flexRow_center')}>
+    <li className={clsx('moonstone-breadcrumbItem', 'flexRow_center')}>
         <Button {...props}
                 variant="ghost"
                 size="small"
-                className={classnames(className)}
+                className={clsx(className)}
         />
     </li>
 );

--- a/src/components/Button/Button.stories.jsx
+++ b/src/components/Button/Button.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import {storiesOf} from '@storybook/react';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 import storyStyles from '~/__storybook__/storybook.module.scss';
@@ -27,25 +27,25 @@ storiesOf('Components/Button', module)
     .addDecorator(withKnobs)
     .add('Button with icon and label', () => (
         <div style={isReversed() ? {backgroundColor: 'var(--color-gray_dark)'} : null}>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3>Variant</h3>
                 </div>
                 {
                     buttonColors.map(color => (
-                        <div key={color} className={classnames(storyStyles.storyGridItem)}>
+                        <div key={color} className={clsx(storyStyles.storyGridItem)}>
                             <h3>{color}</h3>
                         </div>
                     ))
                 }
             </section>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3>default</h3>
                 </div>
                 {
                     buttonColors.map(color => (
-                        <div key={color} className={classnames(storyStyles.storyGridItem)}>
+                        <div key={color} className={clsx(storyStyles.storyGridItem)}>
                             <Button icon={<IconWrapper iconName={selectIcon()}/>}
                                     label="Button"
                                     color={color}
@@ -57,13 +57,13 @@ storiesOf('Components/Button', module)
                     ))
                 }
             </section>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3>outlined</h3>
                 </div>
                 {
                     buttonColors.map(color => (
-                        <div key={color} className={classnames(storyStyles.storyGridItem)}>
+                        <div key={color} className={clsx(storyStyles.storyGridItem)}>
                             <Button icon={<IconWrapper iconName={selectIcon()}/>}
                                     label="Button"
                                     color={color}
@@ -75,13 +75,13 @@ storiesOf('Components/Button', module)
                     ))
                 }
             </section>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3>ghost</h3>
                 </div>
                 {
                     buttonColors.map(color => (
-                        <div key={color} className={classnames(storyStyles.storyGridItem)}>
+                        <div key={color} className={clsx(storyStyles.storyGridItem)}>
                             <Button icon={<IconWrapper iconName={selectIcon()}/>}
                                     label="Button"
                                     color={color}
@@ -97,25 +97,25 @@ storiesOf('Components/Button', module)
     ))
     .add('Button with label only', () => (
         <div style={isReversed() ? {backgroundColor: 'var(--color-gray_dark)'} : null}>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3>Variant</h3>
                 </div>
                 {
                     buttonColors.map(color => (
-                        <div key={color} className={classnames(storyStyles.storyGridItem)}>
+                        <div key={color} className={clsx(storyStyles.storyGridItem)}>
                             <h3>{color}</h3>
                         </div>
                     ))
                 }
             </section>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3>default</h3>
                 </div>
                 {
                     buttonColors.map(color => (
-                        <div key={color} className={classnames(storyStyles.storyGridItem)}>
+                        <div key={color} className={clsx(storyStyles.storyGridItem)}>
                             <Button label={labelValue()}
                                     color={color}
                                     size={sizeValues()}
@@ -126,13 +126,13 @@ storiesOf('Components/Button', module)
                     ))
                 }
             </section>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3>outlined</h3>
                 </div>
                 {
                     buttonColors.map(color => (
-                        <div key={color} className={classnames(storyStyles.storyGridItem)}>
+                        <div key={color} className={clsx(storyStyles.storyGridItem)}>
                             <Button label={labelValue()}
                                     color={color}
                                     size={sizeValues()}
@@ -143,13 +143,13 @@ storiesOf('Components/Button', module)
                     ))
                 }
             </section>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3>ghost</h3>
                 </div>
                 {
                     buttonColors.map(color => (
-                        <div key={color} className={classnames(storyStyles.storyGridItem)}>
+                        <div key={color} className={clsx(storyStyles.storyGridItem)}>
                             <Button label={labelValue()}
                                     color={color}
                                     size={sizeValues()}
@@ -164,25 +164,25 @@ storiesOf('Components/Button', module)
     ))
     .add('Button with icon only', () => (
         <div style={isReversed() ? {backgroundColor: 'var(--color-gray_dark)'} : null}>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3>Variant</h3>
                 </div>
                 {
                     buttonColors.map(color => (
-                        <div key={color} className={classnames(storyStyles.storyGridItem)}>
+                        <div key={color} className={clsx(storyStyles.storyGridItem)}>
                             <h3>{color}</h3>
                         </div>
                     ))
                 }
             </section>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3>default</h3>
                 </div>
                 {
                     buttonColors.map(color => (
-                        <div key={color} className={classnames(storyStyles.storyGridItem)}>
+                        <div key={color} className={clsx(storyStyles.storyGridItem)}>
                             <Button icon={<IconWrapper iconName={selectIcon()}/>}
                                     color={color}
                                     size={sizeValues()}
@@ -193,13 +193,13 @@ storiesOf('Components/Button', module)
                     ))
                 }
             </section>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3>outlined</h3>
                 </div>
                 {
                     buttonColors.map(color => (
-                        <div key={color} className={classnames(storyStyles.storyGridItem)}>
+                        <div key={color} className={clsx(storyStyles.storyGridItem)}>
                             <Button icon={<IconWrapper iconName={selectIcon()}/>}
                                     color={color}
                                     size={sizeValues()}
@@ -210,13 +210,13 @@ storiesOf('Components/Button', module)
                     ))
                 }
             </section>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3>ghost</h3>
                 </div>
                 {
                     buttonColors.map(color => (
-                        <div key={color} className={classnames(storyStyles.storyGridItem)}>
+                        <div key={color} className={clsx(storyStyles.storyGridItem)}>
                             <Button icon={<IconWrapper iconName={selectIcon()}/>}
                                     color={color}
                                     size={sizeValues()}
@@ -231,19 +231,19 @@ storiesOf('Components/Button', module)
     ))
     .add('Playground', () => (
         <div style={isReversed() ? {backgroundColor: 'var(--color-gray_dark)'} : null}>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3 style={isReversed() ? {color: 'var(--color-white)'} : null}>Button with icon and label</h3>
                 </div>
-                <div className={classnames(storyStyles.storyGridItem)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3 style={isReversed() ? {color: 'var(--color-white)'} : null}>Button with label only</h3>
                 </div>
-                <div className={classnames(storyStyles.storyGridItem)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3 style={isReversed() ? {color: 'var(--color-white)'} : null}>Button with icon only</h3>
                 </div>
             </section>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <Button icon={<IconWrapper iconName={selectIcon()}/>}
                             label={labelValue()}
                             color={colorValues()}
@@ -253,7 +253,7 @@ storiesOf('Components/Button', module)
                             isDisabled={isDisabled()}
                             onClick={() => {}}/>
                 </div>
-                <div className={classnames(storyStyles.storyGridItem)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <Button label={labelValue()}
                             color={colorValues()}
                             size={sizeValues()}
@@ -262,7 +262,7 @@ storiesOf('Components/Button', module)
                             isDisabled={isDisabled()}
                             onClick={() => {}}/>
                 </div>
-                <div className={classnames(storyStyles.storyGridItem)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <Button icon={<IconWrapper iconName={selectIcon()}/>}
                             color={colorValues()}
                             size={sizeValues()}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,5 @@
 import React, {useRef} from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './Button.scss';
 import {Typography, TypographyWeight} from '../Typography';
 import {ButtonProps} from './Button.types';
@@ -36,7 +36,7 @@ export const Button: React.FC<ButtonProps> = ({
     return (
         <button
             ref={ButtonEl}
-            className={classnames(
+            className={clsx(
                 'moonstone-button',
                 `moonstone-size_${size}`,
                 `moonstone-variant_${variant}`,
@@ -59,7 +59,7 @@ export const Button: React.FC<ButtonProps> = ({
                     variant="button"
                     isUpperCase={size === 'big'}
                     weight={typoWeight}
-                    className={classnames('flexFluid')}
+                    className={clsx('flexFluid')}
                     isHtml={isHtml}
                 >
                     {label}

--- a/src/components/ButtonGroup/ButtonGroup.stories.jsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import {storiesOf} from '@storybook/react';
 import {boolean, select, withKnobs} from '@storybook/addon-knobs';
 import storyStyles from '~/__storybook__/storybook.module.scss';
@@ -23,7 +23,7 @@ storiesOf('Components/ButtonGroup', module)
     })
     .addDecorator(withKnobs)
     .add('Default', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
             <ButtonGroup
                 variant={variantValues()}
                 color={colorValues()}
@@ -37,7 +37,7 @@ storiesOf('Components/ButtonGroup', module)
         </section>
     ))
     .add('Button with actions', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
             <ButtonGroup
                 color="accent"
                 size="big"
@@ -48,7 +48,7 @@ storiesOf('Components/ButtonGroup', module)
         </section>
     ))
     .add('ButtonGroup with 1 button', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
             <ButtonGroup
                 color="accent"
                 size="big"

--- a/src/components/ButtonGroup/ButtonGroup.stories.jsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'classnames';
+import classnames from 'clsx';
 import {storiesOf} from '@storybook/react';
 import {boolean, select, withKnobs} from '@storybook/addon-knobs';
 import storyStyles from '~/__storybook__/storybook.module.scss';

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import './ButtonGroup.scss';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import {ButtonGroupProps} from './ButtonGroup.types';
 
 export const ButtonGroup: React.FC<ButtonGroupProps> = ({
@@ -20,7 +20,7 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = ({
     return (
         <div
             role="group"
-            className={classnames(
+            className={clsx(
                 'moonstone-buttonGroup',
                 className,
                 'flexRow',
@@ -41,7 +41,7 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = ({
                             variant={variant}
                             isReversed={isReversed}
                             color={color}
-                            className={classnames(
+                            className={clsx(
                                 `moonstone-variant_${variant}`,
                                 `moonstone-color_${color}`
                             )}

--- a/src/components/Chip/Chip.stories.jsx
+++ b/src/components/Chip/Chip.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import {storiesOf} from '@storybook/react';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 
@@ -26,20 +26,20 @@ storiesOf('Components/Chip', module)
     })
     .addDecorator(withKnobs)
     .addDecorator(storyFn => (
-        <section className={classnames(storyStyles.storyWrapper)}>
-            <section className={classnames(storyStyles.storyColumn)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
+            <section className={clsx(storyStyles.storyColumn)}>
                 {storyFn()}
             </section>
         </section>
     ))
     .add('icon + text', () => (
         <section style={{display: 'flex', flexDirection: 'flow'}}>
-            <section className={classnames(storyStyles.storyColumn)}>
+            <section className={clsx(storyStyles.storyColumn)}>
                 {colors.map(color => (
                     <Chip key={color} label={capitalize(color)} icon={<DefaultIcon/>} color={color}/>
                 ))}
             </section>
-            <section className={classnames(storyStyles.storyColumn)}>
+            <section className={clsx(storyStyles.storyColumn)}>
                 {colors.map(color => (
                     <Chip key={color} isDisabled label={capitalize(color)} icon={<DefaultIcon/>} color={color}/>
                 ))}

--- a/src/components/Chip/Chip.stories.jsx
+++ b/src/components/Chip/Chip.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'classnames';
+import classnames from 'clsx';
 import {storiesOf} from '@storybook/react';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './Chip.scss';
 import {ChipProps} from './Chip.types';
 import {Typography} from '~/components/Typography';
@@ -13,7 +13,7 @@ export const Chip: React.FC<ChipProps> = ({
     ...props
 }: ChipProps) => (
     <div
-        className={classnames(
+        className={clsx(
             'moonstone-chip',
             `moonstone-color_${color}`,
             {'moonstone-disabled': isDisabled},

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './Dropdown.scss';
 import spacings from '~/tokens/spacings/spacing.json';
 
@@ -205,7 +205,7 @@ export const Dropdown: React.FC<DropdownProps> = (
     // CSS classes
     // ---
 
-    const cssDropdown = classnames(
+    const cssDropdown = clsx(
         'flexRow',
         'alignCenter',
         'moonstone-dropdown',
@@ -256,7 +256,7 @@ export const Dropdown: React.FC<DropdownProps> = (
 
     return (
         <div
-            className={classnames('moonstone-dropdown_container', className)}
+            className={clsx('moonstone-dropdown_container', className)}
             style={{maxWidth}}
             {...props}
             onKeyPress={e => {
@@ -266,7 +266,7 @@ export const Dropdown: React.FC<DropdownProps> = (
             }}
         >
             <div
-                className={classnames(cssDropdown)}
+                className={clsx(cssDropdown)}
                 tabIndex={0}
                 onClick={handleOpenMenu}
                 onKeyPress={(e: React.KeyboardEvent) => {
@@ -277,14 +277,14 @@ export const Dropdown: React.FC<DropdownProps> = (
             >
                 {
                     icon &&
-                    <icon.type {...icon.props} size="small" className={classnames('moonstone-dropdown_icon')}/>
+                    <icon.type {...icon.props} size="small" className={clsx('moonstone-dropdown_icon')}/>
                 }
 
                 <Typography
                     isNowrap
                     variant="caption"
                     component="span"
-                    className={classnames('flexFluid')}
+                    className={clsx('flexFluid')}
                 >
                     {label}
                 </Typography>

--- a/src/components/GlobalStyle/GlobalStyle.stories.jsx
+++ b/src/components/GlobalStyle/GlobalStyle.stories.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {withKnobs, select} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import markdownNotes from './GlobalStyle_layout.md';
-import classnames from 'classnames';
+import classnames from 'clsx';
 
 const justifyOptions = [null, 'center', 'reverse', 'between', 'nowrap'];
 const alignOptions = ['start', 'center', 'end'];

--- a/src/components/GlobalStyle/GlobalStyle.stories.jsx
+++ b/src/components/GlobalStyle/GlobalStyle.stories.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {withKnobs, select} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import markdownNotes from './GlobalStyle_layout.md';
-import classnames from 'clsx';
+import clsx from 'clsx';
 
 const justifyOptions = [null, 'center', 'reverse', 'between', 'nowrap'];
 const alignOptions = ['start', 'center', 'end'];
@@ -19,7 +19,7 @@ const ItemContainer = ({title, direction, justify, align}) => {
     const cssDirection = direction === 'row' ? 'flexRow' : 'flexCol';
     const cssJustify = justify ? `${cssDirection}_${justify}` : cssDirection;
     const cssAlign = align ? `align${align.charAt(0).toUpperCase() + align.slice(1)}` : null;
-    let css = classnames(cssJustify, cssAlign);
+    let css = clsx(cssJustify, cssAlign);
 
     return (
         <section style={{marginBottom: '48px'}}>
@@ -28,7 +28,7 @@ const ItemContainer = ({title, direction, justify, align}) => {
                     {css}
                 </code>
             </h2>
-            <div className={classnames(cssJustify, cssAlign)} style={cssWrap}>
+            <div className={clsx(cssJustify, cssAlign)} style={cssWrap}>
                 <Item/>
                 <Item/>
                 <Item/>
@@ -79,7 +79,7 @@ function displayItems(direction, type) {
     for (let option of arrayOptions) {
         display.push(
             <ItemContainer
-                title={`${type} ${classnames(option)}`}
+                title={`${type} ${clsx(option)}`}
                 direction={direction}
                 justify={type === 'justify' ? option : 'center'}
                 align={type === 'align' ? option : 'center'}

--- a/src/components/Input/Input.stories.jsx
+++ b/src/components/Input/Input.stories.jsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import {storiesOf} from '@storybook/react';
 import {boolean, select, withKnobs} from '@storybook/addon-knobs';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import storyStyles from '~/__storybook__/storybook.module.scss';
 import PropTypes from 'prop-types';
 
@@ -33,7 +33,7 @@ storiesOf('Components/Input', module)
         };
 
         return (
-            <section className={classnames(storyStyles.storyWrapper)}>
+            <section className={clsx(storyStyles.storyWrapper)}>
                 <Parent>
                     {(state, setState) => (
                         <Input
@@ -58,7 +58,7 @@ storiesOf('Components/Input', module)
             children: PropTypes.node
         };
         return (
-            <section className={classnames(storyStyles.storyWrapper)}>
+            <section className={clsx(storyStyles.storyWrapper)}>
                 <Parent>
                     {(state, setState) => (
                         <Input
@@ -84,7 +84,7 @@ storiesOf('Components/Input', module)
         };
 
         return (
-            <section className={classnames(storyStyles.storyWrapper)}>
+            <section className={clsx(storyStyles.storyWrapper)}>
                 <Parent>
                     {(state, setState) => (
                         <Input
@@ -110,7 +110,7 @@ storiesOf('Components/Input', module)
         };
 
         return (
-            <section className={classnames(storyStyles.storyWrapper)}>
+            <section className={clsx(storyStyles.storyWrapper)}>
                 <Parent>
                     {(state, setState) => (
                         <Input

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 
 import {Cancel, Search} from '~/icons';
 import './Input.scss';
@@ -89,7 +89,7 @@ export const Input: React.FC<InputProps> =
         onFocus,
         ...props
     }) => {
-    const classNameProps = classnames(
+    const classNameProps = clsx(
         'moonstone-input',
         {'moonstone-size_big': size === InputSize.Big},
         {'moonstone-disabled': isDisabled},
@@ -102,7 +102,7 @@ export const Input: React.FC<InputProps> =
         <div className={classNameProps}>
             <input
                 className={
-                    classnames(
+                    clsx(
                         'moonstone-input-element',
                         {'start-icon-padding': icon || variant === InputVariant.Search},
                         {'end-icon-padding': onClear}
@@ -121,7 +121,7 @@ export const Input: React.FC<InputProps> =
             />
             {(icon || variant === InputVariant.Search) && (
                 <div
-                    className={classnames(
+                    className={clsx(
                         'start-icon-wrap',
                         'flexRow_nowrap',
                         'alignCenter',

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './ListItem.scss';
 import {Typography} from '~/components/Typography';
 
@@ -61,7 +61,7 @@ export const ListItem: React.FC<ListItemProps> = ({
     className = '',
     ...props
 }) => {
-    const cssListItem = classnames(
+    const cssListItem = clsx(
         className,
         'moonstone-listItem',
         'flexRow',
@@ -70,7 +70,7 @@ export const ListItem: React.FC<ListItemProps> = ({
 
     return (
         <li
-            className={classnames(cssListItem)}
+            className={clsx(cssListItem)}
             tabIndex={tabIndex}
             {...props}
         >
@@ -87,7 +87,7 @@ export const ListItem: React.FC<ListItemProps> = ({
             <Typography
                 isNowrap
                 isHtml={isHtml}
-                className={classnames('flexFluid')}
+                className={clsx('flexFluid')}
                 variant="caption"
                 component="span"
             >

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useEffect} from 'react';
 import {usePositioning} from '~/hooks/usePositioning';
 import {useEnterExitCallbacks} from '~/hooks/useEnterExitCallbacks';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './Menu.scss';
 import {Input} from '~/components/Input';
 import {Typography} from '~/components/Typography';
@@ -230,7 +230,7 @@ export const Menu: React.FC<MenuProps> = ({
             <menu
                 ref={itemRef}
                 style={styleMenu}
-                className={classnames(
+                className={clsx(
                     'moonstone-menu',
                     className,
                     {'moonstone-hidden': !isDisplayed || !stylePosition}

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {ListItem} from '~/components/ListItem';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './MenuItem.scss';
 
 type TMenuItemVariant = 'default' | 'title';
@@ -117,7 +117,7 @@ export const MenuItem: React.FC<MenuItemProps> = ({
     <ListItem
         tabIndex={isDisabled || variant === MenuItemVariant.Title || isSelected ? null : 0}
         aria-disabled={isDisabled}
-        className={classnames(
+        className={clsx(
             'moonstone-menuItem',
             {
                 'moonstone-hover': isHover,

--- a/src/components/PrimaryNav/PrimaryNav.jsx
+++ b/src/components/PrimaryNav/PrimaryNav.jsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './PrimaryNav.scss';
 import {PrimaryNavContext} from './PrimaryNav.context';
 import {MenuIcon, ArrowLeft} from '~/icons';
@@ -9,7 +9,7 @@ const NavButton = ({isExpanded, toggleExpand, modeIcon}) => {
     if (isExpanded) {
         return (
             <button
-                className={classnames('moonstone-primaryNav_button')}
+                className={clsx('moonstone-primaryNav_button')}
                 type="button"
                 role="primary-nav-control"
                 onClick={toggleExpand}
@@ -23,7 +23,7 @@ const NavButton = ({isExpanded, toggleExpand, modeIcon}) => {
 
     if (modeIcon) {
         icon = React.cloneElement(modeIcon, {
-            className: classnames('moonstone-primaryNav_modeIcon')
+            className: clsx('moonstone-primaryNav_modeIcon')
         });
     }
 
@@ -31,7 +31,7 @@ const NavButton = ({isExpanded, toggleExpand, modeIcon}) => {
         <>
             {icon}
             <button
-                className={classnames('moonstone-primaryNav_button')}
+                className={clsx('moonstone-primaryNav_button')}
                 type="button"
                 role="primary-nav-control"
                 onClick={toggleExpand}
@@ -53,14 +53,14 @@ const NavHeader = ({headerCaption, modeIcon, headerLogo}) => {
 
     if (modeIcon) {
         icon = React.cloneElement(modeIcon, {
-            className: classnames('moonstone-primaryNav_modeIconHeader')
+            className: clsx('moonstone-primaryNav_modeIconHeader')
         });
     }
 
     return (
         <>
             {headerLogo}
-            <div className={classnames('flexRow_nowrap', 'alignCenter', 'moonstone-primaryNav_headerCaption')}>
+            <div className={clsx('flexRow_nowrap', 'alignCenter', 'moonstone-primaryNav_headerCaption')}>
                 {icon}{headerCaption}
             </div>
         </>
@@ -84,18 +84,18 @@ export const PrimaryNav = ({headerLogo, top, bottom, headerCaption, modeIcon, ..
         <PrimaryNavContext.Provider value={{isExpanded: isExpanded, collapse: () => setExpanded(false)}}>
             <nav {...props}
                  aria-expanded={isExpanded}
-                 className={classnames(
+                 className={clsx(
                      'moonstone-primaryNav',
                      {'moonstone-expanded': isExpanded},
                     'flexCol_nowrap'
                 )}
             >
-                <div className={classnames('flexRow_nowrap', 'moonstone-primaryNav_header')}>
-                    <div className={classnames('moonstone-primaryNav_buttonContainer', 'flexRow_center', 'alignCenter')}>
+                <div className={clsx('flexRow_nowrap', 'moonstone-primaryNav_header')}>
+                    <div className={clsx('moonstone-primaryNav_buttonContainer', 'flexRow_center', 'alignCenter')}>
                         <NavButton isExpanded={isExpanded} toggleExpand={toggleExpand} modeIcon={modeIcon}/>
                     </div>
                     <div
-                        className={classnames(
+                        className={clsx(
                             'flexCol_center',
                             'alignCenter',
                             'flexFluid',
@@ -106,7 +106,7 @@ export const PrimaryNav = ({headerLogo, top, bottom, headerCaption, modeIcon, ..
                     </div>
                 </div>
 
-                <ul className={classnames('flexCol', 'flexFluid')}>
+                <ul className={clsx('flexCol', 'flexFluid')}>
                     {top}
                 </ul>
 

--- a/src/components/PrimaryNav/PrimaryNavItem/PrimaryNavItem.jsx
+++ b/src/components/PrimaryNav/PrimaryNavItem/PrimaryNavItem.jsx
@@ -1,23 +1,23 @@
 import React, {useContext} from 'react';
 import PropTypes from 'prop-types';
 import './PrimaryNavItem.scss';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import {Typography, variants as typographyVariants} from '~/components/Typography';
 import {PrimaryNavContext} from '../PrimaryNav.context';
 
 // Internal component
 const Item = ({icon, label, textVariant, subtitle, button}) => (
     <>
-        <div className={classnames('moonstone-primaryNavItem_content')}>
-            <div className={classnames('moonstone-primaryNavItem_iconContainer')}>
+        <div className={clsx('moonstone-primaryNavItem_content')}>
+            <div className={clsx('moonstone-primaryNavItem_iconContainer')}>
                 {icon && <icon.type {...icon.props} size="big"/>}
             </div>
 
-            <div className={classnames('moonstone-primaryNavItem_textContainer')}>
+            <div className={clsx('moonstone-primaryNavItem_textContainer')}>
                 <Typography isNowrap
                             variant={textVariant}
                             component="span"
-                            className={classnames('moonstone-primaryNavItem_label')}
+                            className={clsx('moonstone-primaryNavItem_label')}
                 >
                     {label}
                 </Typography>
@@ -25,14 +25,14 @@ const Item = ({icon, label, textVariant, subtitle, button}) => (
                 <Typography isNowrap
                             component="div"
                             variant="caption"
-                            className={classnames('moonstone-primaryNavItem_label', 'moonstone-subtitle')}
+                            className={clsx('moonstone-primaryNavItem_label', 'moonstone-subtitle')}
                 >
                     {subtitle}
                 </Typography>}
             </div>
         </div>
         {button &&
-        <div className={classnames('moonstone-primaryNavItem_buttonContainer')}>
+        <div className={clsx('moonstone-primaryNavItem_buttonContainer')}>
             {button}
         </div>}
     </>
@@ -50,7 +50,7 @@ Item.propTypes = {
 const ItemTypeResolver = ({url, icon, label, subtitle, button}) => {
     if (url) {
         return (
-            <a className={classnames('moonstone-primaryNavItem', 'moonstone-primaryNavItem_linkItem')}
+            <a className={clsx('moonstone-primaryNavItem', 'moonstone-primaryNavItem_linkItem')}
                href={url}
                target="_blank"
                rel="noopener noreferrer"
@@ -78,7 +78,7 @@ export const PrimaryNavItem = ({label, icon, className, subtitle, url, button, i
 
     return (
         <li
-            className={classnames(
+            className={clsx(
                 'moonstone-primaryNavItem',
                 {'moonstone-selected': isSelected},
                 className
@@ -93,7 +93,7 @@ export const PrimaryNavItem = ({label, icon, className, subtitle, url, button, i
             <ItemTypeResolver icon={icon} label={label} subtitle={subtitle} url={url} button={button}/>
 
             {badge &&
-            <badge.type className={classnames('moonstone-primaryNavItem_badge')}
+            <badge.type className={clsx('moonstone-primaryNavItem_badge')}
                         color="danger"
                         type="round"
                         label={badge.props.label}/>}

--- a/src/components/PrimaryNav/PrimaryNavItemsGroup/PrimaryNavItemsGroup.jsx
+++ b/src/components/PrimaryNav/PrimaryNavItemsGroup/PrimaryNavItemsGroup.jsx
@@ -1,6 +1,6 @@
 import React, {useContext} from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './PrimaryNavItemsGroup.scss';
 import {PrimaryNavContext} from '../PrimaryNav.context';
 import {Separator} from '~/components/Separator';
@@ -14,10 +14,10 @@ export const PrimaryNavItemsGroup = ({isDisplayedWhenCollapsed, children, ...pro
 
     return (
         <>
-            <li className={classnames('moonstone-primaryNavItemsGroup')}>
+            <li className={clsx('moonstone-primaryNavItemsGroup')}>
                 <Separator size="large" spacing="small"/>
             </li>
-            <li className={classnames('moonstone-primaryNavItemsGroup')} {...props}>
+            <li className={clsx('moonstone-primaryNavItemsGroup')} {...props}>
                 <ul>
                     {children}
                 </ul>

--- a/src/components/ResizableBox/ResizableBox.tsx
+++ b/src/components/ResizableBox/ResizableBox.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Resizable} from 're-resizable';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './ResizableBox.scss';
 import HandleResize from '~/icons/HandleResize';
 import {zones, EnableZones, ResizableBoxProps} from './ResizableBox.types';
@@ -34,17 +34,17 @@ export const ResizableBox: React.FC<ResizableBoxProps> = ({
             defaultSize={defaultSize}
             handleClasses={
                 {
-                    right: classnames('moonstone-resizable_handle'),
-                    left: classnames('moonstone-resizable_handle')
+                    right: clsx('moonstone-resizable_handle'),
+                    left: clsx('moonstone-resizable_handle')
                 }
             }
             handleComponent={
                 {
-                    right: <HandleResize className={classnames('moonstone-resizable_handle_icon')} size="big"/>,
-                    left: <HandleResize className={classnames('moonstone-resizable_handle_icon')} size="big"/>
+                    right: <HandleResize className={clsx('moonstone-resizable_handle_icon')} size="big"/>,
+                    left: <HandleResize className={clsx('moonstone-resizable_handle_icon')} size="big"/>
                 }
             }
-            className={classnames(className)}
+            className={clsx(className)}
             onResize={onResizing}
             onResizeStart={onResizeStart}
             onResizeStop={onResizeStop}

--- a/src/components/SecondaryNav/SecondaryNav.jsx
+++ b/src/components/SecondaryNav/SecondaryNav.jsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './SecondaryNav.scss';
 import {ResizableBox} from '~/components/ResizableBox';
 import ChevronDoubleRight from '~/icons/ChevronDoubleRight';
@@ -17,7 +17,7 @@ export const SecondaryNav = ({header, children, isDefaultVisible, onToggled, cla
     return (
         <ResizableBox
             className={
-                classnames(
+                clsx(
                     className,
                     'flexFluid',
                     'flexCol_nowrap',
@@ -36,7 +36,7 @@ export const SecondaryNav = ({header, children, isDefaultVisible, onToggled, cla
             {...props}
         >
             <button type="button"
-                    className={classnames('moonstone-secondaryNav_buttonToggle')}
+                    className={clsx('moonstone-secondaryNav_buttonToggle')}
                     onClick={handleToggle}
             >
                 {isVisible &&
@@ -45,9 +45,9 @@ export const SecondaryNav = ({header, children, isDefaultVisible, onToggled, cla
                     <ChevronDoubleRight/>}
             </button>
 
-            <div className={classnames('moonstone-secondaryNav_wrapper', 'flexFluid', 'flexCol_nowrap')}>
+            <div className={clsx('moonstone-secondaryNav_wrapper', 'flexFluid', 'flexCol_nowrap')}>
                 {header}
-                <div className={classnames('flexFluid', 'flexCol_nowrap')}>
+                <div className={clsx('flexFluid', 'flexCol_nowrap')}>
                     {children}
                 </div>
             </div>

--- a/src/components/SecondaryNav/SecondaryNavHeader/SecondaryNavHeader.jsx
+++ b/src/components/SecondaryNav/SecondaryNavHeader/SecondaryNavHeader.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './SecondaryNavHeader.scss';
 import {Typography} from '../../Typography';
 
 const SecondaryNavHeader = ({children}) => (
     <Typography component="header"
-                className={classnames('moonstone-secondaryNavHeader', 'flexCol_center', 'alignCenter')}
+                className={clsx('moonstone-secondaryNavHeader', 'flexCol_center', 'alignCenter')}
                 variant="heading"
     >
         {children}

--- a/src/components/Separator/Separator.stories.jsx
+++ b/src/components/Separator/Separator.stories.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withKnobs, select} from '@storybook/addon-knobs';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import storyStyles from '~/__storybook__/storybook.module.scss';
 
 import {Separator, SeparatorSizes, SeparatorSpacings, SeparatorInvisible, Typography} from '~/components';
@@ -39,8 +39,8 @@ storiesOf('Components/Separator', module)
         </div>
     ))
     .add('Invisible', () => (
-        <section className={classnames(storyStyles.storyColumn)}>
-            <div className={classnames(storyStyles.storyItem)}>
+        <section className={clsx(storyStyles.storyColumn)}>
+            <div className={clsx(storyStyles.storyItem)}>
                 <Typography variant="heading">Before</Typography>
                 <Separator
                     variant="vertical"
@@ -51,7 +51,7 @@ storiesOf('Components/Separator', module)
                 <Typography variant="heading">After</Typography>
             </div>
             <Separator variant="horizontal"/>
-            <div className={classnames(storyStyles.storyItem)}>
+            <div className={clsx(storyStyles.storyItem)}>
                 <Typography variant="heading">Before</Typography>
                 <Separator
                     variant="vertical"
@@ -61,7 +61,7 @@ storiesOf('Components/Separator', module)
                 />
             </div>
             <Separator variant="horizontal"/>
-            <div className={classnames(storyStyles.storyItem)}>
+            <div className={clsx(storyStyles.storyItem)}>
                 <Separator
                     variant="vertical"
                     size="full"
@@ -71,7 +71,7 @@ storiesOf('Components/Separator', module)
                 <Typography variant="heading">After</Typography>
             </div>
             <Separator variant="horizontal"/>
-            <div className={classnames(storyStyles.storyItem)}>
+            <div className={clsx(storyStyles.storyItem)}>
                 <Separator
                     variant="vertical"
                     size="full"

--- a/src/components/Separator/Separator.stories.jsx
+++ b/src/components/Separator/Separator.stories.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withKnobs, select} from '@storybook/addon-knobs';
-import classnames from 'classnames';
+import classnames from 'clsx';
 import storyStyles from '~/__storybook__/storybook.module.scss';
 
 import {Separator, SeparatorSizes, SeparatorSpacings, SeparatorInvisible, Typography} from '~/components';

--- a/src/components/Separator/Separator.tsx
+++ b/src/components/Separator/Separator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './Separator.scss';
 
 type TSeparatorSpacings = 'none' | 'small' | 'medium' | 'big';
@@ -69,7 +69,7 @@ export const Separator: React.FC<SeparatorProps> = ({
 }) => {
     return (
         <hr {...props}
-            className={classnames(
+            className={clsx(
                 'moonstone-separator',
                 `moonstone-separator_${variant}`,
                 `moonstone-size_${size}`,

--- a/src/components/Tab/Tab.stories.jsx
+++ b/src/components/Tab/Tab.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import {storiesOf} from '@storybook/react';
 import {boolean, select, withKnobs} from '@storybook/addon-knobs';
 import storyStyles from '~/__storybook__/storybook.module.scss';
@@ -21,8 +21,8 @@ storiesOf('Components/Tab', module)
     })
     .addDecorator(withKnobs)
     .add('Tab', () => (
-        <section className={classnames(storyStyles.storyGrid)}>
-            <div className={classnames(storyStyles.storyGridItem)}>
+        <section className={clsx(storyStyles.storyGrid)}>
+            <div className={clsx(storyStyles.storyGridItem)}>
                 <Tab>
                     <TabItem icon={<IconWrapper iconName={selectIcon()}/>} label="Tab 1" isSelected={isSelected()}/>
                     <TabItem icon={<IconWrapper iconName={selectIcon()}/>} label="Tab 2" isSelected={!isSelected()}/>

--- a/src/components/Tab/Tab.stories.jsx
+++ b/src/components/Tab/Tab.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'classnames';
+import classnames from 'clsx';
 import {storiesOf} from '@storybook/react';
 import {boolean, select, withKnobs} from '@storybook/addon-knobs';
 import storyStyles from '~/__storybook__/storybook.module.scss';

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './Tab.scss';
 import {TabProps} from './Tab.types';
 
@@ -11,7 +11,7 @@ export const Tab: React.FC<TabProps> = ({children, className = '', ...props}: Ta
     return (
         <div
             {...props}
-            className={classnames(
+            className={clsx(
                 'moonstone-tab',
                 'flexRow_center',
                 'alignCenter',

--- a/src/components/Tab/TabItem/TabItem.stories.jsx
+++ b/src/components/Tab/TabItem/TabItem.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import {storiesOf} from '@storybook/react';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 import storyStyles from '~/__storybook__/storybook.module.scss';
@@ -28,24 +28,24 @@ storiesOf('Components/Tab/TabItem', module)
     .addDecorator(withKnobs)
     .add('TabItem with icon and label', () => (
         <div style={isReversed() ? {backgroundColor: 'var(--color-gray_dark)'} : null}>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3>Variant</h3>
                 </div>
                 {
                     tabItemColors.map(color => (
-                        <div key={color} className={classnames(storyStyles.storyGridItem)}>
+                        <div key={color} className={clsx(storyStyles.storyGridItem)}>
                             <h3>{color}</h3>
                         </div>
                     ))
                 }
             </section>
-            <section className={classnames(storyStyles.storyGrid)}>
-                <div className={classnames(storyStyles.storyGridItem)}>
+            <section className={clsx(storyStyles.storyGrid)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <h3>default</h3>
                 </div>
 
-                <div className={classnames(storyStyles.storyGridItem)}>
+                <div className={clsx(storyStyles.storyGridItem)}>
                     <TabItem icon={<IconWrapper iconName={selectIcon()}/>}
                              label={labelValue()}
                              color={colorValues()}

--- a/src/components/Tab/TabItem/TabItem.stories.jsx
+++ b/src/components/Tab/TabItem/TabItem.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'classnames';
+import classnames from 'clsx';
 import {storiesOf} from '@storybook/react';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 import storyStyles from '~/__storybook__/storybook.module.scss';

--- a/src/components/Tab/TabItem/TabItem.tsx
+++ b/src/components/Tab/TabItem/TabItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './TabItem.scss';
 import {TabItemProps} from './TabItem.types';
 import {Typography} from '~/components/Typography';
@@ -20,7 +20,7 @@ export const TabItem: React.FC<TabItemProps> = ({
     React.createElement(
         component,
         {
-            className: classnames(
+            className: clsx(
                 'moonstone-tab-item',
                 `moonstone-size_${size}`,
                 `moonstone-variant_${variant}`,

--- a/src/components/TreeView/ControlledTreeView.jsx
+++ b/src/components/TreeView/ControlledTreeView.jsx
@@ -1,4 +1,4 @@
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './TreeView.scss';
 import Loading from '~/icons/Loading';
 import ChevronDown from '~/icons/ChevronDown';
@@ -49,7 +49,7 @@ export const ControlledTreeView = ({data, openedItems, selectedItems, onClickIte
             // ---
             // Define CSS treeView_item classes
             // ---
-            const cssTreeViewItem = classnames(
+            const cssTreeViewItem = clsx(
                 'flexRow_between',
                 'alignCenter',
                 'moonstone-treeView_item',
@@ -66,7 +66,7 @@ export const ControlledTreeView = ({data, openedItems, selectedItems, onClickIte
                 }
 
                 return (
-                    <i className={classnames('flexRow', 'alignCenter', className)}>
+                    <i className={clsx('flexRow', 'alignCenter', className)}>
                         {icon &&
                             <icon.type {...icon.props} size={size}/>}
                     </i>
@@ -95,24 +95,24 @@ export const ControlledTreeView = ({data, openedItems, selectedItems, onClickIte
                             {/* Icon arrow */}
                             {isClosable && hasChild &&
                                 <div
-                                    className={classnames('flexRow', 'alignCenter', 'moonstone-treeView_itemToggle')}
+                                    className={clsx('flexRow', 'alignCenter', 'moonstone-treeView_itemToggle')}
                                     onClick={toggleNode}
                                 >
                                     {isOpen ? <ChevronDown/> : <ChevronRight/>}
                                 </div>}
                             {!isFlatData && !hasChild &&
-                                <div className={classnames('flexRow', 'alignCenter', 'moonstone-treeView_itemToggle')}/>}
+                                <div className={clsx('flexRow', 'alignCenter', 'moonstone-treeView_itemToggle')}/>}
 
                             {/* TreeViewItem */}
                             <div
-                                className={classnames('flexRow_nowrap', 'alignCenter', 'flexFluid', 'moonstone-treeView_itemLabel', node.className)}
+                                className={clsx('flexRow_nowrap', 'alignCenter', 'flexFluid', 'moonstone-treeView_itemLabel', node.className)}
                                 onClick={handleNodeClick}
                                 onDoubleClick={handleNodeDoubleClick}
                                 onContextMenu={handleNodeContextMenu}
                             >
                                 {displayIcon(node.iconStart, 'small', 'moonstone-treeView_itemIconStart', parentHasIconStart)}
                                 <Typography isNowrap
-                                            className={classnames('flexFluid')}
+                                            className={clsx('flexFluid')}
                                             component="span"
                                             variant="body"
                                             {...node.typographyOptions}

--- a/src/components/Typography/Typography.stories.jsx
+++ b/src/components/Typography/Typography.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import {storiesOf} from '@storybook/react';
 import {boolean, select, withKnobs} from '@storybook/addon-knobs';
 import storyStyles from '~/__storybook__/storybook.module.scss';
@@ -14,25 +14,25 @@ storiesOf('Tokens/Typography', module)
         notes: {markdown: markdownNotes}
     })
     .addDecorator(withKnobs)
-    .addDecorator(storyFn => <section className={classnames(storyStyles.storyWrapper)}>{storyFn()}</section>)
+    .addDecorator(storyFn => <section className={clsx(storyStyles.storyWrapper)}>{storyFn()}</section>)
     .add('Variants', () => (
         <>
-            <div className={classnames(storyStyles.storyItem)}>
+            <div className={clsx(storyStyles.storyItem)}>
                 <Typography variant="title">Title</Typography>
             </div>
-            <div className={classnames(storyStyles.storyItem)}>
+            <div className={clsx(storyStyles.storyItem)}>
                 <Typography variant="heading">Heading</Typography>
             </div>
-            <div className={classnames(storyStyles.storyItem)}>
+            <div className={clsx(storyStyles.storyItem)}>
                 <Typography variant="subheading">Subheading</Typography>
             </div>
-            <div className={classnames(storyStyles.storyItem)}>
+            <div className={clsx(storyStyles.storyItem)}>
                 <Typography>Body (default)</Typography>
             </div>
-            <div className={classnames(storyStyles.storyItem)}>
+            <div className={clsx(storyStyles.storyItem)}>
                 <Typography variant="caption">Caption</Typography>
             </div>
-            <div className={classnames(storyStyles.storyItem)}>
+            <div className={clsx(storyStyles.storyItem)}>
                 <Typography variant="button">Button</Typography>
             </div>
         </>

--- a/src/components/Typography/Typography.stories.jsx
+++ b/src/components/Typography/Typography.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'classnames';
+import classnames from 'clsx';
 import {storiesOf} from '@storybook/react';
 import {boolean, select, withKnobs} from '@storybook/addon-knobs';
 import storyStyles from '~/__storybook__/storybook.module.scss';

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -1,5 +1,5 @@
 import React, {FunctionComponent} from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './Typography.scss';
 
 export type TypographyVariant = 'title' | 'heading' | 'subheading' | 'body' | 'caption' | 'button';
@@ -83,7 +83,7 @@ export const Typography: FunctionComponent<TypographyProps> = ({
         component,
         {
             ...filterOutIsHtml(props),
-            className: classnames(
+            className: clsx(
                 'moonstone-typography',
                 `moonstone-variant_${variant}`,
                 `moonstone-weight_${weight}`,

--- a/src/icons/Icons.stories.jsx
+++ b/src/icons/Icons.stories.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import {storiesOf} from '@storybook/react';
 import {withKnobs, select, color} from '@storybook/addon-knobs';
 import storyStyles from '~/__storybook__/storybook.module.scss';
@@ -15,7 +15,7 @@ const iconsSize = () => select('Set icon size', {Big: 'big', Default: 'default',
 // Create a component to display in storybook
 export const IconWrapper = ({iconName, size, color}) => {
     return (
-        <div className={classnames(storyStyles.storyGridItem)} style={{color: color}}>
+        <div className={clsx(storyStyles.storyGridItem)} style={{color: color}}>
             {React.createElement(Icons[iconName], {size: size})}
             <span>{iconName}</span>
         </div>
@@ -43,7 +43,7 @@ storiesOf('Tokens/Icons', module)
     })
     .addDecorator(withKnobs)
     .add('Default', () => (
-        <section className={classnames(storyStyles.storyGrid)}>
+        <section className={clsx(storyStyles.storyGrid)}>
             {displayIcons()}
         </section>
     ))

--- a/src/layouts/app/LayoutApp.tsx
+++ b/src/layouts/app/LayoutApp.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import './LayoutApp.scss';
 import {LayoutAppProps} from './LayoutApp.types';
 
 export const LayoutApp: React.FC<LayoutAppProps> = ({navigation = null, content = null}) => {
     return (
-        <div className={classnames('moonstone-layoutApp', 'flexRow_center', 'flexRow_nowrap')}>
-            <div className={classnames('moonstone-slotNavigation')}>
+        <div className={clsx('moonstone-layoutApp', 'flexRow_center', 'flexRow_nowrap')}>
+            <div className={clsx('moonstone-slotNavigation')}>
                 {navigation}
             </div>
-            <div className={classnames('flexFluid', 'flexRow_nowrap')}>
+            <div className={clsx('flexFluid', 'flexRow_nowrap')}>
                 {content}
             </div>
         </div>

--- a/src/layouts/module/LayoutModule.tsx
+++ b/src/layouts/module/LayoutModule.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'clsx';
+import clsx from 'clsx';
 import {LayoutModuleProps} from './LayoutModule.types';
 import {Loader} from '~/components/Loader';
 
@@ -10,20 +10,20 @@ export const LayoutModule: React.FC<LayoutModuleProps> = ({
     component = 'main'
 }) => {
 
-    const classNameProps = classnames(
+    const classNameProps = clsx(
         'flexFluid',
         isLoading ? ['flexCol_center', 'alignCenter'] : 'flexCol'
     );
 
     return (
         <>
-            <div className={classnames('flexCol')}>
+            <div className={clsx('flexCol')}>
                 {navigation}
             </div>
             {
                 React.createElement(
                     component,
-                    {className: classnames(classNameProps), 'role-busy': isLoading},
+                    {className: clsx(classNameProps), 'role-busy': isLoading},
                     isLoading ? <Loader size="big"/> : content
                 )
             }

--- a/src/tokens/colors/color.stories.jsx
+++ b/src/tokens/colors/color.stories.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames/bind';
+import clsx from 'clsx';
 import styles from './colors.stories.module.scss';
 import storyStyles from '~/__storybook__/storybook.module.scss';
-
-let cx = classnames.bind(styles);
 
 const paletteNeutral = ['light',
     'light60',
@@ -52,9 +50,9 @@ const paletteColors = [
 
 export const Color = ({color, name}) => {
     return (
-        <div className={classnames(storyStyles.storyItem)}>
+        <div className={clsx(storyStyles.storyItem)}>
             <p>{name}</p>
-            <div className={classnames(styles.colorShape, cx([`color-${color}`]))}/>
+            <div className={clsx(styles.colorShape, styles[`color-${color}`])}/>
         </div>
     );
 };
@@ -73,22 +71,22 @@ function displayColors(palette) {
 
 storiesOf('Tokens/Colors', module)
     .add('Accent', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
             {displayColors(paletteAccent)}
         </section>
     ))
     .add('Neutral', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
             {displayColors(paletteNeutral)}
         </section>
     ))
     .add('Support', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
             {displayColors(paletteSupport)}
         </section>
     ))
     .add('Palette', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
             {displayColors(paletteColors)}
         </section>
     ));

--- a/src/tokens/spacings/spacing.stories.jsx
+++ b/src/tokens/spacings/spacing.stories.jsx
@@ -1,25 +1,23 @@
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames/bind';
+import clsx from 'clsx';
 
 import styles from './spacings.stories.module.scss';
 import storyStyles from '~/__storybook__/storybook.module.scss';
 
-let cx = classnames.bind(styles);
-
 export const Spacing = ({name}) => {
     return (
-        <div className={classnames(storyStyles.storyItem)}>
+        <div className={clsx(storyStyles.storyItem)}>
             <p>{name}</p>
-            <div className={classnames(cx([`spacing-${name}`]))}/>
+            <div className={clsx(styles[`spacing-${name}`])}/>
         </div>
     );
 };
 
 storiesOf('Tokens/Spacings', module)
     .add('Default', () => (
-        <section className={classnames(storyStyles.storyWrapper)}>
+        <section className={clsx(storyStyles.storyWrapper)}>
             <Spacing name="nano"/>
             <Spacing name="small"/>
             <Spacing name="medium"/>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-270

## Description
- Use `clsx` everywhere we were still using `classnames` to add classes to some stories
- Replace `classnames` to `clsx`