### PR TITLE
MOON-271: Add a loading state to LayoutApp

### DIFF
--- a/src/layouts/app/LayoutApp.spec.jsx
+++ b/src/layouts/app/LayoutApp.spec.jsx
@@ -1,12 +1,17 @@
 import React from 'react';
-import {shallow} from 'component-test-utils-react';
+import {render, screen} from '@testing-library/react';
 import {LayoutApp} from './index';
 
 describe('LayoutApp', () => {
-    it('should display navigation in the right slot', () => {
-        const wrapper = shallow(<LayoutApp navigation="test-navigation"/>);
+    it('should display navigation', () => {
+        render(<LayoutApp navigation="test-navigation"/>);
+        expect(screen.getByText('test-navigation')).toBeInTheDocument();
+    });
 
-        expect(wrapper.html()).toContain('test-navigation');
+    it('should display the loader and not the content when LayoutModule is loading', () => {
+        render(<LayoutApp isLoading content="my content"/>);
+        expect(screen.getByRole('status')).toBeInTheDocument();
+        expect(screen.queryByText('my content')).not.toBeInTheDocument();
     });
 });
 

--- a/src/layouts/app/LayoutApp.stories.jsx
+++ b/src/layouts/app/LayoutApp.stories.jsx
@@ -48,4 +48,11 @@ storiesOf('Layouts/LayoutApp', module)
             navigation={<FakeNavigation/>}
             content={<FakeContent/>}
         />
+    ))
+    .add('Loading', () => (
+        <LayoutApp
+            isLoading
+            navigation={<FakeNavigation/>}
+            content={<FakeContent/>}
+        />
     ));

--- a/src/layouts/app/LayoutApp.tsx
+++ b/src/layouts/app/LayoutApp.tsx
@@ -2,15 +2,25 @@ import React from 'react';
 import clsx from 'clsx';
 import './LayoutApp.scss';
 import {LayoutAppProps} from './LayoutApp.types';
+import {Loader} from '~/components/Loader';
 
-export const LayoutApp: React.FC<LayoutAppProps> = ({navigation = null, content = null}) => {
+export const LayoutApp: React.FC<LayoutAppProps> = ({
+    navigation = null,
+    content = null,
+    isLoading = false
+}) => {
+    const classNameProps = clsx(
+        'flexFluid',
+        isLoading ? ['flexCol_center', 'alignCenter'] : 'flexRow_nowrap'
+    );
+
     return (
         <div className={clsx('moonstone-layoutApp', 'flexRow_center', 'flexRow_nowrap')}>
             <div className={clsx('moonstone-slotNavigation')}>
                 {navigation}
             </div>
-            <div className={clsx('flexFluid', 'flexRow_nowrap')}>
-                {content}
+            <div className={classNameProps}>
+                {isLoading ? <Loader size="big"/> : content}
             </div>
         </div>
     );

--- a/src/layouts/app/LayoutApp.types.ts
+++ b/src/layouts/app/LayoutApp.types.ts
@@ -5,8 +5,14 @@ export type LayoutAppProps = {
      * Slot for the application's navigation
      */
     navigation?: React.ReactNode;
+
     /**
      * Slot for the application's content
      */
     content?: React.ReactNode;
+
+    /**
+     * Replace the content by a loader
+     */
+    isLoading?: boolean;
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-271

## Description

- Add a new prop `isLoading` to LayoutApp: replace the content by a loader
- Add a story for LayoutApp with isLoading
- Rewrite LayoutApp tests with testing-library