### PR TITLE
MOON-272: Fix Dropdown Arrow Alignment

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.jsx
+++ b/src/components/Dropdown/Dropdown.stories.jsx
@@ -213,7 +213,7 @@ storiesOf('Components/Dropdown', module)
             <div style={{transform: 'scale(1)', height: '100vh', padding: '90px'}}>
                 <Dropdown
                     icon={<Love/>}
-                    // Label={currentOption.label}
+                    label={currentOption.label}
                     value={currentOption.value}
                     size={select('Size', DropdownSizes, DropdownSizes.Small)}
                     isDisabled={boolean('Disabled', false)}

--- a/src/components/Dropdown/Dropdown.stories.jsx
+++ b/src/components/Dropdown/Dropdown.stories.jsx
@@ -4,7 +4,8 @@ import {withKnobs, boolean, select, text} from '@storybook/addon-knobs';
 import {action} from '@storybook/addon-actions';
 import markdownNotes from './Dropdown.md';
 
-import {Dropdown, DropdownVariants, DropdownSizes} from './index';
+import {Dropdown} from './index';
+import {DropdownVariants, DropdownSizes} from './Dropdown.types';
 import {Love} from '~/icons';
 import IconWrapper from '~/__storybook__/IconWrapper';
 import {iconsName} from '~/__storybook__/utils';
@@ -212,7 +213,7 @@ storiesOf('Components/Dropdown', module)
             <div style={{transform: 'scale(1)', height: '100vh', padding: '90px'}}>
                 <Dropdown
                     icon={<Love/>}
-                    label={currentOption.label}
+                    // Label={currentOption.label}
                     value={currentOption.value}
                     size={select('Size', DropdownSizes, DropdownSizes.Small)}
                     isDisabled={boolean('Disabled', false)}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -3,116 +3,18 @@ import clsx from 'clsx';
 import './Dropdown.scss';
 import spacings from '~/tokens/spacings/spacing.json';
 
+import {
+    DropdownProps,
+    DropdownImageSizes,
+    HandleSelect,
+    DropdownDataOptions,
+    DropdownVariants,
+    DropdownSizes
+} from './Dropdown.types';
 import {Menu, MenuItem} from '~/components/Menu';
 import {Typography} from '~/components/Typography';
 import {Separator} from '~/components/Separator';
 import {ChevronDown} from '~/icons';
-
-type TDropdownVariant = 'ghost' | 'outlined';
-export enum DropdownVariants {
-    Ghost = 'ghost',
-    Outlined = 'outlined'
-}
-
-type TDropdownSize = 'small' | 'medium';
-export enum DropdownSizes {
-    Small = 'small',
-    Medium = 'medium'
-}
-
-type TDropdownImageSize = 'small' | 'big';
-export enum DropdownImageSizes {
-    Small = 'small',
-    Big = 'big'
-}
-
-type DropdownDataOptions = {
-    label?: string;
-    value?: string;
-    isDisabled?: boolean;
-    iconStart?: React.ReactElement;
-    iconEnd?: React.ReactElement;
-    attributes?: {};
-    image?: HTMLImageElement;
-    imageSize?: TDropdownImageSize;
-}
-
-type DropdownData = {
-    groupLabel?: string;
-    options?: [DropdownDataOptions];
-}
-
-type HandleSelect = (e: React.MouseEvent | React.KeyboardEvent, item?: DropdownDataOptions) => void;
-
-interface DropdownProps {
-    /**
-     * Content of the dropdown
-     */
-    data: [DropdownDataOptions & DropdownData];
-
-    /**
-     * Label of the dropdown
-     */
-    label?: string;
-
-    /**
-     * Value of the dropdown
-     */
-    value?: string;
-
-    /**
-     * Icon displays before the dropdown's label
-     */
-    icon?: React.ReactElement;
-
-    /**
-     * Dropdown's variants
-     */
-    variant?: TDropdownVariant;
-
-    /**
-     * Dropdown's sizes
-     */
-    size?: TDropdownSize;
-
-    /**
-     * Size of images to show in the Dropdown
-     */
-    imageSize?: TDropdownImageSize;
-
-    /**
-     * Max width of the dropdown
-     */
-    maxWidth?: string;
-
-    /**
-     * Dropdown is disabled
-     */
-    isDisabled?: boolean;
-
-    /**
-     * Whether the Menu within the Dropdown has a search input
-     */
-    hasSearch?: boolean;
-
-    /**
-     * The text to display if the Dropdown Menu has a search input and the search doesn't have any results
-     */
-    searchEmptyText?: string;
-
-    /**
-     * Additional classname
-     */
-    className?: string;
-
-    /**
-     * Function trigger on change with the current option as param
-     * @param {object} event - Mouse event
-     * @param {object} item - The current item selected
-     */
-    onChange?: () => {};
-}
-
 
 export const Dropdown: React.FC<DropdownProps> = (
     {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -108,7 +108,7 @@ export const Dropdown: React.FC<DropdownProps> = (
     // ---
 
     const cssDropdown = clsx(
-        'flexRow',
+        !label && !icon ? 'flexRow_reverse' : 'flexRow_between',
         'alignCenter',
         'moonstone-dropdown',
         `moonstone-${size}`,

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -1,0 +1,106 @@
+import React from 'react';
+
+export type TDropdownVariant = 'ghost' | 'outlined';
+export enum DropdownVariants {
+    Ghost = 'ghost',
+    Outlined = 'outlined'
+}
+
+export type TDropdownSize = 'small' | 'medium';
+export enum DropdownSizes {
+    Small = 'small',
+    Medium = 'medium'
+}
+
+export type TDropdownImageSize = 'small' | 'big';
+export enum DropdownImageSizes {
+    Small = 'small',
+    Big = 'big'
+}
+
+export type DropdownDataOptions = {
+    label?: string;
+    value?: string;
+    isDisabled?: boolean;
+    iconStart?: React.ReactElement;
+    iconEnd?: React.ReactElement;
+    attributes?: {};
+    image?: HTMLImageElement;
+    imageSize?: TDropdownImageSize;
+}
+
+export type DropdownData = {
+    groupLabel?: string;
+    options?: [DropdownDataOptions];
+}
+
+export type HandleSelect = (e: React.MouseEvent | React.KeyboardEvent, item?: DropdownDataOptions) => void;
+
+export type DropdownProps = {
+    /**
+     * Content of the dropdown
+     */
+    data: [DropdownDataOptions & DropdownData];
+
+    /**
+     * Label of the dropdown
+     */
+    label?: string;
+
+    /**
+     * Value of the dropdown
+     */
+    value?: string;
+
+    /**
+     * Icon displays before the dropdown's label
+     */
+    icon?: React.ReactElement;
+
+    /**
+     * Dropdown's variants
+     */
+    variant?: TDropdownVariant;
+
+    /**
+     * Dropdown's sizes
+     */
+    size?: TDropdownSize;
+
+    /**
+     * Size of images to show in the Dropdown
+     */
+    imageSize?: TDropdownImageSize;
+
+    /**
+     * Max width of the dropdown
+     */
+    maxWidth?: string;
+
+    /**
+     * Dropdown is disabled
+     */
+    isDisabled?: boolean;
+
+    /**
+     * Whether the Menu within the Dropdown has a search input
+     */
+    hasSearch?: boolean;
+
+    /**
+     * The text to display if the Dropdown Menu has a search input and the search doesn't have any results
+     */
+    searchEmptyText?: string;
+
+    /**
+     * Additional classname
+     */
+    className?: string;
+
+    /**
+     * Function trigger on change with the current option as param
+     * @param {object} event - Mouse event
+     * @param {object} item - The current item selected
+     */
+    onChange?: () => {};
+}

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -1,18 +1,18 @@
 import React from 'react';
 
-export type TDropdownVariant = 'ghost' | 'outlined';
+export type DropdownVariant = 'ghost' | 'outlined';
 export enum DropdownVariants {
     Ghost = 'ghost',
     Outlined = 'outlined'
 }
 
-export type TDropdownSize = 'small' | 'medium';
+export type DropdownSize = 'small' | 'medium';
 export enum DropdownSizes {
     Small = 'small',
     Medium = 'medium'
 }
 
-export type TDropdownImageSize = 'small' | 'big';
+export type DropdownImageSize = 'small' | 'big';
 export enum DropdownImageSizes {
     Small = 'small',
     Big = 'big'
@@ -26,7 +26,7 @@ export type DropdownDataOptions = {
     iconEnd?: React.ReactElement;
     attributes?: {};
     image?: HTMLImageElement;
-    imageSize?: TDropdownImageSize;
+    imageSize?: DropdownImageSize;
 }
 
 export type DropdownData = {
@@ -60,17 +60,17 @@ export type DropdownProps = {
     /**
      * Dropdown's variants
      */
-    variant?: TDropdownVariant;
+    variant?: DropdownVariant;
 
     /**
      * Dropdown's sizes
      */
-    size?: TDropdownSize;
+    size?: DropdownSize;
 
     /**
      * Size of images to show in the Dropdown
      */
-    imageSize?: TDropdownImageSize;
+    imageSize?: DropdownImageSize;
 
     /**
      * Max width of the dropdown

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -96,7 +96,7 @@ export const ListItem: React.FC<ListItemProps> = ({
 
             {
                 iconEnd &&
-                <div className="moonstone-listItem_iconStart"><iconEnd.type {...iconEnd.props} size="small"/></div>
+                <div className="moonstone-listItem_iconEnd"><iconEnd.type {...iconEnd.props} size="small"/></div>
             }
         </li>
     );


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-272

## Description

* Fixes the down arrow icon in the Dropdown to be correctly aligned when a label isn't provided
* Update Dropdown to use our newer typescript conventions
* Changed the class on `iconEnd` on ListItem to have the correct class
