### PR TITLE
MOON-273: Fix LayoutModule role-busy error

### DIFF
--- a/src/layouts/module/LayoutModule.tsx
+++ b/src/layouts/module/LayoutModule.tsx
@@ -23,7 +23,7 @@ export const LayoutModule: React.FC<LayoutModuleProps> = ({
             {
                 React.createElement(
                     component,
-                    {className: clsx(classNameProps), 'role-busy': isLoading},
+                    {className: clsx(classNameProps), 'role-busy': isLoading ? 'true' : undefined},
                     isLoading ? <Loader size="big"/> : content
                 )
             }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-273

## Description
Fixes a small bug that was causing a warning when using the LayoutModule component