### PR TITLE
MOON-280: Make onClick Handlers Optional

### DIFF
--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.types.ts
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.types.ts
@@ -16,6 +16,6 @@ export type BreadcrumbItemProps = {
     /**
      * Function trigger on click
      */
-    onClick: React.MouseEventHandler;
+    onClick?: React.MouseEventHandler;
 }
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -15,7 +15,7 @@ export const Button: React.FC<ButtonProps> = ({
     color = 'default',
     className = null,
     isHtml = false,
-    onClick,
+    onClick = () => undefined,
     ...props
 }) => {
     let typoWeight: TypographyWeight = 'default';

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -58,5 +58,5 @@ export type ButtonProps = {
     /**
      * Function trigger on click
      */
-    onClick: React.MouseEventHandler;
+    onClick?: React.MouseEventHandler;
 }

--- a/src/components/Tab/TabItem/TabItem.tsx
+++ b/src/components/Tab/TabItem/TabItem.tsx
@@ -15,6 +15,7 @@ export const TabItem: React.FC<TabItemProps> = ({
     color = 'default',
     className = null,
     isSelected = false,
+    onClick = () => undefined,
     ...props
 }) =>
     React.createElement(
@@ -32,6 +33,7 @@ export const TabItem: React.FC<TabItemProps> = ({
                 className
             ),
             disabled: isDisabled,
+            onClick,
             ...props
         },
         (

--- a/src/components/Tab/TabItem/TabItem.types.ts
+++ b/src/components/Tab/TabItem/TabItem.types.ts
@@ -45,7 +45,7 @@ export type TabItemProps = {
     /**
      * Function trigger on click
      */
-    onClick: React.MouseEventHandler;
+    onClick?: React.MouseEventHandler;
     /**
      * Is tabItem color reversed
      */


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-280

## Description
Make `onClick` handler props optional for any components where they were a required prop.
