### PR TITLE
MOON-196: useFlexLayout react-table plugin example

### DIFF
--- a/src/components/Table/Table.stories.jsx
+++ b/src/components/Table/Table.stories.jsx
@@ -1,9 +1,11 @@
-// This file has been written in jsx instead of tsx due to issues using
-// typescript with react-table. When react-table v8 is released in 2021,
-// these issues should be resolved.
+/*
+    This file has been written in jsx instead of tsx due to issues using
+    Typescript with react-table. When react-table v8 is released in 2021,
+    these issues should be resolved.
+*/
 
 import React, {useEffect, useState} from 'react';
-import {useExpanded, useRowSelect, useSortBy, useTable} from 'react-table';
+import {useExpanded, useFlexLayout, useRowSelect, useSortBy, useTable} from 'react-table';
 import storyStyles from '~/__storybook__/storybook.module.scss';
 
 import {
@@ -476,6 +478,84 @@ export const StructuredView = () => {
 };
 
 StructuredView.storyName = 'Structured View with React-Table';
+
+export const ColumnWidthReactTable = () => {
+    const data = React.useMemo(() => tableDataFlat, []);
+    const columns = React.useMemo(() => [
+        /*
+            Use the width property in these column definitions to specify column widths.
+            A column without a width property, such as the column definition immediately
+            below this comment, will expand to fit any remaining space.
+                "`width` is used as both the flex-basis and flex-grow. This means that it
+                essentially acts as both the minimum width and flex-ratio of the column."
+                - https://react-table.tanstack.com/docs/api/useFlexLayout
+        */
+        {Header: 'Name', id: 'name', accessor: row => row.name.value},
+        {Header: 'Status', accessor: 'status', width: 35},
+        {Header: 'Content Type', accessor: 'type', width: 50},
+        {Header: 'Created By', accessor: 'createdBy', width: 30},
+        {Header: 'Last Modified On', accessor: 'lastModifiedOn', width: 50}
+    ], []);
+
+    const {
+        getTableProps,
+        getTableBodyProps,
+        headerGroups,
+        rows,
+        prepareRow
+    } = useTable(
+        {
+            data,
+            columns
+        },
+        // Use the useFlexLayout plugin to render the table elements with flexbox
+        // (instead of with table element widths which are calculated by the browser)
+        useFlexLayout
+    );
+
+    return (
+        <Table {...getTableProps()}>
+            <TableHead>
+                {headerGroups.map(headerGroup => (
+                    // A key is included in headerGroup.getHeaderGroupProps
+                    // eslint-disable-next-line react/jsx-key
+                    <TableRow {...headerGroup.getHeaderGroupProps()}>
+                        {headerGroup.headers.map(column => (
+                            // A key is included in column.getHeaderProps
+                            // eslint-disable-next-line react/jsx-key
+                            <TableHeadCell {...column.getHeaderProps()}>
+                                {column.render('Header')}
+                            </TableHeadCell>
+                        ))}
+                    </TableRow>
+                ))}
+            </TableHead>
+            <TableBody {...getTableBodyProps()}>
+                {rows.map(row => {
+                    prepareRow(row);
+                    return (
+                        // A key is included in row.getRowProps
+                        // eslint-disable-next-line react/jsx-key
+                        <TableRow {...row.getRowProps()}>
+                            {row.cells.map(cell => (
+                                // A key is included in cell.getCellProps
+                                // eslint-disable-next-line react/jsx-key
+                                <TableBodyCell
+                                    {...cell.getCellProps()}
+                                    iconStart={cell.column.id === 'name' && row.original.name.icon}
+                                >
+                                    {cell.render('Cell')}
+                                </TableBodyCell>
+                            ))}
+                        </TableRow>
+                    );
+                })}
+            </TableBody>
+        </Table>
+    );
+};
+
+ColumnWidthReactTable.storyName = 'Column Width Management with React-Table';
 
 // Export const KitchenSink = () => {};
 // KitchenSink.storyName = 'Everything and the Kitchen Sink with React-Table';

--- a/src/components/Table/TableRow/TableRow.tsx
+++ b/src/components/Table/TableRow/TableRow.tsx
@@ -16,6 +16,7 @@ export const TableRow: React.FC<TableRowProps> = ({
         className={
             clsx(
                 'moonstone-TableRow',
+                'alignCenter', // necessary for useFlexLayout react-table plugin
                 hasMultipleLines && 'moonstone-TableRow-multipleLines',
                 isSelected && 'moonstone-TableRow-selected',
                 isHighlighted && 'moonstone-TableRow-highlighted',


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-196

## Description

- Shows an example of how to specify column widths of the `Table` by using the `useFlexLayout` react-table plugin.
- See the story, "Column Width Management with React-Table" in Storybook.