### PR TITLE
QA-13381 Close menu when onContextMenu is triggered on overlay

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -139,6 +139,7 @@ export const Menu: React.FC<MenuProps> = ({
                         aria-hidden="true"
                         className="moonstone-menu_overlay"
                         onClick={onClose}
+                        onContextMenu={onClose}
                     />
                 )
             }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-13381

## Description

Basically equating right click on the overlay with a click. In jcontent a user can right click on entries in the table, if a menu is open a right click on the overlay doesn't change selection, although for the user it seems like a different entry is selected. Alternatively, we can disable right click but I think it may leave the user confused.  