### PR TITLE
MOON-301: Table Sticky Header

### DIFF
--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -1,0 +1,3 @@
+.moonstone-Table {
+    border-collapse: separate;
+}

--- a/src/components/Table/Table.stories.jsx
+++ b/src/components/Table/Table.stories.jsx
@@ -5,7 +5,7 @@
 */
 
 import React, {useEffect, useState} from 'react';
-import {useExpanded, useFlexLayout, useRowSelect, useSortBy, useTable} from 'react-table';
+import {useExpanded, useFlexLayout, useGridLayout, useRowSelect, useSortBy, useTable} from 'react-table';
 import storyStyles from '~/__storybook__/storybook.module.scss';
 
 import {
@@ -490,11 +490,15 @@ export const ColumnWidthReactTable = () => {
                 essentially acts as both the minimum width and flex-ratio of the column."
                 - https://react-table.tanstack.com/docs/api/useFlexLayout
         */
-        {Header: 'Name', id: 'name', accessor: row => row.name.value},
-        {Header: 'Status', accessor: 'status', width: 35},
-        {Header: 'Content Type', accessor: 'type', width: 50},
-        {Header: 'Created By', accessor: 'createdBy', width: 30},
-        {Header: 'Last Modified On', accessor: 'lastModifiedOn', width: 50}
+        {Header: 'Name', id: 'name', accessor: row => row.name.value, width: 50},
+        // {Header: 'Status', accessor: 'status', width: 35},
+        {Header: 'Status', accessor: 'status', width: 50},
+        // {Header: 'Content Type', accessor: 'type', width: 50},
+        {Header: 'Content Type', accessor: 'type'},
+        // {Header: 'Created By', accessor: 'createdBy', width: 30},
+        {Header: 'Created By', accessor: 'createdBy'},
+        // {Header: 'Last Modified On', accessor: 'lastModifiedOn', width: 50}
+        {Header: 'Last Modified On', accessor: 'lastModifiedOn'}
     ], []);
 
     const {
@@ -510,7 +514,8 @@ export const ColumnWidthReactTable = () => {
         },
         // Use the useFlexLayout plugin to render the table elements with flexbox
         // (instead of with table element widths which are calculated by the browser)
-        useFlexLayout
+        // useFlexLayout
+        useGridLayout
     );
 
     return (
@@ -556,6 +561,40 @@ export const ColumnWidthReactTable = () => {
 };
 
 ColumnWidthReactTable.storyName = 'Column Width Management with React-Table';
+
+export const StickyHeader = () => {
+    const colNum = 4;
+    const rowNum = 20;
+    const cols = [];
+    const rows = [];
+
+    for (let i = 1; i <= colNum; i++) {
+        cols.push('column ' + i);
+    }
+
+    for (let i = 1; i <= rowNum; i++) {
+        rows.push('row ' + i);
+    }
+
+    return (
+        <Table>
+            <TableHead sticky>
+                <TableRow>
+                    {cols.map(col => <TableHeadCell key={col}>{col}</TableHeadCell>)}
+                </TableRow>
+            </TableHead>
+            <TableBody>
+                {rows.map(row => (
+                    <TableRow key={row}>
+                        {cols.map(col => (
+                            <TableBodyCell key={row + col}>this is a cell!</TableBodyCell>
+                        ))}
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    );
+};
 
 export const KitchenSinkFlat = () => {
     const [rowsPerPage, setRowsPerPage] = useState(5);

--- a/src/components/Table/Table.stories.jsx
+++ b/src/components/Table/Table.stories.jsx
@@ -5,7 +5,7 @@
 */
 
 import React, {useEffect, useState} from 'react';
-import {useExpanded, useFlexLayout, useGridLayout, useRowSelect, useSortBy, useTable} from 'react-table';
+import {useExpanded, useFlexLayout, useRowSelect, useSortBy, useTable} from 'react-table';
 import storyStyles from '~/__storybook__/storybook.module.scss';
 
 import {
@@ -490,15 +490,11 @@ export const ColumnWidthReactTable = () => {
                 essentially acts as both the minimum width and flex-ratio of the column."
                 - https://react-table.tanstack.com/docs/api/useFlexLayout
         */
-        {Header: 'Name', id: 'name', accessor: row => row.name.value, width: 50},
-        // {Header: 'Status', accessor: 'status', width: 35},
-        {Header: 'Status', accessor: 'status', width: 50},
-        // {Header: 'Content Type', accessor: 'type', width: 50},
-        {Header: 'Content Type', accessor: 'type'},
-        // {Header: 'Created By', accessor: 'createdBy', width: 30},
-        {Header: 'Created By', accessor: 'createdBy'},
-        // {Header: 'Last Modified On', accessor: 'lastModifiedOn', width: 50}
-        {Header: 'Last Modified On', accessor: 'lastModifiedOn'}
+        {Header: 'Name', id: 'name', accessor: row => row.name.value},
+        {Header: 'Status', accessor: 'status', width: 35},
+        {Header: 'Content Type', accessor: 'type', width: 50},
+        {Header: 'Created By', accessor: 'createdBy', width: 30},
+        {Header: 'Last Modified On', accessor: 'lastModifiedOn', width: 50}
     ], []);
 
     const {
@@ -515,7 +511,7 @@ export const ColumnWidthReactTable = () => {
         // Use the useFlexLayout plugin to render the table elements with flexbox
         // (instead of with table element widths which are calculated by the browser)
         // useFlexLayout
-        useGridLayout
+        useFlexLayout
     );
 
     return (

--- a/src/components/Table/Table.stories.jsx
+++ b/src/components/Table/Table.stories.jsx
@@ -5,7 +5,7 @@
 */
 
 import React, {useEffect, useState} from 'react';
-import {useExpanded, useFlexLayout, useRowSelect, useSortBy, useTable} from 'react-table';
+import {useExpanded, /* useFlexLayout, */ useRowSelect, useSortBy, useTable} from 'react-table';
 import storyStyles from '~/__storybook__/storybook.module.scss';
 
 import {
@@ -507,11 +507,10 @@ export const ColumnWidthReactTable = () => {
         {
             data,
             columns
-        },
+        }
         // Use the useFlexLayout plugin to render the table elements with flexbox
         // (instead of with table element widths which are calculated by the browser)
         // useFlexLayout
-        useFlexLayout
     );
 
     return (
@@ -574,7 +573,7 @@ export const StickyHeader = () => {
 
     return (
         <Table>
-            <TableHead sticky>
+            <TableHead isSticky>
                 <TableRow>
                     {cols.map(col => <TableHeadCell key={col}>{col}</TableHeadCell>)}
                 </TableRow>
@@ -633,8 +632,8 @@ export const KitchenSinkFlat = () => {
             disableSortRemove: true
         },
         useSortBy,
-        useRowSelect,
-        useFlexLayout
+        useRowSelect
+        // UseFlexLayout
     );
 
     const renderSortIndicator = (isSorted, isSortedDesc) => {
@@ -645,7 +644,7 @@ export const KitchenSinkFlat = () => {
     return (
         <>
             <Table {...getTableProps()}>
-                <TableHead>
+                <TableHead isSticky>
                     {headerGroups.map(headerGroup => (
                         // A key is included in headerGroup.getHeaderGroupProps
                         // eslint-disable-next-line react/jsx-key
@@ -738,8 +737,8 @@ export const KitchenSinkNested = () => {
         },
         useSortBy,
         useExpanded,
-        useRowSelect,
-        useFlexLayout
+        useRowSelect
+        // UseFlexLayout
     );
 
     const renderSortIndicator = (isSorted, isSortedDesc) => {
@@ -753,7 +752,7 @@ export const KitchenSinkNested = () => {
 
     return (
         <Table {...getTableProps()}>
-            <TableHead>
+            <TableHead isSticky>
                 {headerGroups.map(headerGroup => (
                     // A key is included in headerGroup.getHeaderGroupProps
                     // eslint-disable-next-line react/jsx-key

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,17 +1,21 @@
 import React from 'react';
 import clsx from 'clsx';
 
-import {TableProps} from './Table.types';
+import { TableProps } from './Table.types';
 import './Table.scss';
 
 export const Table: React.FC<TableProps> = ({
+    component = 'table',
     className,
     children,
     ...props
-}) => (
-    <table className={clsx('moonstone-Table', className)} {...props}>
-        {children}
-    </table>
+}) => React.createElement(
+    component,
+    {
+        className: clsx('moonstone-Table', className),
+        ...props
+    },
+    children
 );
 
 Table.displayName = 'Table';

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import clsx from 'clsx';
 
 import {TableProps} from './Table.types';
+import './Table.scss';
 
 export const Table: React.FC<TableProps> = ({
+    className,
     children,
     ...props
 }) => (
-    <table {...props}>
+    <table className={clsx('moonstone-Table', className)} {...props}>
         {children}
     </table>
 );

--- a/src/components/Table/Table.types.ts
+++ b/src/components/Table/Table.types.ts
@@ -2,6 +2,11 @@ import React from 'react';
 
 export type TableProps = {
     /**
+     * Which html element to render the table as
+     */
+    component?: string;
+
+    /**
      * Any additional class names to apply to the Table
      */
     className?: string;

--- a/src/components/Table/Table.types.ts
+++ b/src/components/Table/Table.types.ts
@@ -2,6 +2,11 @@ import React from 'react';
 
 export type TableProps = {
     /**
+     * Any additional class names to apply to the Table
+     */
+    className?: string;
+
+    /**
      * The children elements to be provided to the Table (e.g., Table Rows, Headers, and Cells)
      */
     children?: React.ReactNode;

--- a/src/components/Table/TableBody/TableBody.tsx
+++ b/src/components/Table/TableBody/TableBody.tsx
@@ -4,18 +4,19 @@ import clsx from 'clsx';
 import {TableBodyProps} from './TableBody.types';
 
 export const TableBody: React.FC<TableBodyProps> = ({
+    component = 'tbody',
     className,
     children,
     ...props
-}) => (
-    <tbody
+}) => React.createElement(
+    component,
+    {
         // 'moonstone-TableBody' class is used to target only rows within the table body
         // to apply the hover effect
-        className={clsx('moonstone-TableBody', className)}
-        {...props}
-    >
-        {children}
-    </tbody>
+        className: clsx('moonstone-TableBody', className),
+        ...props
+    },
+    children
 );
 
 TableBody.displayName = 'TableBody';

--- a/src/components/Table/TableBody/TableBody.types.ts
+++ b/src/components/Table/TableBody/TableBody.types.ts
@@ -7,6 +7,11 @@ export type TableBodyProps = {
     className?: string;
 
     /**
+     * Name of HTML element to render in the DOM for this component
+     */
+    component?: string;
+
+    /**
      * The children elements provided
      */
     children?: React.ReactNode;

--- a/src/components/Table/TableHead/TableHead.scss
+++ b/src/components/Table/TableHead/TableHead.scss
@@ -1,3 +1,10 @@
 .moonstone-tableHead {
     color: var(--color-gray);
+
+    background-color: var(--color-white);
+}
+
+.moonstone-tableHead-sticky {
+    position: sticky;
+    top: 0;
 }

--- a/src/components/Table/TableHead/TableHead.scss
+++ b/src/components/Table/TableHead/TableHead.scss
@@ -7,4 +7,5 @@
 .moonstone-tableHead-sticky {
     position: sticky;
     top: 0;
+    z-index: 1;
 }

--- a/src/components/Table/TableHead/TableHead.tsx
+++ b/src/components/Table/TableHead/TableHead.tsx
@@ -6,20 +6,17 @@ import clsx from 'clsx';
 
 export const TableHead: React.FC<TableHeadProps> = ({
     sticky = false,
+    component = 'thead',
     className,
     children,
     ...props
-}) => (
-    <thead
-        className={clsx(
-            'moonstone-tableHead',
-            sticky && 'moonstone-tableHead-sticky',
-            className
-        )}
-        {...props}
-    >
-        {children}
-    </thead>
+}) => React.createElement(
+    component,
+    {
+        className: clsx('moonstone-tableHead', sticky && 'moonstone-tableHead-sticky', className),
+        ...props
+    },
+    children
 );
 
 TableHead.displayName = 'TableHead';

--- a/src/components/Table/TableHead/TableHead.tsx
+++ b/src/components/Table/TableHead/TableHead.tsx
@@ -5,7 +5,7 @@ import './TableHead.scss';
 import clsx from 'clsx';
 
 export const TableHead: React.FC<TableHeadProps> = ({
-    sticky = false,
+    isSticky = false,
     component = 'thead',
     className,
     children,
@@ -13,7 +13,7 @@ export const TableHead: React.FC<TableHeadProps> = ({
 }) => React.createElement(
     component,
     {
-        className: clsx('moonstone-tableHead', sticky && 'moonstone-tableHead-sticky', className),
+        className: clsx('moonstone-tableHead', isSticky && 'moonstone-tableHead-sticky', className),
         ...props
     },
     children

--- a/src/components/Table/TableHead/TableHead.tsx
+++ b/src/components/Table/TableHead/TableHead.tsx
@@ -4,9 +4,18 @@ import {TableHeadProps} from './TableHead.types';
 import './TableHead.scss';
 import clsx from 'clsx';
 
-export const TableHead: React.FC<TableHeadProps> = ({children, className, ...props}) => (
+export const TableHead: React.FC<TableHeadProps> = ({
+    sticky = false,
+    className,
+    children,
+    ...props
+}) => (
     <thead
-        className={clsx('moonstone-tableHead', className)}
+        className={clsx(
+            'moonstone-tableHead',
+            sticky && 'moonstone-tableHead-sticky',
+            className
+        )}
         {...props}
     >
         {children}

--- a/src/components/Table/TableHead/TableHead.types.ts
+++ b/src/components/Table/TableHead/TableHead.types.ts
@@ -2,6 +2,12 @@ import React from 'react';
 
 export type TableHeadProps = {
     /**
+     * Determines whether the table header row should stay sticky while the
+     * table content is being scrolled through
+     */
+    sticky?: boolean;
+
+    /**
      * Any additional class names to apply to the component
      */
     className?: string;

--- a/src/components/Table/TableHead/TableHead.types.ts
+++ b/src/components/Table/TableHead/TableHead.types.ts
@@ -5,7 +5,7 @@ export type TableHeadProps = {
      * Determines whether the table header row should stay sticky while the
      * table content is being scrolled through
      */
-    sticky?: boolean;
+    isSticky?: boolean;
 
     /**
      * Name of HTML element to render in the DOM for this component

--- a/src/components/Table/TableHead/TableHead.types.ts
+++ b/src/components/Table/TableHead/TableHead.types.ts
@@ -8,6 +8,11 @@ export type TableHeadProps = {
     sticky?: boolean;
 
     /**
+     * Name of HTML element to render in the DOM for this component
+     */
+    component?: string;
+
+    /**
      * Any additional class names to apply to the component
      */
     className?: string;

--- a/src/components/Table/TableRow/TableRow.scss
+++ b/src/components/Table/TableRow/TableRow.scss
@@ -4,8 +4,6 @@ $row-multiple-line-height: 64px;
 .moonstone-TableRow {
     height: $row-regular-height;
 
-    border-bottom: 1px solid var(--color-gray_light);
-
     transition: background-color 0.2s ease-in-out;
 
     .moonstone-TableBody &:hover {

--- a/src/components/Table/TableRow/TableRow.tsx
+++ b/src/components/Table/TableRow/TableRow.tsx
@@ -6,27 +6,26 @@ import './TableRow.scss';
 
 export const TableRow: React.FC<TableRowProps> = ({
     className,
+    component = 'tr',
     hasMultipleLines = false,
     isSelected = false,
     isHighlighted = false,
     children,
     ...props
-}) => (
-    <tr
-        className={
-            clsx(
-                'moonstone-TableRow',
-                'alignCenter', // necessary for useFlexLayout react-table plugin
-                hasMultipleLines && 'moonstone-TableRow-multipleLines',
-                isSelected && 'moonstone-TableRow-selected',
-                isHighlighted && 'moonstone-TableRow-highlighted',
-                className
-            )
-        }
-        {...props}
-    >
-        {children}
-    </tr>
+}) => React.createElement(
+    component,
+    {
+        className: clsx(
+            'moonstone-TableRow',
+            'alignCenter', // necessary for useFlexLayout react-table plugin
+            hasMultipleLines && 'moonstone-TableRow-multipleLines',
+            isSelected && 'moonstone-TableRow-selected',
+            isHighlighted && 'moonstone-TableRow-highlighted',
+            className
+        ),
+        ...props
+    },
+    children
 );
 
 TableRow.displayName = 'TableRow';

--- a/src/components/Table/TableRow/TableRow.types.ts
+++ b/src/components/Table/TableRow/TableRow.types.ts
@@ -7,6 +7,11 @@ export type TableRowProps = {
     className?: React.ReactNode;
 
     /**
+     * Name of HTML element to render in the DOM for this component
+     */
+    component?: 'string;'
+
+    /**
      * Whether the cell height should be increased to show more than 1 line
      */
     hasMultipleLines?: boolean;

--- a/src/components/Table/table-cells/TableBodyCell.tsx
+++ b/src/components/Table/table-cells/TableBodyCell.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import clsx from 'clsx';
 
-import {TableCellProps} from './TableCell.types';
-import {IconTextIcon, Typography} from '~/components';
-import {ChevronRight, ChevronDown} from '~/icons';
-import {capitalize} from '~/utils/helpers';
-import {TableCell} from './TableCell';
+import { TableCellProps } from './TableCell.types';
+import { IconTextIcon, Typography } from '~/components';
+import { ChevronRight, ChevronDown } from '~/icons';
+import { capitalize } from '~/utils/helpers';
+import { TableCell } from './TableCell';
 
 export const TableBodyCell: React.FC<TableCellProps> = ({
     component = 'td',
@@ -24,10 +24,7 @@ export const TableBodyCell: React.FC<TableCellProps> = ({
     const leftMarginIndentDepth = row?.depth * 20; // px
 
     const renderCellContent = () => (
-        <IconTextIcon
-            component="div"
-            iconStart={iconStart}
-        >
+        <IconTextIcon component="div" iconStart={iconStart}>
             {children}
         </IconTextIcon>
     );
@@ -38,12 +35,15 @@ export const TableBodyCell: React.FC<TableCellProps> = ({
         if (isExpandableColumn && row?.canExpand) {
             return (
                 <TableCell
-                    {...row?.getToggleRowExpandedProps({style: {marginLeft: `${leftMarginIndentDepth}px`}})}
+                    {...row?.getToggleRowExpandedProps({
+                        style: { marginLeft: `${leftMarginIndentDepth}px` }
+                    })}
                 >
-                    {row?.isExpanded
-                        ? <ChevronDown className="moonstone-marginRightNano"/>
-                        : <ChevronRight className="moonstone-marginRightNano"/>
-                    }
+                    {row?.isExpanded ? (
+                        <ChevronDown className="moonstone-marginRightNano" />
+                    ) : (
+                        <ChevronRight className="moonstone-marginRightNano" />
+                    )}
                     {renderCellContent()}
                 </TableCell>
             );
@@ -56,7 +56,13 @@ export const TableBodyCell: React.FC<TableCellProps> = ({
         // the chevron icons for expand/collapse
         if (isExpandableColumn && !row?.canExpand) {
             return (
-                <TableCell style={{marginLeft: `${leftMarginIndentDepth + leftmarginbuffer}px`}}>
+                <TableCell
+                    style={{
+                        marginLeft: `${
+                            leftMarginIndentDepth + leftMarginBuffer
+                        }px`
+                    }}
+                >
                     {renderCellContent()}
                 </TableCell>
             );
@@ -66,7 +72,6 @@ export const TableBodyCell: React.FC<TableCellProps> = ({
         // relation to the row expansion feature
         return <TableCell>{renderCellContent()}</TableCell>;
     };
-
 
     return (
         <Typography

--- a/src/components/Table/table-cells/TableBodyCell.tsx
+++ b/src/components/Table/table-cells/TableBodyCell.tsx
@@ -56,7 +56,7 @@ export const TableBodyCell: React.FC<TableCellProps> = ({
         // the chevron icons for expand/collapse
         if (isExpandableColumn && !row?.canExpand) {
             return (
-                <TableCell style={{marginLeft: `${leftMarginIndentDepth + leftMarginBuffer}px`}}>
+                <TableCell style={{marginLeft: `${leftMarginIndentDepth + leftmarginbuffer}px`}}>
                     {renderCellContent()}
                 </TableCell>
             );
@@ -71,6 +71,7 @@ export const TableBodyCell: React.FC<TableCellProps> = ({
     return (
         <Typography
             className={clsx(
+                'moonstone-TableCell-border',
                 'textAlign' + capitalize(textAlign),
                 'moonstone-verticalAlign' + capitalize(verticalAlign),
                 className

--- a/src/components/Table/table-cells/TableBodyCell.tsx
+++ b/src/components/Table/table-cells/TableBodyCell.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import clsx from 'clsx';
 
-import { TableCellProps } from './TableCell.types';
-import { IconTextIcon, Typography } from '~/components';
-import { ChevronRight, ChevronDown } from '~/icons';
-import { capitalize } from '~/utils/helpers';
-import { TableCell } from './TableCell';
+import {TableCellProps} from './TableCell.types';
+import {IconTextIcon, Typography} from '~/components';
+import {ChevronRight, ChevronDown} from '~/icons';
+import {capitalize} from '~/utils/helpers';
+import {TableCell} from './TableCell';
 
 export const TableBodyCell: React.FC<TableCellProps> = ({
     component = 'td',
@@ -34,16 +34,12 @@ export const TableBodyCell: React.FC<TableCellProps> = ({
         // which the cells show the chevron icon to expand and collapse sub-rows (isExpandableColumn)
         if (isExpandableColumn && row?.canExpand) {
             return (
-                <TableCell
-                    {...row?.getToggleRowExpandedProps({
-                        style: { marginLeft: `${leftMarginIndentDepth}px` }
-                    })}
+                <TableCell {...row?.getToggleRowExpandedProps({style: {marginLeft: `${leftMarginIndentDepth}px`}})}
                 >
-                    {row?.isExpanded ? (
-                        <ChevronDown className="moonstone-marginRightNano" />
-                    ) : (
-                        <ChevronRight className="moonstone-marginRightNano" />
-                    )}
+                    {row?.isExpanded
+                        ? <ChevronDown className="moonstone-marginRightNano"/>
+                        : <ChevronRight className="moonstone-marginRightNano"/>
+                    }
                     {renderCellContent()}
                 </TableCell>
             );
@@ -56,13 +52,7 @@ export const TableBodyCell: React.FC<TableCellProps> = ({
         // the chevron icons for expand/collapse
         if (isExpandableColumn && !row?.canExpand) {
             return (
-                <TableCell
-                    style={{
-                        marginLeft: `${
-                            leftMarginIndentDepth + leftMarginBuffer
-                        }px`
-                    }}
-                >
+                <TableCell style={{marginLeft: `${leftMarginIndentDepth + leftMarginBuffer}px`}}>
                     {renderCellContent()}
                 </TableCell>
             );

--- a/src/components/Table/table-cells/TableCell.scss
+++ b/src/components/Table/table-cells/TableCell.scss
@@ -10,6 +10,10 @@
     }
 }
 
+.moonstone-TableCell-border {
+    border-bottom: 1px solid var(--color-gray_light);
+}
+
 .moonstone-verticalAlignTop {
     vertical-align: top;
 }

--- a/src/components/Table/table-cells/TableHeadCell.tsx
+++ b/src/components/Table/table-cells/TableHeadCell.tsx
@@ -21,6 +21,7 @@ export const TableHeadCell: React.FC<TableCellProps> = ({
     return (
         <Typography
             className={clsx(
+                'moonstone-TableCell-border',
                 'textAlign' + capitalize(textAlign),
                 'moonstone-verticalAlign' + capitalize(verticalAlign),
                 className


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-301

## Description

- Allows the header of a table to be sticky with the use of the `isSticky` prop
- Use of the sticky header causes issues with the `useFlexLayout` plugin, so its usages in `Table.stories.jsx` have been commented out for now. Further investigation into adding the ability to specify column widths will be done with MOON-299