### PR TITLE
MOON-316: Avoid scrolling to top when a dropdown with search is used

### DIFF
--- a/src/components/Dropdown/Dropdown.spec.js
+++ b/src/components/Dropdown/Dropdown.spec.js
@@ -77,16 +77,30 @@ describe('Dropdown', () => {
         expect(screen.getByTestId('moonstone-dropdown').firstChild).toHaveClass('moonstone-disabled');
     });
 
-    it('should display the correct search results', () => {
+    it('should not display the menu dropdown by default', () => {
         render(
-            <Dropdown hasSearch data={dataGrouped} data-testid="moonstone-dropdown" onChange={() => 'testing'}/>
+            <Dropdown data={dataGrouped} data-testid="moonstone-dropdown" onChange={() => 'testing'}/>
         );
-        userEvent.type(screen.getByRole('textbox'), 'option 4');
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
 
-        expect(screen.queryByText('option 1')).not.toBeInTheDocument();
-        expect(screen.queryByText('option 2')).not.toBeInTheDocument();
-        expect(screen.queryByText('option 3')).not.toBeInTheDocument();
-        expect(screen.getByText('option 4')).toBeInTheDocument();
+    it('should display the menu dropdown when I click on the dropdown', () => {
+        render(
+            <Dropdown data={dataGrouped} data-testid="moonstone-dropdown" onChange={() => 'testing'}/>
+        );
+
+        userEvent.click(screen.getByRole('dropdown'));
+        expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('should close the menu dropdown when I click on an option', () => {
+        render(
+            <Dropdown data={dataGrouped} data-testid="moonstone-dropdown" onChange={() => 'testing'}/>
+        );
+
+        userEvent.click(screen.getByRole('dropdown'));
+        userEvent.click(screen.getAllByRole('option')[1]);
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
     });
 
     it('should display nothing if data is not an array', () => {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -167,6 +167,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
             }}
         >
             <div
+                role="dropdown"
                 className={clsx(cssDropdown)}
                 tabIndex={0}
                 onClick={handleOpenMenu}
@@ -192,31 +193,33 @@ export const Dropdown: React.FC<DropdownProps> = ({
                 <ChevronDown className="moonstone-dropdown_chevronDown"/>
             </div>
 
-            <Menu
-                isDisplayed={isOpened}
-                position="absolute"
-                anchorPosition={anchorPosition}
-                minWidth={minWidth}
-                maxWidth={menuMaxWidth}
-                maxHeight={menuMaxHeight}
-                anchorEl={anchorEl}
-                hasSearch={hasSearch}
-                searchEmptyText={searchEmptyText}
-                onClose={handleCloseMenu}
-            >
-                {
-                    data.map((item, index) => {
-                        if (isGrouped) {
-                            item.options.map((o: DropdownDataOptions) => {
-                                return dropdownOption(o);
-                            });
-                            return dropdownGrouped(item.options, item.groupLabel, index);
-                        }
+            {isOpened && (
+                <Menu
+                    isDisplayed
+                    position="absolute"
+                    anchorPosition={anchorPosition}
+                    minWidth={minWidth}
+                    maxWidth={menuMaxWidth}
+                    maxHeight={menuMaxHeight}
+                    anchorEl={anchorEl}
+                    hasSearch={hasSearch}
+                    searchEmptyText={searchEmptyText}
+                    onClose={handleCloseMenu}
+                >
+                    {
+                        data.map((item, index) => {
+                            if (isGrouped) {
+                                item.options.map((o: DropdownDataOptions) => {
+                                    return dropdownOption(o);
+                                });
+                                return dropdownGrouped(item.options, item.groupLabel, index);
+                            }
 
-                        return dropdownOption(item);
-                    })
-                }
-            </Menu>
+                            return dropdownOption(item);
+                        })
+                    }
+                </Menu>
+            )}
         </div>
     );
 };

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -35,7 +35,8 @@ export const Input: React.FC<InputProps> = ({
         if (focusOnField) {
             searchRef.current.focus({preventScroll: true});
         }
-    });
+    }, [focusOnField]);
+
     return (
         <div className={classNameProps}>
             <input

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -103,6 +103,7 @@ export const Menu: React.FC<MenuProps> = ({
             <menu
                 ref={itemRef}
                 style={styleMenu}
+                role="listbox"
                 className={clsx(
                     'moonstone-menu',
                     className,


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-316

## Description
- Prevent scrolling to the top when we open a dropdown with `hasSearch` by adding `preventScroll: true`
- Remove the dropdown menu from the DOM when it doesn't display to avoid catching the focus (and scrolling to it) when the dropdown or a parent component is rendered.
- Add some roles for accessibility and tests.
- Fix and add tests to fit the new behavior.