### PR TITLE
MOON-335: Don't use react clone to display the backButton in the Header

### DIFF
--- a/src/components/Header/Header.stories.jsx
+++ b/src/components/Header/Header.stories.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import {Header} from './index';
-
 import {Button, Breadcrumb, BreadcrumbItem, Chip, Dropdown, Tab, TabItem} from '~/components';
-import {ViewGrid, ViewList} from '~/icons';
+import {ViewGrid, ViewList, ArrowLeft} from '~/icons';
 
 const DropdownData = [
     {
@@ -80,7 +79,7 @@ export const Full = Template.bind({});
 
 Full.args = {
     title: 'Page Title',
-    backButton: <Button onClick={() => undefined}/>,
+    backButton: <Button variant="outlined" icon={<ArrowLeft/>} onClick={() => undefined}/>,
     search: <Button size="big" variant="ghost" label="Search" onClick={() => undefined}/>,
     mainActions: [
         <Button key="1" size="big" label="Secondary" variant="outlined" onClick={() => undefined}/>,

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -26,11 +26,11 @@ export const Header: React.FC<HeaderProps> = ({
         <header className={clsx('moonstone-header', className)} {...props}>
             {/* Main area */}
             <div className={clsx('moonstone-header_main', 'flexRow', 'alignCenter', 'flexFluid')}>
-                { backButton && React.cloneElement(backButton, {
-                    className: 'moonstone-header_back',
-                    variant: 'outlined',
-                    icon: <ArrowLeft/>
-                })}
+                { backButton && (
+                    <div className="moonstone-header_back">
+                        {backButton}
+                    </div>
+                )}
 
                 <Typography isNowrap component="h1" variant="title" className={clsx('flexFluid', 'moonstone-header_title')}>{title}</Typography>
 
@@ -62,17 +62,18 @@ export const Header: React.FC<HeaderProps> = ({
                 </div>
             )}
 
-            <Separator invisible="firstOrLastChild"/>
-
             {hasToolbar && (
-                <div role="toolbar" className={clsx('flexRow_between', 'alignCenter', 'moonstone-header_toolbar')}>
-                    <div className={clsx('flexRow', 'alignCenter', 'flexFluid', 'moonstone-header_actions')}>
-                        { toolbarLeft }
+                <>
+                    <Separator/>
+                    <div role="toolbar" className={clsx('flexRow_between', 'alignCenter', 'moonstone-header_toolbar')}>
+                        <div className={clsx('flexRow', 'alignCenter', 'flexFluid', 'moonstone-header_actions')}>
+                            { toolbarLeft }
+                        </div>
+                        <div className={clsx('flexRow', 'alignCenter', 'moonstone-header_actions')}>
+                            { toolbarRight }
+                        </div>
                     </div>
-                    <div className={clsx('flexRow', 'alignCenter', 'moonstone-header_actions')}>
-                        { toolbarRight }
-                    </div>
-                </div>
+                </>
             )}
         </header>
     );


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-335

## Description

- Avoid to use `React.cloneElement` to display backButton in the header component to prevent issue with the action. Otherwise we have to set the variant `outlined`  and the icon `ArrowLeft` in the implementation side, it's no longer provided by moonstone.
- Only display header `Separator` when the `toolbar` is displayed to avoid having unnecessary element in the DOM.

