### PR TITLE
MOON-343: Add hasPadding prop to LayoutContent

### DIFF
--- a/src/layouts/content/LayoutContent.scss
+++ b/src/layouts/content/LayoutContent.scss
@@ -3,10 +3,12 @@
 }
 
 .moonstone-layoutContent {
-    padding: var(--spacing-large);
-
     background-color: var(--color-gray_light40);
     overflow: auto;
+}
+
+.moonstone-layoutContent_withPadding {
+    padding: var(--spacing-large);
 }
 
 .moonstone-layoutContent_centered {

--- a/src/layouts/content/LayoutContent.spec.js
+++ b/src/layouts/content/LayoutContent.spec.js
@@ -19,8 +19,13 @@ describe('LayoutContent', () => {
         expect(screen.queryByText('my content')).not.toBeInTheDocument();
     });
 
-    it('should have the class `moonstone-layoutContent_centered` when `isCentered` set to true', () => {
+    it('should have the class "moonstone-layoutContent_centered" when "isCentered" set to true', () => {
         const {container} = render(<LayoutContent isCentered content="my content"/>);
         expect(container.querySelector('.moonstone-layoutContent_centered')).toBeInTheDocument();
+    });
+
+    it('should not have the class "moonstone-layoutContent_withPadding" when "hasPadding" set to false', () => {
+        const {container} = render(<LayoutContent hasPadding={false} content="my content"/>);
+        expect(container.querySelector('.moonstone-layoutContent_withPadding')).not.toBeInTheDocument();
     });
 });

--- a/src/layouts/content/LayoutContent.stories.js
+++ b/src/layouts/content/LayoutContent.stories.js
@@ -41,6 +41,11 @@ Centered.args = {
     isCentered: true
 };
 
+export const WithoutPadding = Template.bind({});
+WithoutPadding.args = {
+    hasPadding: false
+};
+
 export const Loading = Template.bind({});
 Loading.args = {
     isLoading: true

--- a/src/layouts/content/LayoutContent.tsx
+++ b/src/layouts/content/LayoutContent.tsx
@@ -8,6 +8,7 @@ import {Loader} from '~/components/Loader';
 export const LayoutContent: React.FC<LayoutContentProps> = ({
     header,
     content,
+    hasPadding = true,
     isLoading = false,
     isCentered = false,
     className,
@@ -16,7 +17,8 @@ export const LayoutContent: React.FC<LayoutContentProps> = ({
         const classNameProps = clsx(
             'flexFluid',
             'moonstone-layoutContent',
-            isLoading ? ['flexCol_center', 'alignCenter'] : 'flexCol_nowrap',
+            {'moonstone-layoutContent_withPadding': hasPadding},
+            isLoading ? ['flexCol_center', 'alignCenter'] : 'flexCol_nowrap'
         );
     return (
         <div className={clsx('flexCol', 'flexFluid', 'moonstone-layoutContent_wrapper', className)} {...props}>

--- a/src/layouts/content/LayoutContent.types.ts
+++ b/src/layouts/content/LayoutContent.types.ts
@@ -22,6 +22,11 @@ export type LayoutContentProps = {
     isLoading?: boolean,
 
     /**
+     * Define if the layout has padding
+     */
+    hasPadding?: boolean
+
+    /**
      * Additional className
      */
      className?: string,


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-343

## Description

Add a new prop `hasPadding` to `LayoutContent` to define if the component has padding or not, by default the value is `true`.
