### PR TITLE
MOON-314: safeguard for incomplete anchor objects

### DIFF
--- a/src/hooks/usePositioning.tsx
+++ b/src/hooks/usePositioning.tsx
@@ -261,7 +261,7 @@ export const usePositioning = (
     useEffect(() => {
         if (isDisplayed) {
             const resolvedAnchorEl = (anchorEl && anchorEl.current ? anchorEl.current : anchorEl) as HTMLDivElement;
-            const hasTransform = resolvedAnchorEl && resolvedAnchorEl.closest('[style*="transform"]');
+            const hasTransform = resolvedAnchorEl && resolvedAnchorEl.closest && resolvedAnchorEl.closest('[style*="transform"]');
             const _stylePosition = (position === 'absolute' || hasTransform) ?
                 getAbsolutePosition(itemRef, anchorElOrigin, transformElOrigin, anchorPosition) :
                 getFixedPosition(itemRef, anchorEl, anchorElOrigin, transformElOrigin, anchorPosition);


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-314

## Description

In some cases, for some reasons, anchorEl is not a real element but a mock object which do not contain "closest" function ..