### PR TITLE
MOON-354: Add global styles to provide design for drag-and-drop behaviors

### DIFF
--- a/src/components/TreeView/ControlledTreeView.tsx
+++ b/src/components/TreeView/ControlledTreeView.tsx
@@ -45,7 +45,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
     }, ref) => {
     const isFlatData = data.filter(item => item.children && item.children.length > 0).length === 0;
 
-    function generateLevelJSX(nodeData: TreeViewData[], deep: number, parentHasIconStart: boolean): React.ReactNode[] {
+    function generateLevelJSX(nodeData: TreeViewData[], depth: number, parentHasIconStart: boolean): React.ReactNode[] {
         return nodeData.map(node => {
             const hasChild = Boolean(node.hasChildren || (node.children && node.children.length !== 0));
             const hasIconStart = Boolean(node.iconStart);
@@ -98,13 +98,14 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
             return [
                 React.createElement(
                     itemComponent,
-                    {role: 'treeitem', 'aria-expanded': isOpen, key: `${deep}-${node.id}`, ...node.treeItemProps},
-                    <div
-                        className={cssTreeViewItem}
-                        style={{
-                            paddingLeft: `calc((var(--spacing-medium) + var(--spacing-nano)) * ${deep} + var(--spacing-medium))`
-                        }}
-                    >
+                    {
+                        role: 'treeitem',
+                        'aria-expanded': isOpen,
+                        key: `${depth}-${node.id}`,
+                        style: {'--treeItem-depth': depth},
+                        ...node.treeItemProps
+                    },
+                    <div className={cssTreeViewItem}>
                         {/* Icon arrow */}
                         {isClosable && hasChild && (
                             <div
@@ -137,7 +138,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
                         </div>
                     </div>
                 ),
-                ...((isOpen && node.children) ? generateLevelJSX(node.children, isClosable ? (deep + 1) : deep, hasIconStart) : [])
+                ...((isOpen && node.children) ? generateLevelJSX(node.children, isClosable ? (depth + 1) : depth, hasIconStart) : [])
             ];
         });
     }

--- a/src/components/TreeView/TreeView.scss
+++ b/src/components/TreeView/TreeView.scss
@@ -1,46 +1,50 @@
-.moonstone-treeView_item {
-    --color-treeItem: inherit;
-    --color-treeItem_hover: var(--color-dark);
-    --color-treeItem_selected: var(--color-light);
-    --color-treeItem_selected_hover: var(--color-light);
-    --background-treeItem: inherit;
-    --background-treeItem_hover: var(--color-gray_light40);
-    --background-treeItem_selected: var(--color-accent);
-    --background-treeItem_selected_hover: var(--color-accent);
+[role='treeitem'] {
+    --treeItem-indent: calc((var(--spacing-medium) + var(--spacing-nano)) * var(--treeItem-depth, 0) + var(--spacing-medium));
+    --treeItem-color: inherit;
+    --treeItem-color_hover: var(--color-dark);
+    --treeItem-color_selected: var(--color-light);
+    --treeItem-color_selected_hover: var(--color-light);
+    --treeItem-background: inherit;
+    --treeItem-background_hover: var(--color-gray_light40);
+    --treeItem-background_selected: var(--color-accent);
+    --treeItem-background_selected_hover: var(--color-accent);
+}
 
+.moonstone-treeView_item {
     flex-wrap: nowrap;
 
     height: 32px;
     padding-right: var(--spacing-small);
+    padding-left: var(--treeItem-indent);
 
-    color: var(--color-treeItem);
+    color: var(--treeItem-color);
 
-    background-color: var(--background-treeItem);
+    background-color: var(--treeItem-background);
     cursor: pointer;
 
     &:hover {
-        color: var(--color-treeItem_hover);
+        color: var(--treeItem-color_hover);
 
-        background-color: var(--background-treeItem_hover);
+        background-color: var(--treeItem-background_hover);
     }
 
     &.moonstone-selected {
-        color: var(--color-treeItem_selected);
+        color: var(--treeItem-color_selected);
 
-        background-color: var(--background-treeItem_selected);
+        background-color: var(--treeItem-background_selected);
 
         &:hover {
-            color: var(--color-treeItem_selected_hover);
+            color: var(--treeItem-color_selected_hover);
 
-            background-color: var(--background-treeItem_selected_hover);
+            background-color: var(--treeItem-background_selected_hover);
         }
     }
 
     // Theme reversed
     &.moonstone-reversed {
-        --color-treeItem: var(--color-gray_light);
-        --color-treeItem_hover: var(--color-light);
-        --background-treeItem_hover: var(--color-gray40);
+        --treeItem-color: var(--color-gray_light);
+        --treeItem-color_hover: var(--color-light);
+        --treeItem-background_hover: var(--color-gray40);
     }
 
     &.moonstone-disabled {

--- a/src/components/TreeView/TreeView.stories.jsx
+++ b/src/components/TreeView/TreeView.stories.jsx
@@ -30,23 +30,23 @@ storiesOf('Components/TreeView', module)
     ))
     .add('data', () => (
         <TreeView
-            data={object('data', [
+            data={[
                 {id: 'A1', label: 'A-1 level1'},
                 {id: 'A2', label: 'A-2 level1', children: [{id: 'B1', label: 'B1 level2'}]},
                 {id: 'A3', label: 'A-3 level1'}
-            ])}
+            ]}
         />
     ))
     .add('Flat', () => (
         <TreeView
-            data={object('data', [
+            data={[
                 {id: 'A1', label: 'A-1 level1'},
                 {id: 'A2', label: 'A-2 level1'},
                 {id: 'A3', label: 'A-3 level1'},
                 {id: 'A4', label: 'A-4 level1'},
                 {id: 'A5', label: 'A-5 level1'},
                 {id: 'A6', label: 'A-6 level1'}
-            ])}
+            ]}
         />
     ))
     .add('selection', () => {

--- a/src/components/TreeView/TreeView.stories.jsx
+++ b/src/components/TreeView/TreeView.stories.jsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {storiesOf} from '@storybook/react';
-import {object, withKnobs} from '@storybook/addon-knobs';
+import {withKnobs} from '@storybook/addon-knobs';
 import {action} from '@storybook/addon-actions';
 
 import markdownNotes from './TreeView.md';

--- a/src/globals.scss
+++ b/src/globals.scss
@@ -3,6 +3,7 @@
 @import './globals/init';
 @import './globals/layout';
 @import './globals/alignment';
+@import './globals/dnd';
 
 @import './tokens/spacings/spacings';
 @import './tokens/colors/colors';

--- a/src/globals/_dnd.scss
+++ b/src/globals/_dnd.scss
@@ -1,0 +1,55 @@
+// ---
+// Drag n Drop classes
+// ---
+$dnd-highlight: var(--color-accent_light60);
+
+.moonstone-drag {
+    opacity: 0.5;
+}
+
+.moonstone-drop_listItem:not(.moonstone-drag) {
+    outline: 2px solid $dnd-highlight;
+    outline-offset: -2px;
+}
+
+.moonstone-drop_row,
+.moonstone-drop_card {
+    &:not(.moonstone-drag) {
+        outline: 4px solid $dnd-highlight;
+        outline-offset: -4px;
+    }
+}
+
+.moonstone-order_before {
+    position: relative;
+
+    &::before {
+        @extend %orderingIndicator;
+
+        position: absolute;
+        content: "";
+
+        top: -1px;
+    }
+}
+
+.moonstone-order_after {
+    position: relative;
+
+    &::after {
+        @extend %orderingIndicator;
+
+        position: absolute;
+        content: "";
+
+        top: calc(100% - 1px);
+    }
+}
+
+%orderingIndicator {
+    width: 100%;
+    height: 1px;
+    margin-left: var(--treeItem-indent, 0);
+
+    background-color: $dnd-highlight;
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-354

## Description

- Expose some CSS classes to provide design for drag-and-drop behaviors `globals/dnd.scss`
- Move all CSS properties relative to the TreeItem at the top level of the component (`li`) instead of `div` with the class `moonstone-treeView_item`
- Rename treeItem's CSS properties for readability
- Expose new CSS properties for treeItem:
    - `var(--treeItem-depth)` represents the depth level of the treeItem
    - `var(--treeItem-indent)` represents the value of the shift indentation of the treeItem
