### PR TITLE
MOON-356: Add tests to RadioGroup and RadioItem

### DIFF
--- a/src/components/RadioGroup/RadioGroup.spec.js
+++ b/src/components/RadioGroup/RadioGroup.spec.js
@@ -1,28 +1,149 @@
 import React from 'react';
 import {render, screen} from '@testing-library/react';
+
+import userEvent from '@testing-library/user-event';
 import {RadioGroup} from './index';
 import {RadioItem} from './RadioItem';
 
 describe('RadioGroup', () => {
-    it('should render the children', () => {
-        const className = 'children-custom';
-        const {container} = render(<RadioGroup name="test-name" value="test-value"><RadioItem aria-label="radio" className={className}/></RadioGroup>);
-        expect(container.getElementsByClassName(className)).toBeTruthy();
+    it('should render', () => {
+        render(
+            <RadioGroup name="test-name" value="01">
+                <RadioItem id="radio-01" label="radio 01" value="01"/>
+                <RadioItem id="radio-02" label="radio 02" value="02"/>
+            </RadioGroup>);
+        expect(screen.getAllByRole('radio')).toHaveLength(2);
     });
 
-    it('should pass props to the element', () => {
-        render(<RadioGroup data-testid="radioGroupTestId" name="test-name" value="test-value" title="test-radioGroup"><RadioItem aria-label="radio"/></RadioGroup>);
-        expect(screen.getByTestId('radioGroupTestId')).toHaveAttribute('title', 'test-radioGroup');
+    it('should display additional attributes', () => {
+        render(
+            <RadioGroup data-testid="moonstone-radioGroup" name="test-name" value="01">
+                <RadioItem id="radio-01" label="radio 01" value="01"/>
+                <RadioItem id="radio-02" label="radio 02" value="02"/>
+            </RadioGroup>
+        );
+        expect(screen.getByTestId('moonstone-radioGroup')).toBeInTheDocument();
     });
 
-    it('should pass className to the element', () => {
-        const className = 'customization';
-        const {container} = render(<RadioGroup name="test-name" value="test-value" className={className}><RadioItem aria-label="radio"/></RadioGroup>);
-        expect(container.getElementsByClassName(className)).toBeTruthy();
+    it('should display additional className', () => {
+        const className = 'test-class';
+        render(
+            <RadioGroup data-testid="moonstone-radioGroup" name="test-name" value="01" className={className}>
+                <RadioItem id="radio-01" label="radio 01" value="01"/>
+                <RadioItem id="radio-02" label="radio 02" value="02"/>
+            </RadioGroup>
+        );
+        expect(screen.getByTestId('moonstone-radioGroup')).toHaveClass(className);
     });
 
     it('should not display the RadioGroup when children is empty', () => {
-        const {container} = render(<RadioGroup className="customization">{[]}</RadioGroup>);
-        expect(container).toBeEmpty();
+        render(<RadioGroup data-testid="moonstone-radioGroup">{[]}</RadioGroup>);
+        expect(screen.queryByTestId('moonstone-radioGroup')).not.toBeInTheDocument();
+    });
+
+    it('should not display the RadioGroup when children is only one element', () => {
+        render(
+            <RadioGroup data-testid="moonstone-radioGroup">
+                <RadioItem id="radio-01" label="radio 01" value="01"/>
+            </RadioGroup>
+        );
+        expect(screen.queryByTestId('moonstone-radioGroup')).not.toBeInTheDocument();
+    });
+
+    it('should set the first item as selected when no value or defaultValue is provided', () => {
+        render(
+            <RadioGroup name="test-name">
+                <RadioItem id="radio-01" label="radio 01" value="01"/>
+                <RadioItem id="radio-02" label="radio 02" value="02"/>
+            </RadioGroup>
+        );
+        expect(screen.getAllByRole('radio')[0]).toBeChecked();
+        expect(screen.getAllByRole('radio')[1]).not.toBeChecked();
+    });
+
+    it('should be disabled', () => {
+        render(
+            <RadioGroup isDisabled name="test-name">
+                <RadioItem id="radio-01" label="radio 01" value="01"/>
+                <RadioItem id="radio-02" label="radio 02" value="02"/>
+            </RadioGroup>
+        );
+        expect(screen.getByLabelText('radio 01')).toBeDisabled();
+        expect(screen.getByLabelText('radio 02')).toBeDisabled();
+    });
+
+    it('should be read-only', () => {
+        render(
+            <RadioGroup isReadOnly name="test-name">
+                <RadioItem id="radio-01" label="radio 01" value="01"/>
+                <RadioItem id="radio-02" label="radio 02" value="02"/>
+            </RadioGroup>
+        );
+        expect(screen.getByLabelText('radio 01')).toHaveAttribute('aria-readonly', 'true');
+        expect(screen.getByLabelText('radio 02')).toHaveAttribute('aria-readonly', 'true');
+    });
+});
+
+describe('UnControlledRadioGroup', () => {
+    it('should have specified defaultValue', () => {
+        render(
+            <RadioGroup defaultValue="02" name="test-name">
+                <RadioItem id="radio-01" label="radio 01" value="01"/>
+                <RadioItem id="radio-02" label="radio 02" value="02"/>
+            </RadioGroup>
+        );
+
+        expect(screen.getByLabelText('radio 01')).not.toBeChecked();
+        expect(screen.getByLabelText('radio 02')).toBeChecked();
+    });
+
+    it('should update specified defaultValue', () => {
+        render(
+            <RadioGroup defaultValue="02" name="test-name">
+                <RadioItem id="radio-01" label="radio 01" value="01"/>
+                <RadioItem id="radio-02" label="radio 02" value="02"/>
+            </RadioGroup>
+        );
+        userEvent.click(screen.getByLabelText('radio 01'));
+
+        expect(screen.getByLabelText('radio 01')).toBeChecked();
+        expect(screen.getByLabelText('radio 02')).not.toBeChecked();
+    });
+
+    it('should call specified onChange function', () => {
+        const handleChange = jest.fn();
+
+        render(
+            <RadioGroup defaultValue="02" name="test-name" onChange={handleChange}>
+                <RadioItem id="radio-01" label="radio 01" value="01"/>
+                <RadioItem id="radio-02" label="radio 02" value="02"/>
+            </RadioGroup>
+        );
+        userEvent.click(screen.getByLabelText('radio 01'));
+
+        expect(handleChange).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('ControlledRadioGroup', () => {
+    it('should display specified value', () => {
+        render(
+            <RadioGroup value="02" name="test-name">
+                <RadioItem id="radio-01" label="radio 01" value="01"/>
+                <RadioItem id="radio-02" label="radio 02" value="02"/>
+            </RadioGroup>
+        );
+        expect(screen.getByLabelText('radio 02')).toBeChecked();
+    });
+
+    it('should set the first item as selected when the empty is an empty string', () => {
+        render(
+            <RadioGroup value="" name="test-name">
+                <RadioItem id="radio-01" label="radio 01" value="01"/>
+                <RadioItem id="radio-02" label="radio 02" value="02"/>
+            </RadioGroup>
+        );
+        expect(screen.getByLabelText('radio 01')).toBeChecked();
+        expect(screen.getByLabelText('radio 02')).not.toBeChecked();
     });
 });

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -4,7 +4,7 @@ import {ControlledRadioGroup} from '~/components/RadioGroup/ControlledRadioGroup
 import {RadioGroupProps} from '~/components/RadioGroup/RadioGroup.types';
 
 export const RadioGroup: React.FC<RadioGroupProps> = ({children, defaultValue, value, ...props}) => {
-    if (!children || React.Children.count(children) < 1) {
+    if (!children || React.Children.count(children) < 2) {
         return null;
     }
 

--- a/src/components/RadioGroup/RadioItem/RadioItem.spec.js
+++ b/src/components/RadioGroup/RadioItem/RadioItem.spec.js
@@ -6,17 +6,39 @@ import {RadioGroup} from '../RadioGroup';
 describe('radio', () => {
     it('should display additional class names', () => {
         const className = 'test';
-        const {container} = render(<RadioGroup name="test-name" value="test-value"><RadioItem aria-label="radio" className={className}/></RadioGroup>);
-        expect(container.getElementsByClassName(className)).toBeTruthy();
+        const {container} = render(
+            <RadioGroup name="test-name">
+                <RadioItem id="radio-01" label="radio 01" value="01" className={className}/>
+                <RadioItem id="radio-02" label="radio 02" value="02"/>
+            </RadioGroup>
+        );
+        expect(container.querySelector('.test')).toBeInTheDocument();
     });
 
     it('should be disabled when isDisabled is set', () => {
-        render(<RadioGroup name="test-name" value="test-value"><RadioItem isDisabled aria-label="radio"/></RadioGroup>);
-        expect(screen.getByRole('radio')).toBeDisabled();
+        render(
+            <RadioGroup name="test-name">
+                <RadioItem id="radio-01" label="radio 01" value="01"/>
+                <RadioItem isDisabled id="radio-02" label="radio 02" value="02"/>
+            </RadioGroup>);
+        expect(screen.getByDisplayValue('02')).toBeDisabled();
     });
 
     it('should be read-only when isReadOnly is set', () => {
-        render(<RadioGroup name="test-name" value="test-value"><RadioItem isReadOnly aria-label="radio"/></RadioGroup>);
-        expect(screen.getByRole('radio')).toHaveAttribute('aria-readonly', 'true');
+        render(
+            <RadioGroup name="test-name">
+                <RadioItem id="radio-01" label="radio 01" value="01"/>
+                <RadioItem isReadOnly id="radio-02" label="radio 02" value="02"/>
+            </RadioGroup>);
+        expect(screen.getByDisplayValue('02')).toHaveAttribute('aria-readonly', 'true');
+    });
+
+    it('should display the description', () => {
+        render(
+            <RadioGroup name="test-name">
+                <RadioItem id="radio-01" label="radio 01" value="01" description="radio description"/>
+                <RadioItem id="radio-02" label="radio 02" value="02"/>
+            </RadioGroup>);
+        expect(screen.getByText('radio description')).toBeInTheDocument();
     });
 });

--- a/src/components/RadioGroup/RadioItem/RadioItem.tsx
+++ b/src/components/RadioGroup/RadioItem/RadioItem.tsx
@@ -25,7 +25,7 @@ export const RadioItem: React.FC<RadioItemProps> = ({className, id, value, label
                         id={id}
                         value={value}
                         aria-labelledby={`${id}-label`}
-                        aria-describedby={`${id}-description`}
+                        aria-describedby={description ? `${id}-description` : null}
                         onChange={event => {
                             context.onChange(event, value);
                         }}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-356

## Description

- Add tests to `RadioGroup` and `RadioItem.`
- Fix the condition to not display `RadioGroup` when only one `children` is provided.
- Avoid displaying the attribute `aria-describedby` when no description is provided.
