### PR TITLE
MOON-366: Remove is-react dependency and isHtml prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
         "clsx": "^1.2.1",
         "prop-types": "^15.8.1",
         "re-resizable": "^6.9.9",
-        "react-is": "^18.2.0",
         "to-px": "^1.1.0"
     },
     "peerDependencies": {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -16,7 +16,6 @@ export const Button: React.FC<ButtonProps> = ({
     variant = 'default',
     color = 'default',
     className = null,
-    isHtml = false,
     onClick = () => undefined,
     ...props
 }) => {
@@ -67,7 +66,6 @@ export const Button: React.FC<ButtonProps> = ({
                     isUpperCase={size === 'big'}
                     weight={typoWeight}
                     className={clsx('flexFluid')}
-                    isHtml={isHtml}
                 >
                     {label}
                 </Typography>

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -16,11 +16,6 @@ export type ButtonProps = {
     label?: React.ReactNode;
 
     /**
-     * Does the label contain HTML markup
-     */
-    isHtml?: boolean;
-
-    /**
      * Icon size
      */
     size?: ButtonSize;

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -7,7 +7,6 @@ import {ListItemProps} from './ListItem.types';
 export const ListItem: React.FC<ListItemProps> = ({
     label,
     description,
-    isHtml = false,
     iconStart = null,
     iconEnd = null,
     tabIndex,
@@ -50,7 +49,6 @@ export const ListItem: React.FC<ListItemProps> = ({
             >
                 <Typography
                     isNowrap
-                    isHtml={isHtml}
                     className={clsx(isDisplayImage ? null : 'flexFluid')}
                     variant={typographyVariant}
                     component="span"

--- a/src/components/ListItem/ListItem.types.ts
+++ b/src/components/ListItem/ListItem.types.ts
@@ -19,11 +19,6 @@ export type ListItemProps = {
     description?: string;
 
     /**
-     * Does the label contain HTML markup
-     */
-    isHtml?: boolean;
-
-    /**
      * A leading icon display before the label. Cannot be used in conjunction with the image property.
      */
     iconStart?: React.ReactElement;

--- a/src/components/Menu/MenuItem.types.ts
+++ b/src/components/Menu/MenuItem.types.ts
@@ -40,11 +40,6 @@ export type MenuItemProps = {
     description?: string;
 
     /**
-     * Does the label contain HTML markup
-     */
-    isHtml?: boolean,
-
-    /**
      * A leading icon display before the label
      */
     iconStart?: React.ReactElement,

--- a/src/components/Typography/Typography.spec.js
+++ b/src/components/Typography/Typography.spec.js
@@ -91,11 +91,4 @@ describe('Typography', () => {
         );
         expect(wrapper.props.className).toContain('yoloooo');
     });
-
-    it('should not bind isHtml prop to the html component', () => {
-        const wrapper = shallow(
-            <Typography isHtml><div>string</div></Typography>
-        );
-        expect(wrapper.html()).not.toContain('isHtml');
-    });
 });

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -3,17 +3,6 @@ import clsx from 'clsx';
 import './Typography.scss';
 import {TypographyProps} from './Typography.types';
 
-// IsHtml prop should eventually be removed (along with this function) as children supports all React Node types
-// including strings and HTML markup
-const filterOutIsHtml = (props: TypographyProps) => {
-    const newProps = {...props};
-    if (newProps.isHtml) {
-        delete newProps.isHtml;
-    }
-
-    return newProps;
-};
-
 export const Typography: React.FC<TypographyProps> = ({
     children = '',
     component = 'p',
@@ -24,7 +13,6 @@ export const Typography: React.FC<TypographyProps> = ({
     isItalic = false,
     isUpperCase = false,
     isNowrap = false,
-    isHtml = false,
     ...props
 }) => {
     if (!children) {
@@ -34,7 +22,7 @@ export const Typography: React.FC<TypographyProps> = ({
     return React.createElement(
         component,
         {
-            ...filterOutIsHtml(props),
+            ...props,
             className: clsx(
                 'moonstone-typography',
                 `moonstone-variant_${variant}`,

--- a/src/components/Typography/Typography.types.ts
+++ b/src/components/Typography/Typography.types.ts
@@ -40,10 +40,6 @@ export type TypographyProps = {
      */
     hasLineThrough?: boolean;
     /**
-     * Does the children contain HTML markup
-     */
-    isHtml?: boolean;
-    /**
      * No wrapping for text
      */
     isNowrap?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12044,11 +12044,6 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
-  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
-
 react-popper-tooltip@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-popper-tooltip/-/react-popper-tooltip-3.1.1.tgz#329569eb7b287008f04fcbddb6370452ad3f9eac"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-366

## Description

- Remove `is-react` as a dependency as it isn't used
- Remove the prop `isHtml` to Typography and component used `Typography` under the wood as this prop cannot be used because we have a function to prevent passing this prop to the component.
