### PR TITLE
MOON-326: Add auto-add search input for menus

### DIFF
--- a/src/components/Dropdown/Dropdown.spec.js
+++ b/src/components/Dropdown/Dropdown.spec.js
@@ -95,4 +95,53 @@ describe('Dropdown', () => {
         userEvent.click(screen.getByRole('dropdown'));
         expect(screen.queryAllByRole('checkbox')).not.toHaveLength(0);
     });
+
+    it('should show search input when autoSearch is enabled (hasSearch=undefined) and exceeds limit', () => {
+        let dData = dropdownData;
+        render(
+            <Dropdown data={dData} data-testid="moonstone-dropdown"/>
+        );
+        expect(dropdownData.length).toBeGreaterThan(7); // Triggers auto-adding search input
+        userEvent.click(screen.getByRole('dropdown'));
+        expect(screen.queryByRole('search')).toBeInTheDocument();
+    });
+
+    it('should not show search input when autoSearch is enabled (hasSearch=undefined) and does not exceed limit', () => {
+        let dData = dropdownData.slice(0, 7);
+        render(
+            <Dropdown data={dData} data-testid="moonstone-dropdown"/>
+        );
+        expect(dData.length).toBeLessThanOrEqual(7); // Does not trigger auto-adding search input
+        userEvent.click(screen.getByRole('dropdown'));
+        expect(screen.queryByRole('search')).not.toBeInTheDocument();
+    });
+
+    it('should show search input when autoSearch is enabled (hasSearch=undefined) and exceeds specified limit', () => {
+        let limit = 4;
+        let dData = dropdownData.slice(0, limit + 1);
+        render(
+            <Dropdown data={dData} data-testid="moonstone-dropdown" autoAddSearchLimit={limit}/>
+        );
+        expect(dropdownData.length).toBeGreaterThan(limit); // Triggers auto-adding search input
+        userEvent.click(screen.getByRole('dropdown'));
+        expect(screen.queryByRole('search')).toBeInTheDocument();
+    });
+
+    it('should show search input when hasSearch is enabled', () => {
+        let dData = dropdownData.slice(0, 3);
+        render(
+            <Dropdown hasSearch data={dData} data-testid="moonstone-dropdown"/>
+        );
+        userEvent.click(screen.getByRole('dropdown'));
+        expect(screen.queryByRole('search')).toBeInTheDocument();
+    });
+
+    it('should not show search input when hasSearch is disabled', () => {
+        let dData = dropdownData;
+        render(
+            <Dropdown data={dData} data-testid="moonstone-dropdown" hasSearch={false}/>
+        );
+        userEvent.click(screen.getByRole('dropdown'));
+        expect(screen.queryByRole('search')).toBeInTheDocument();
+    });
 });

--- a/src/components/Dropdown/Dropdown.spec.js
+++ b/src/components/Dropdown/Dropdown.spec.js
@@ -142,6 +142,6 @@ describe('Dropdown', () => {
             <Dropdown data={dData} data-testid="moonstone-dropdown" hasSearch={false}/>
         );
         userEvent.click(screen.getByRole('dropdown'));
-        expect(screen.queryByRole('search')).toBeInTheDocument();
+        expect(screen.queryByRole('search')).not.toBeInTheDocument();
     });
 });

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -44,6 +44,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
     size = DropdownSizes.Medium,
     icon,
     hasSearch = false,
+    autoAddSearchLimit = 7,
     searchEmptyText = 'No results found.',
     imageSize,
     onClear,
@@ -259,6 +260,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
                     maxHeight={menuMaxHeight}
                     anchorEl={anchorEl}
                     hasSearch={hasSearch}
+                    autoAddSearchLimit={autoAddSearchLimit}
                     searchEmptyText={searchEmptyText}
                     handleKeyPress={handleKeyPress}
                     handleSelect={handleSelect}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -43,7 +43,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
     variant = DropdownVariants.Ghost,
     size = DropdownSizes.Medium,
     icon,
-    hasSearch = false,
+    hasSearch,
     autoAddSearchLimit = 7,
     searchEmptyText = 'No results found.',
     imageSize,

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -97,7 +97,7 @@ export type DropdownProps = {
      * Autosearch is when search input is automatically added in the dropdown when autoAddSearchLimit is reached
      * @see autoAddSearchLimit
      */
-    hasSearch?: boolean | undefined;
+    hasSearch?: boolean;
 
     /**
      * Autosearch is triggered when data items exceed this limit

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -93,8 +93,19 @@ export type DropdownProps = {
 
     /**
      * Whether the Menu within the Dropdown has a search input
+     * Autosearch is enabled if undefined
+     * Autosearch is when search input is automatically added in the dropdown when autoAddSearchLimit is reached
+     * @see autoAddSearchLimit
      */
-    hasSearch?: boolean;
+    hasSearch?: boolean | undefined;
+
+    /**
+     * Autosearch is triggered when data items exceed this limit
+     * Applies only when autosearch is enabled (i.e. hasSearch is undefined)
+     * Defaults to 7 if undefined or < 0
+     * Autosearch is when search input is automatically added in the dropdown
+     */
+    autoAddSearchLimit?: number;
 
     /**
      * The text to display if the Dropdown Menu has a search input and the search doesn't have any results

--- a/src/components/Dropdown/DropdownMenu.tsx
+++ b/src/components/Dropdown/DropdownMenu.tsx
@@ -12,6 +12,7 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
     maxHeight,
     anchorEl,
     hasSearch,
+    autoAddSearchLimit = 7,
     searchEmptyText,
     data,
     value,
@@ -78,6 +79,7 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
             maxHeight={maxHeight}
             anchorEl={anchorEl}
             hasSearch={hasSearch}
+            autoAddSearchLimit={autoAddSearchLimit}
             searchEmptyText={searchEmptyText}
             onClose={onClose}
         >

--- a/src/components/Dropdown/DropdownMenu.tsx
+++ b/src/components/Dropdown/DropdownMenu.tsx
@@ -12,7 +12,7 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
     maxHeight,
     anchorEl,
     hasSearch,
-    autoAddSearchLimit = 7,
+    autoAddSearchLimit,
     searchEmptyText,
     data,
     value,

--- a/src/components/Dropdown/DropdownMenu.types.tsx
+++ b/src/components/Dropdown/DropdownMenu.types.tsx
@@ -10,6 +10,7 @@ export type DropdownMenuProps = {
     anchorEl?: React.MutableRefObject<HTMLDivElement>;
     anchorPosition?: AnchorPosition;
     hasSearch?: boolean;
+    autoAddSearchLimit: number;
     searchInput?: string;
     searchEmptyText?: string;
     hasOverlay?: boolean;

--- a/src/components/Dropdown/TreeViewMenu.tsx
+++ b/src/components/Dropdown/TreeViewMenu.tsx
@@ -85,7 +85,7 @@ export const TreeViewMenu: React.FC<TreeViewMenuProps> = ({
     position,
     hasOverlay,
     hasSearch,
-    autoAddSearchLimit = 7,
+    autoAddSearchLimit,
     // SearchEmptyText,
     treeData,
     value,
@@ -216,6 +216,7 @@ export const TreeViewMenu: React.FC<TreeViewMenuProps> = ({
 /* eslint-disable react/default-props-match-prop-types */
 TreeViewMenu.defaultProps = {
     hasOverlay: true,
+    autoAddSearchLimit: 7,
     searchEmptyText: 'No results found.',
     position: 'fixed',
     anchorEl: null,

--- a/src/components/Dropdown/TreeViewMenu.tsx
+++ b/src/components/Dropdown/TreeViewMenu.tsx
@@ -216,7 +216,6 @@ export const TreeViewMenu: React.FC<TreeViewMenuProps> = ({
 /* eslint-disable react/default-props-match-prop-types */
 TreeViewMenu.defaultProps = {
     hasOverlay: true,
-    hasSearch: false,
     searchEmptyText: 'No results found.',
     position: 'fixed',
     anchorEl: null,

--- a/src/components/Dropdown/TreeViewMenu.tsx
+++ b/src/components/Dropdown/TreeViewMenu.tsx
@@ -58,6 +58,21 @@ const find = (predicate: (data: TreeViewData) => boolean, data: TreeViewData, op
     }
 };
 
+const flatten = (data: TreeViewData[]): TreeViewData[] => {
+    const res: TreeViewData[] = [];
+
+    const fn = (current: TreeViewData) => {
+        res.push(current);
+        if (current.children) {
+            current.children.forEach(fn);
+        }
+    };
+
+    data?.forEach?.(fn);
+
+    return res;
+};
+
 export const TreeViewMenu: React.FC<TreeViewMenuProps> = ({
     isDisplayed,
     minWidth,
@@ -70,6 +85,7 @@ export const TreeViewMenu: React.FC<TreeViewMenuProps> = ({
     position,
     hasOverlay,
     hasSearch,
+    autoAddSearchLimit = 7,
     // SearchEmptyText,
     treeData,
     value,
@@ -139,6 +155,11 @@ export const TreeViewMenu: React.FC<TreeViewMenuProps> = ({
         styleMenu.maxHeight = maxHeight;
     }
 
+    let hasAutoSearch: boolean = hasSearch;
+    if (typeof hasSearch === 'undefined') {
+        hasAutoSearch = flatten(treeData)?.length > autoAddSearchLimit;
+    }
+
     // ---
     // Render
     // ---
@@ -148,7 +169,7 @@ export const TreeViewMenu: React.FC<TreeViewMenuProps> = ({
                   className="moonstone-menu"
                   style={styleMenu}
             >
-                {hasSearch && (
+                {hasAutoSearch && (
                     <div className="moonstone-menu_searchInput">
                         <SearchInput
                             value={inputValue}

--- a/src/components/Dropdown/TreeViewMenu.types.ts
+++ b/src/components/Dropdown/TreeViewMenu.types.ts
@@ -24,6 +24,7 @@ export type TreeViewMenuProps = {
     transformElOrigin?: TransformElOrigin;
     position?: PositioningType;
     hasSearch?: boolean;
+    autoAddSearchLimit: number;
     searchInput?: string;
     searchEmptyText?: string;
     hasOverlay?: boolean;

--- a/src/components/Menu/Menu.spec.js
+++ b/src/components/Menu/Menu.spec.js
@@ -62,4 +62,64 @@ describe('Menu', () => {
         );
         expect(screen.getByTestId('moonstone-menuItem')).toHaveClass('test-custom-class');
     });
+
+    it('should show search input when autoSearch is enabled (hasSearch=undefined) and exceeds limit', () => {
+        render(
+            <Menu isDisplayed data-testid="moonstone-menu">
+                <MenuItem label="Item1"/>
+                <MenuItem label="Item2"/>
+                <MenuItem label="Item3"/>
+                <MenuItem label="Item4"/>
+                <MenuItem label="Item5"/>
+                <MenuItem label="Item6"/>
+                <MenuItem label="Item7"/>
+                <MenuItem label="Item8"/>
+            </Menu>
+        );
+        expect(screen.queryByRole('search')).toBeInTheDocument();
+    });
+
+    it('should not show search input when autoSearch is enabled (hasSearch=undefined) and does not exceed limit', () => {
+        render(
+            <Menu isDisplayed data-testid="moonstone-menu">
+                <MenuItem label="Item1"/>
+                <MenuItem label="Item2"/>
+                <MenuItem label="Item3"/>
+            </Menu>
+        );
+        expect(screen.queryByRole('search')).not.toBeInTheDocument();
+    });
+
+    it('should show search input when autoSearch is enabled (hasSearch=undefined) and exceeds specified limit', () => {
+        render(
+            <Menu isDisplayed data-testid="moonstone-menu" autoAddSearchLimit={2}>
+                <MenuItem label="Item1"/>
+                <MenuItem label="Item2"/>
+                <MenuItem label="Item3"/>
+            </Menu>
+        );
+        expect(screen.queryByRole('search')).toBeInTheDocument();
+    });
+
+    it('should show search input when hasSearch is enabled', () => {
+        render(
+            <Menu isDisplayed hasSearch data-testid="moonstone-menu">
+                <MenuItem label="Item1"/>
+                <MenuItem label="Item2"/>
+                <MenuItem label="Item3"/>
+            </Menu>
+        );
+        expect(screen.queryByRole('search')).toBeInTheDocument();
+    });
+
+    it('should not show search input when hasSearch is disabled', () => {
+        render(
+            <Menu isDisplayed hasSearch={false} data-testid="moonstone-menu">
+                <MenuItem label="Item1"/>
+                <MenuItem label="Item2"/>
+                <MenuItem label="Item3"/>
+            </Menu>
+        );
+        expect(screen.queryByRole('search')).not.toBeInTheDocument();
+    });
 });

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -39,6 +39,7 @@ export const Menu: React.FC<MenuProps> = ({
     onExited,
     hasOverlay,
     hasSearch,
+    autoAddSearchLimit = 7,
     searchEmptyText,
     ...props
 }) => {
@@ -74,6 +75,11 @@ export const Menu: React.FC<MenuProps> = ({
 
     if (!children || React.Children.count(children) < 1) {
         return null;
+    }
+
+    let hasAutoSearch = hasSearch;
+    if (typeof hasSearch === 'undefined') {
+        hasAutoSearch = React.Children.count(children) > autoAddSearchLimit;
     }
 
     // ---
@@ -115,7 +121,7 @@ export const Menu: React.FC<MenuProps> = ({
                 onMouseLeave={onMouseLeave}
                 {...props}
             >
-                { hasSearch && (
+                { hasAutoSearch && (
                     <div className="moonstone-menu_searchInput">
                         <SearchInput
                             focusOnField

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -39,7 +39,7 @@ export const Menu: React.FC<MenuProps> = ({
     onExited,
     hasOverlay,
     hasSearch,
-    autoAddSearchLimit = 7,
+    autoAddSearchLimit,
     searchEmptyText,
     ...props
 }) => {
@@ -167,6 +167,7 @@ export const Menu: React.FC<MenuProps> = ({
 /* eslint-disable react/default-props-match-prop-types */
 Menu.defaultProps = {
     hasOverlay: true,
+    autoAddSearchLimit: 7,
     searchEmptyText: 'No results found.',
     position: 'fixed',
     anchorEl: null,

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -167,7 +167,6 @@ export const Menu: React.FC<MenuProps> = ({
 /* eslint-disable react/default-props-match-prop-types */
 Menu.defaultProps = {
     hasOverlay: true,
-    hasSearch: false,
     searchEmptyText: 'No results found.',
     position: 'fixed',
     anchorEl: null,

--- a/src/components/Menu/Menu.types.ts
+++ b/src/components/Menu/Menu.types.ts
@@ -75,8 +75,19 @@ export type MenuProps = {
 
     /**
      * Whether the Menu displays a search input at the top
+     * Autosearch is enabled if undefined
+     * Autosearch is when search input is automatically added in the dropdown when autoAddSearchLimit is reached
+     * @see autoAddSearchLimit
      */
     hasSearch?: boolean;
+
+    /**
+     * Autosearch is triggered when data items exceed this limit
+     * Applies only when autosearch is enabled (i.e. hasSearch is undefined)
+     * Defaults to 7 if undefined or < 0
+     * Autosearch is when search input is automatically added in the dropdown
+     */
+    autoAddSearchLimit?: number;
 
     /**
      * Text to display when the search doesn't show any results


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-326

## Description

Add logic to be able to auto-add search input when `hasSearch=undefined`, and be able to specify limit when auto-add search input is triggered

## Tests

The following are included in this PR

- [ ] Unit Test skeleton

## Checklist

<!--
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics.
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

- [ ] All files present (component - md - scss - spec - stories)
- [ ] All props ok and documented (propTypes or typescript types)
- [ ] Required props, default values, variants and colors
- [ ] Example in storybook
- [ ] Reversed style (light/dark mode)
- [ ] Allows custom props

## Documentation

<!--
Indicate if you have been writing documentation has part of this change.
-->

- [ ] README documentation (specification of the component, responsiveness, dependencies on other components, states, behaviours, animations, accessibility)
- [ ] Design mockups (figma - where/when/how the component should be used)
