### PR TITLE
MOON-406: Set SecondaryNav min-width to 300px

### DIFF
--- a/src/components/SecondaryNav/SecondaryNav.tsx
+++ b/src/components/SecondaryNav/SecondaryNav.tsx
@@ -37,11 +37,11 @@ export const SecondaryNav: React.FC<SecondaryNavProps> = ({
             }
             enable={['right']}
             size={isVisible ? null : {height: '0%', width: 0}}
-            minWidth={isVisible ? 245 : 0}
+            minWidth={isVisible ? 300 : 0}
             maxWidth="900"
             defaultSize={{
                 height: '0%',
-                width: '245px'
+                width: '300px'
             }}
             {...props}
         >


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-406

## Description

- Set the default with of the SecondaryNav to 300px
- Set the minimum size when resizing the SecondaryNav to 300px
