### PR TITLE
MOON-408: Improve button loading state

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -89,15 +89,9 @@ $button-size_big: 32px;
 
 .moonstone-button_loading {
     position: relative;
-
-    pointer-events: none;
-
-    > :not(.moonstone-button_loader) {
-        visibility: hidden;
-    }
 }
 
-.moonstone-loader.moonstone-button_loader {
+.moonstone-button .moonstone-button_loaderOverlay {
     position: absolute;
     top: 50%;
     left: 50%;
@@ -105,4 +99,9 @@ $button-size_big: 32px;
     fill: var(--color-white);
 
     transform: translate(-50%, -50%);
+
+    // Hide siblings of the loader when it displays as overlay (Typography, iconEnd)
+    ~ * {
+        visibility: hidden;
+    }
 }

--- a/src/components/Button/Button.spec.js
+++ b/src/components/Button/Button.spec.js
@@ -57,9 +57,27 @@ describe('Button', () => {
         expect(screen.getByTestId('moonstone-button')).toBeDisabled();
     });
 
-    it('should display a spinner when the button is loading', () => {
+    it('should display a loader when no icon is provided', () => {
         render(<Button isLoading data-testid="moonstone-button" label="test me"/>);
         expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    it('should display loader when an icon is provided', () => {
+        render(<Button isLoading icon={<Love/>} label="test me"/>);
+        expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    it('should prevent click when the button is loading', () => {
+        const onClick = jest.fn();
+        render(<Button isLoading data-testid="moonstone-button" label="test me" onClick={onClick}/>);
+
+        userEvent.click(screen.getByTestId('moonstone-button'));
+        expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('should not display icon when the button is loading', () => {
+        render(<Button isLoading icon={<Love data-testid="moonstone-buttonIcon"/>} label="test me"/>);
+        expect(screen.queryByTestId('moonstone-buttonIcon')).not.toBeInTheDocument();
     });
 
     test.each(buttonVariants)('should use the specified variant %s', variant => {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -53,12 +53,14 @@ export const Button = ({
                 className
             )}
             type="button"
-            disabled={isDisabled}
+            disabled={isDisabled || isLoading}
             onClick={e => handleOnClick(e)}
             {...props}
         >
-            {isLoading && <Loader size="small" isReversed={LoaderReversed} className={clsx('moonstone-button_loader')}/>}
-            {icon && <icon.type {...icon.props} size={(size === 'big') ? 'default' : size}/>}
+            {/* Display icon when an icon is provided */}
+            {icon && !isLoading && <icon.type {...icon.props} size={(size === 'big') ? 'default' : size}/>}
+            {/* When the button has an icon the loader replaces the icon otherwise we display the loader as overlay */}
+            {isLoading && <Loader size="small" isReversed={LoaderReversed} className={clsx({'moonstone-button_loaderOverlay': !icon})}/>}
             {label && (
                 <Typography
                     isNowrap


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-408

## Description
- When the button `isLoading`  with an icon the `Loader` is displayed instead of the icon
- When the button doesn't have an icon provided the `Loader` is displayed as overlay. The label is hidden. (same as we currently have)
- When the button `isLoading` the button is disabled to prevent `:hover`, `:active`, `:focus` style and click event
- Add tests to fit the new behavior