### PR TITLE
BACKLOG-21345: Add data attribute for tree item depth

### DIFF
--- a/src/components/TreeView/ControlledTreeView.tsx
+++ b/src/components/TreeView/ControlledTreeView.tsx
@@ -109,6 +109,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
                         'aria-expanded': isOpen,
                         'aria-busy': isLoading,
                         'aria-current': isHighlighted ? 'page' : null,
+                        'data-treeItem-depth': depth,
                         key: `${depth}-${node.id}`,
                         style: {'--treeItem-depth': depth},
                         ...node.treeItemProps

--- a/src/components/TreeView/ControlledTreeView.tsx
+++ b/src/components/TreeView/ControlledTreeView.tsx
@@ -109,7 +109,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
                         'aria-expanded': isOpen,
                         'aria-busy': isLoading,
                         'aria-current': isHighlighted ? 'page' : null,
-                        'data-treeItem-depth': depth,
+                        'aria-level': depth,
                         key: `${depth}-${node.id}`,
                         style: {'--treeItem-depth': depth},
                         ...node.treeItemProps

--- a/src/components/TreeView/TreeView.spec.tsx
+++ b/src/components/TreeView/TreeView.spec.tsx
@@ -67,6 +67,14 @@ describe('TreeView', () => {
         expect(container.getElementsByClassName('reversed')).toBeTruthy();
     });
 
+    it('should have aria-level attribute', () => {
+        render(<TreeView openedItems={['A']} data={tree}/>);
+
+        expect(screen.getAllByRole('treeitem').length).toBe(2);
+        expect(screen.getAllByRole('treeitem')[0]).toHaveAttribute('aria-level', '0');
+        expect(screen.getAllByRole('treeitem')[1]).toHaveAttribute('aria-level', '1');
+    });
+
     it('should select item set with selectedItems', () => {
         render(<TreeView data={tree} selectedItems={['A']}/>);
         expect(screen.getByRole('treeitem', {selected: true})).toHaveTextContent('A level1');


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21345

## Description

Ran into an issue trying to select tree item for a given tree depth using style attribute.

Add a dedicated data attribute for specifying tree item depth to simplify css attribute selection.

Related PR context: https://github.com/Jahia/jcontent/pull/1129#issuecomment-1863466587