### PR TITLE
BACKLOG-22393: Allow variable image sizes for Dropdown

### DIFF
--- a/src/components/ListItem/ListItem.scss
+++ b/src/components/ListItem/ListItem.scss
@@ -10,27 +10,25 @@ $big-image-size: 96px;
 
     list-style: none;
 
-    .moonstone-listItem-image_small {
-        flex: 0 0 $small-image-size;
-        height: $small-image-size;
+    .moonstone-listItem-image {
         margin-right: var(--spacing-small);
 
         img {
-            max-width: $small-image-size;
-            max-height: 100%;
             margin: auto;
         }
     }
 
-    .moonstone-listItem-image_big {
-        flex: 0 0 $big-image-size;
-        height: $big-image-size;
-        margin-right: var(--spacing-small);
+    .moonstone-listItem-image_small {
+        img {
+            max-width: $small-image-size;
+            max-height: $small-image-size;
+        }
+    }
 
+    .moonstone-listItem-image_big {
         img {
             max-width: $big-image-size;
-            max-height: 100%;
-            margin: auto;
+            max-height: $big-image-size;
         }
     }
 }

--- a/src/components/ListItem/ListItem.scss
+++ b/src/components/ListItem/ListItem.scss
@@ -13,23 +13,19 @@ $big-image-size: 96px;
     .moonstone-listItem-image {
         margin-right: var(--spacing-small);
 
-        img {
+        & > * {
             margin: auto;
         }
     }
 
-    .moonstone-listItem-image_small {
-        img {
-            max-width: $small-image-size;
-            max-height: $small-image-size;
-        }
+    .moonstone-listItem-image_small > * {
+        max-width: $small-image-size;
+        max-height: $small-image-size;
     }
 
-    .moonstone-listItem-image_big {
-        img {
-            max-width: $big-image-size;
-            max-height: $big-image-size;
-        }
+    .moonstone-listItem-image_big > * {
+        max-width: $big-image-size;
+        max-height: $big-image-size;
     }
 }
 

--- a/src/components/ListItem/ListItem.spec.js
+++ b/src/components/ListItem/ListItem.spec.js
@@ -44,4 +44,9 @@ describe('ListItem', () => {
         userEvent.click(item);
         expect(handleClick).toBeCalled();
     });
+
+    it('should have default imageSize ', () => {
+        const {container} = render(<ListItem data-testid="moonstone-listItem" label="my label"/>);
+        expect(container.querySelector('.moonstone-listItem moonstone-listItem-image_small').exists()).toBeTruthy();
+    });
 });

--- a/src/components/ListItem/ListItem.spec.js
+++ b/src/components/ListItem/ListItem.spec.js
@@ -47,7 +47,7 @@ describe('ListItem', () => {
 
     it('should have default imageSize=small', () => {
         const Image = () => <img/>;
-        const {container} = render(<ListItem image={<Image/>}/>);
+        const {container} = render(<ListItem label="my label" image={<Image/>}/>);
         expect(container.querySelector('.moonstone-listItem-image_small')).toBeInTheDocument();
     });
 });

--- a/src/components/ListItem/ListItem.spec.js
+++ b/src/components/ListItem/ListItem.spec.js
@@ -45,8 +45,9 @@ describe('ListItem', () => {
         expect(handleClick).toBeCalled();
     });
 
-    it('should have default imageSize ', () => {
-        const {container} = render(<ListItem data-testid="moonstone-listItem" label="my label"/>);
-        expect(container.querySelector('.moonstone-listItem moonstone-listItem-image_small').exists()).toBeTruthy();
+    it('should have default imageSize=small', () => {
+        const Image = () => <img/>;
+        const {container} = render(<ListItem image={<Image/>}/>);
+        expect(container.querySelector('.moonstone-listItem-image_small')).toBeInTheDocument();
     });
 });

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -32,7 +32,7 @@ export const ListItem: React.FC<ListItemProps> = ({
             {...props}
         >
             {isDisplayImage && (
-                <figure className={clsx(`moonstone-listItem-image_${imageSize}`, 'flexRow', 'alignCenter')}>
+                <figure className={clsx(`moonstone-listItem-image moonstone-listItem-image_${imageSize}`, 'flexRow', 'alignCenter')}>
                     {image}
                 </figure>
             )}

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -11,7 +11,7 @@ export const ListItem: React.FC<ListItemProps> = ({
     iconEnd = null,
     tabIndex,
     image,
-    imageSize,
+    imageSize = 'small',
     className = '',
     typographyVariant = 'caption',
     iconSize = 'small',

--- a/src/components/ListItem/ListItem.types.ts
+++ b/src/components/ListItem/ListItem.types.ts
@@ -38,7 +38,7 @@ export type ListItemProps = {
     image?: React.ReactElement;
 
     /**
-     * If there's an image, it should be this size
+     * Sets pre-defined max height/width to image
      */
     imageSize?: 'small' | 'big';
 

--- a/src/components/ListItem/ListItem.types.ts
+++ b/src/components/ListItem/ListItem.types.ts
@@ -38,7 +38,7 @@ export type ListItemProps = {
     image?: React.ReactElement;
 
     /**
-     * Sets pre-defined max height/width to image
+     * Sets pre-defined max height/width to image; defaults to small
      */
     imageSize?: 'small' | 'big';
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22393

## Description

- Remove fixed categorical sizes and let image size dictate the height of the row and width of image, up to a max width/height.
- Fixed `.moonstone-listItem-image_undefined` classes and default imageSize to small if not specified