### PR TITLE
BACKLOG-22873 Stop propagation menu is opened

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -110,6 +110,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
     // Functions to handle events
     // ---
     const handleOpenMenu = (e: React.MouseEvent | React.KeyboardEvent) => {
+        e.stopPropagation();
         const dropdownWidth = (e.currentTarget as HTMLElement).offsetWidth;
         setMinWith(`${dropdownWidth < menuMinWidth ? menuMinWidth : dropdownWidth}px`);
         setAnchorEl(e.currentTarget);


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22873

## Description

Stop propagation menu is opened

We stop propagation for menu items but not the menu open button itself, which causes issues if dropdown ancestors have clicks on them.