### PR TITLE
MOON-447: Fix lint:scss error on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "test": "jest --ci --runInBand --coverage",
         "tdd": "jest --watch",
         "lint:js": "eslint --ext js,jsx,ts,tsx,json .",
-        "lint:scss": "stylelint './src/**/*.scss'",
+        "lint:scss": "stylelint ./src/**/*.scss",
         "lint": "yarn lint:js && yarn lint:scss",
         "lint:js:fix": "yarn lint:js --fix .",
         "lint:scss:fix": "yarn lint:scss --fix",


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/MOON-447

## Description

Fix lint:scss script error by removing single quotes on pattern in package.json