### PR TITLE
MOON-364: Fix contrast issue with dropdown description

### DIFF
--- a/src/components/ListItem/ListItem.scss
+++ b/src/components/ListItem/ListItem.scss
@@ -50,13 +50,13 @@ $big-image-size: 96px;
 
     max-width: inherit;
 
-    color: var(--color-gray60);
-
     white-space: normal;
 
-    overflow: hidden;
-
     text-overflow: ellipsis;
+
+    opacity: 0.6;
+
+    overflow: hidden;
 
     -webkit-box-orient: vertical;
 


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/MOON-364

## Description

Replace color property with opacity property in listItem_description style
