### PR TITLE
MOON-432: Migrate tests of Breadcrumb and BreadcrumbItem

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.spec.js
+++ b/src/components/Breadcrumb/Breadcrumb.spec.js
@@ -14,11 +14,11 @@ describe('Breadcrumb', () => {
 
     it('should display additional attributes', () => {
         render(
-            <Breadcrumb data-testid="breadcrumb" data-custom="test">
+            <Breadcrumb data-testid="breadcrumb" data-custom="extra">
                 <BreadcrumbItem label="item 1" onClick={() => null}/>
             </Breadcrumb>
         );
-        expect(screen.getByTestId('breadcrumb')).toHaveAttribute('data-custom', 'test');
+        expect(screen.getByTestId('breadcrumb')).toHaveAttribute('data-custom', 'extra');
     });
 
     it('should display nothing when the component has no children', () => {

--- a/src/components/Breadcrumb/Breadcrumb.spec.js
+++ b/src/components/Breadcrumb/Breadcrumb.spec.js
@@ -1,38 +1,38 @@
 import React from 'react';
 import {Breadcrumb, BreadcrumbItem} from '~/components';
-import {shallow} from 'component-test-utils-react';
+import {render, screen} from '@testing-library/react';
 
 describe('Breadcrumb', () => {
     it('should display additional className', () => {
-        const wrapper = shallow(
-            <Breadcrumb className="extra">
+        render(
+            <Breadcrumb data-testid="breadcrumb" className="extra">
                 <BreadcrumbItem label="item 1" onClick={() => null}/>
             </Breadcrumb>
         );
-        expect(wrapper.querySelector('.extra').exists()).toBeTruthy();
+        expect(screen.getByTestId('breadcrumb')).toHaveClass('extra');
     });
 
     it('should display additional attributes', () => {
-        const wrapper = shallow(
-            <Breadcrumb data-custom="test">
+        render(
+            <Breadcrumb data-testid="breadcrumb" data-custom="test">
                 <BreadcrumbItem label="item 1" onClick={() => null}/>
             </Breadcrumb>
         );
-        expect(wrapper.querySelector('[data-custom="test"]').exists()).toBeTruthy();
+        expect(screen.getByTestId('breadcrumb')).toHaveAttribute('data-custom', 'test');
     });
 
     it('should display nothing when the component has no children', () => {
-        const wrapper = shallow(<Breadcrumb/>);
-        expect(wrapper.html()).toEqual('');
+        render(<Breadcrumb/>);
+        expect(screen.queryByRole('breadcrumb-item')).not.toBeInTheDocument();
     });
 
     it('should display items', () => {
-        const wrapper = shallow(
+        render(
             <Breadcrumb>
                 <BreadcrumbItem label="item 1" onClick={() => null}/>
                 <BreadcrumbItem label="item 2" onClick={() => null}/>
             </Breadcrumb>
         );
-        expect(wrapper.html()).toContain('item 1');
+        expect(screen.getByText('item 1')).toBeInTheDocument();
     });
 });

--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.spec.js
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.spec.js
@@ -1,25 +1,25 @@
 import React from 'react';
 import {BreadcrumbItem} from '~/components';
-import {shallow} from 'component-test-utils-react';
+import {render, screen} from '@testing-library/react';
 
 describe('BreadcrumbItem', () => {
     it('should display additional className', () => {
-        const wrapper = shallow(<BreadcrumbItem className="extra" onClick={() => null}/>);
-        expect(wrapper.querySelector('.extra').exists()).toBeTruthy();
+        render(<BreadcrumbItem data-testid="breadcrumb-item" className="extra" onClick={() => null}/>);
+        expect(screen.getByTestId('breadcrumb-item')).toHaveClass('extra');
     });
 
     it('should display additional attributes', () => {
-        const wrapper = shallow(<BreadcrumbItem data-custom="test" onClick={() => null}/>);
-        expect(wrapper.querySelector('[data-custom="test"]').exists()).toBeTruthy();
+        render(<BreadcrumbItem data-testid="breadcrumb-item" data-custom="test" onClick={() => null}/>);
+        expect(screen.getByTestId('breadcrumb-item')).toHaveAttribute('data-custom', 'test');
     });
 
-    it('should enforce the right button\'s variant', () => {
-        const wrapper = shallow(<BreadcrumbItem variant="outlined" onClick={() => null}/>);
-        expect(wrapper.html()).toContain('ghost');
+    it('should enforce the ghost button\'s variant', () => {
+        render(<BreadcrumbItem data-testid="breadcrumb-item" variant="outlined" onClick={() => null}/>);
+        expect(screen.getByRole('button')).toHaveClass('moonstone-variant_ghost');
     });
 
-    it('should enforce the right button\'s size', () => {
-        const wrapper = shallow(<BreadcrumbItem size="big" onClick={() => null}/>);
-        expect(wrapper.html()).toContain('small');
+    it('should enforce the small button\'s size', () => {
+        render(<BreadcrumbItem data-testid="breadcrumb-item" size="big" onClick={() => null}/>);
+        expect(screen.getByRole('button')).toHaveClass('moonstone-size_small');
     });
 });

--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.spec.js
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.spec.js
@@ -9,8 +9,8 @@ describe('BreadcrumbItem', () => {
     });
 
     it('should display additional attributes', () => {
-        render(<BreadcrumbItem data-testid="breadcrumb-item" data-custom="test" onClick={() => null}/>);
-        expect(screen.getByTestId('breadcrumb-item')).toHaveAttribute('data-custom', 'test');
+        render(<BreadcrumbItem data-testid="breadcrumb-item" data-custom="extra" onClick={() => null}/>);
+        expect(screen.getByTestId('breadcrumb-item')).toHaveAttribute('data-custom', 'extra');
     });
 
     it('should enforce the ghost button\'s variant', () => {


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/MOON-432

## Description

Migrate tests of Breadcrumb and BreadcrumbItem from react component-test-utils to react testing-library