### PR TITLE
MOON-435: Migrate tests of ImgWrapper

### DIFF
--- a/src/components/ImgWrapper/ImgWrapper.spec.jsx
+++ b/src/components/ImgWrapper/ImgWrapper.spec.jsx
@@ -1,10 +1,25 @@
 import React from 'react';
-import {shallow} from 'component-test-utils-react';
+import {render, screen} from '@testing-library/react';
 import {ImgWrapper} from './ImgWrapper';
 
 describe('ImgWrapper', () => {
     it('should render', () => {
-        const img = shallow(<ImgWrapper src="https://toto.jahia.com" alt="toto face"/>);
-        expect(img.html()).toBe('<img src="https://toto.jahia.com" alt="toto face" class=" moonstone-icon moonstone-icon_default"/>');
+        render(<ImgWrapper src="https://toto.jahia.com"/>);
+        expect(screen.getByRole('img')).toHaveAttribute('src', 'https://toto.jahia.com');
+    });
+
+    it('should display alt attribute', () => {
+        render(<ImgWrapper src="https://toto.jahia.com" alt="extra"/>);
+        expect(screen.getByAltText('extra')).toBeInTheDocument();
+    });
+
+    it('should add extra className', () => {
+        render(<ImgWrapper data-testid="imgwrapper" src="https://toto.jahia.com" className="extra"/>);
+        expect(screen.getByTestId('imgwrapper')).toHaveClass('extra');
+    });
+
+    it('should add extra attribute', () => {
+        render(<ImgWrapper data-testid="imgwrapper" src="https://toto.jahia.com" data-custom="extra"/>);
+        expect(screen.getByTestId('imgwrapper')).toHaveAttribute('data-custom', 'extra');
     });
 });


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/MOON-435

## Description

Migrate tests of ImgWrapper from react component-test-utils to react testing-library