### PR TITLE
MOON-434: Migrate tests of GlobalStyle

### DIFF
--- a/src/components/GlobalStyle/GlobalStyle.spec.jsx
+++ b/src/components/GlobalStyle/GlobalStyle.spec.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import {shallow} from 'component-test-utils-react';
+import {render, screen} from '@testing-library/react';
 import {GlobalStyle} from './index';
 
 describe('GlobalStyle', () => {
     it('should not render anything', () => {
-        const wrapper = shallow(<GlobalStyle/>);
-        expect(wrapper.html()).toEqual('</>');
+        render(<GlobalStyle data-testid="global-style"/>);
+        expect(screen.queryByTestId('global-style')).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/MOON-XXX

## Description

Migrate tests of GlobalStyle from react component-test-utils to react testing-library