### PR TITLE
MOON-438: Migrate tests of SecondaryNav

### DIFF
--- a/src/components/SecondaryNav/SecondaryNav.spec.js
+++ b/src/components/SecondaryNav/SecondaryNav.spec.js
@@ -18,14 +18,15 @@ describe('SecondaryNav', () => {
         expect(screen.getByTestId('secondary-nav')).toHaveAttribute('data-custom', 'extra');
     });
 
-    it('should have .secondaryNav_hidden when the menu is hidden', () => {
+    it('should not be expanded when the menu is hidden', () => {
         render(<SecondaryNav data-testid="secondary-nav" isDefaultVisible={false}>content here</SecondaryNav>);
-        expect(screen.getByTestId('secondary-nav')).toHaveClass('moonstone-secondaryNav_hidden');
+        screen.debug();
+        expect(screen.getByTestId('secondary-nav')).toHaveAttribute('aria-expanded', 'false');
     });
 
-    it('should not have .secondaryNav_hidden when the menu is visible', () => {
+    it('should be expanded when the menu is visible', () => {
         render(<SecondaryNav data-testid="secondary-nav">content here</SecondaryNav>);
-        expect(screen.getByTestId('secondary-nav')).not.toHaveClass('moonstone-secondaryNav_hidden');
+        expect(screen.getByTestId('secondary-nav')).toHaveAttribute('aria-expanded', 'true');
     });
 
     it('should set width to zero when the menu is hidden', () => {
@@ -36,13 +37,13 @@ describe('SecondaryNav', () => {
     it('should show the navigation by clicking on expand button when the menu is hidden', () => {
         render(<SecondaryNav data-testid="secondary-nav" isDefaultVisible={false}>content here</SecondaryNav>);
         userEvent.click(screen.getByRole('button', {class: /moonstone-secondaryNav_buttonToggle/i}));
-        expect(screen.getByTestId('secondary-nav')).not.toHaveClass('moonstone-secondaryNav_hidden');
+        expect(screen.getByTestId('secondary-nav')).toHaveAttribute('aria-expanded', 'true');
     });
 
     it('should hide the navigation by clicking on expand button when the menu is visible', () => {
         render(<SecondaryNav data-testid="secondary-nav">content here</SecondaryNav>);
         userEvent.click(screen.getByRole('button', {class: /moonstone-secondaryNav_buttonToggle/i}));
-        expect(screen.getByTestId('secondary-nav')).toHaveClass('moonstone-secondaryNav_hidden');
+        expect(screen.getByTestId('secondary-nav')).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('should not throw error when there is no onToggled defined', () => {

--- a/src/components/SecondaryNav/SecondaryNav.spec.js
+++ b/src/components/SecondaryNav/SecondaryNav.spec.js
@@ -20,7 +20,6 @@ describe('SecondaryNav', () => {
 
     it('should not be expanded when the menu is hidden', () => {
         render(<SecondaryNav data-testid="secondary-nav" isDefaultVisible={false}>content here</SecondaryNav>);
-        screen.debug();
         expect(screen.getByTestId('secondary-nav')).toHaveAttribute('aria-expanded', 'false');
     });
 
@@ -35,27 +34,27 @@ describe('SecondaryNav', () => {
     });
 
     it('should show the navigation by clicking on expand button when the menu is hidden', () => {
-        render(<SecondaryNav data-testid="secondary-nav" isDefaultVisible={false}>content here</SecondaryNav>);
-        userEvent.click(screen.getByRole('button', {class: /moonstone-secondaryNav_buttonToggle/i}));
+        render(<SecondaryNav data-testid="secondary-nav" id="test" isDefaultVisible={false}>content here</SecondaryNav>);
+        userEvent.click(screen.getByRole('secondary-nav-control'));
         expect(screen.getByTestId('secondary-nav')).toHaveAttribute('aria-expanded', 'true');
     });
 
     it('should hide the navigation by clicking on expand button when the menu is visible', () => {
         render(<SecondaryNav data-testid="secondary-nav">content here</SecondaryNav>);
-        userEvent.click(screen.getByRole('button', {class: /moonstone-secondaryNav_buttonToggle/i}));
+        userEvent.click(screen.getByRole('secondary-nav-control'));
         expect(screen.getByTestId('secondary-nav')).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('should not throw error when there is no onToggled defined', () => {
         render(<SecondaryNav data-testid="secondary-nav">content here</SecondaryNav>);
         // No error should occur when there is no onClick defined
-        userEvent.click(screen.getByRole('button', {class: /moonstone-secondaryNav_buttonToggle/i}));
+        userEvent.click(screen.getByRole('secondary-nav-control'));
     });
 
     it('should call onToggled when clicking on expand button', () => {
         const clickHandler = jest.fn();
         render(<SecondaryNav onToggled={clickHandler}>content here</SecondaryNav>);
-        userEvent.click(screen.getByRole('button', {class: /moonstone-secondaryNav_buttonToggle/i}));
+        userEvent.click(screen.getByRole('secondary-nav-control'));
         expect(clickHandler).toHaveBeenCalled();
     });
 });

--- a/src/components/SecondaryNav/SecondaryNav.spec.js
+++ b/src/components/SecondaryNav/SecondaryNav.spec.js
@@ -1,77 +1,60 @@
 import React from 'react';
-import {shallow} from 'component-test-utils-react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {SecondaryNav} from './index';
 
 describe('SecondaryNav', () => {
     it('should display children content', () => {
-        const wrapper = shallow(
-            <SecondaryNav header="">
-                content here
-            </SecondaryNav>
-        );
-
-        expect(wrapper.html()).toContain('content here');
+        render(<SecondaryNav header="">content here</SecondaryNav>);
+        expect(screen.queryByText('content here')).toBeInTheDocument();
     });
     it('should display a string in the header', () => {
-        const wrapper = shallow(<SecondaryNav header="my header">hello</SecondaryNav>);
-
-        expect(wrapper.html()).toContain('my header');
+        render(<SecondaryNav header="my header">content here</SecondaryNav>);
+        expect(screen.queryByText('my header')).toBeInTheDocument();
     });
 
     it('should add extra attribute', () => {
-        const wrapper = shallow(<SecondaryNav data-custom="test" header="my header">hello</SecondaryNav>);
-
-        expect(wrapper.html()).toContain('data-custom="test"');
+        render(<SecondaryNav data-testid="secondary-nav" data-custom="extra">content here</SecondaryNav>);
+        expect(screen.getByTestId('secondary-nav')).toHaveAttribute('data-custom', 'extra');
     });
 
     it('should have .secondaryNav_hidden when the menu is hidden', () => {
-        const wrapper = shallow(<SecondaryNav header="my header" isDefaultVisible={false}>hello</SecondaryNav>);
-
-        expect(wrapper.html()).toContain('secondaryNav_hidden');
+        render(<SecondaryNav data-testid="secondary-nav" isDefaultVisible={false}>content here</SecondaryNav>);
+        expect(screen.getByTestId('secondary-nav')).toHaveClass('moonstone-secondaryNav_hidden');
     });
 
     it('should not have .secondaryNav_hidden when the menu is visible', () => {
-        const wrapper = shallow(<SecondaryNav header="my header">hello</SecondaryNav>);
-
-        expect(wrapper.html()).not.toContain('secondaryNav_hidden');
+        render(<SecondaryNav data-testid="secondary-nav">content here</SecondaryNav>);
+        expect(screen.getByTestId('secondary-nav')).not.toHaveClass('moonstone-secondaryNav_hidden');
     });
 
     it('should set width to zero when the menu is hidden', () => {
-        const wrapper = shallow(<SecondaryNav isDefaultVisible={false} header="my header">hello</SecondaryNav>);
-
-        expect(wrapper.props.size.width).toEqual(0);
+        render(<SecondaryNav data-testid="secondary-nav" isDefaultVisible={false}>content here</SecondaryNav>);
+        expect(screen.getByTestId('secondary-nav').style.width).toBe('0px');
     });
 
     it('should show the navigation by clicking on expand button when the menu is hidden', () => {
-        const wrapper = shallow(<SecondaryNav isDefaultVisible={false} header="my header">hello</SecondaryNav>);
-
-        wrapper.querySelector('.moonstone-secondaryNav_buttonToggle').dispatchEvent('click');
-        expect(wrapper.html()).not.toContain('moonstone-secondaryNav_hidden');
+        render(<SecondaryNav data-testid="secondary-nav" isDefaultVisible={false}>content here</SecondaryNav>);
+        userEvent.click(screen.getByRole('button', {class: /moonstone-secondaryNav_buttonToggle/i}));
+        expect(screen.getByTestId('secondary-nav')).not.toHaveClass('moonstone-secondaryNav_hidden');
     });
 
     it('should hide the navigation by clicking on expand button when the menu is visible', () => {
-        const wrapper = shallow(<SecondaryNav header="my header">hello</SecondaryNav>);
-
-        wrapper.querySelector('.moonstone-secondaryNav_buttonToggle').dispatchEvent('click');
-        expect(wrapper.html()).toContain('moonstone-secondaryNav_hidden');
+        render(<SecondaryNav data-testid="secondary-nav">content here</SecondaryNav>);
+        userEvent.click(screen.getByRole('button', {class: /moonstone-secondaryNav_buttonToggle/i}));
+        expect(screen.getByTestId('secondary-nav')).toHaveClass('moonstone-secondaryNav_hidden');
     });
 
     it('should not throw error when there is no onToggled defined', () => {
-        const wrapper = shallow(
-            <SecondaryNav header="my header">hello</SecondaryNav>
-        );
-
+        render(<SecondaryNav data-testid="secondary-nav">content here</SecondaryNav>);
         // No error should occur when there is no onClick defined
-        wrapper.querySelector('.moonstone-secondaryNav_buttonToggle').dispatchEvent('click');
+        userEvent.click(screen.getByRole('button', {class: /moonstone-secondaryNav_buttonToggle/i}));
     });
 
     it('should call onToggled when clicking on expand button', () => {
         const clickHandler = jest.fn();
-        const wrapper = shallow(
-            <SecondaryNav header="my header" onToggled={clickHandler}>hello</SecondaryNav>
-        );
-
-        wrapper.querySelector('.moonstone-secondaryNav_buttonToggle').dispatchEvent('click');
+        render(<SecondaryNav onToggled={clickHandler}>content here</SecondaryNav>);
+        userEvent.click(screen.getByRole('button', {class: /moonstone-secondaryNav_buttonToggle/i}));
         expect(clickHandler).toHaveBeenCalled();
     });
 });

--- a/src/components/SecondaryNav/SecondaryNav.tsx
+++ b/src/components/SecondaryNav/SecondaryNav.tsx
@@ -46,7 +46,10 @@ export const SecondaryNav: React.FC<SecondaryNavProps> = ({
             }}
             {...props}
         >
-            <button type="button"
+            <button
+                    aria-controls="moonstone-secondaryNav_wrapper"
+                    type="button"
+                    role="secondary-nav-control"
                     className={clsx(
                         'moonstone-secondaryNav_buttonToggle',
                         {'moonstone-secondaryNav_buttonToggle_reversed': isReversed}
@@ -59,7 +62,7 @@ export const SecondaryNav: React.FC<SecondaryNavProps> = ({
                     <ChevronDoubleRight/>}
             </button>
 
-            <div className={clsx('moonstone-secondaryNav_wrapper', 'flexFluid', 'flexCol_nowrap')}>
+            <div id="moonstone-secondaryNav_wrapper" className={clsx('moonstone-secondaryNav_wrapper', 'flexFluid', 'flexCol_nowrap')}>
                 {header}
                 <div className={clsx('flexFluid', 'flexCol_nowrap')}>
                     {children}

--- a/src/components/SecondaryNav/SecondaryNav.tsx
+++ b/src/components/SecondaryNav/SecondaryNav.tsx
@@ -23,6 +23,7 @@ export const SecondaryNav: React.FC<SecondaryNavProps> = ({
 
     return (
         <ResizableBox
+            aria-expanded={isVisible}
             className={
                 clsx(
                     className,


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/MOON-438

## Description

Migrate tests of SecondaryNav from react component-test-utils to react testing-library