### PR TITLE
MOON-478: Fix issue with long text in Header and Breadcrumb

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.scss
+++ b/src/components/Breadcrumb/Breadcrumb.scss
@@ -1,3 +1,8 @@
+.moonstone-breadcrumb {
+    max-width: 100%;
+    overflow: hidden;
+}
+
 .moonstone-breadcrumb_separator {
     color: var(--color-gray60);
 }

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -5,8 +5,6 @@ import {BreadcrumbProps} from './Breadcrumb.types';
 import {ChevronRight} from '~/icons';
 
 export const Breadcrumb: React.FC<BreadcrumbProps> = ({children, className, ...props}) => {
-    const classNames = clsx(className);
-
     const allItems = React.Children.toArray(children);
 
     if (!children || allItems.length < 1) {
@@ -14,7 +12,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({children, className, ...p
     }
 
     return (
-        <nav className={classNames} aria-label="breadcrumb" {...props}>
+        <nav className={clsx('moonstone-breadcrumb', className)} aria-label="breadcrumb" {...props}>
             <ol className={clsx('flexRow_nowrap', 'alignCenter')}>
                 {
                     allItems.map((item: React.ReactElement, index) => (

--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.scss
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.scss
@@ -1,5 +1,6 @@
 .moonstone-breadcrumbItem {
     min-width: 0;
+    max-width: 150px;
 
     & + & {
         margin-left: var(--spacing-small);

--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.stories.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.stories.tsx
@@ -52,6 +52,6 @@ export const WithIcons = {
 
     args: {
         icon: <Love/>,
-        label: 'beadcrumbItem'
+        label: 'breadcrumbItem'
     }
 };

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -2,6 +2,7 @@ $header-minHeight: 64px;
 $header-toolbar-minheight: 35px;
 
 .moonstone-header {
+    width: 100%;
     min-height: $header-minHeight;
     padding: var(--spacing-medium) var(--spacing-large) 0 var(--spacing-large);
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-478

## Description

- Fix truncation of the `title` in the `Header`
- Fix a `max-width` on `BreadcrumbItem` to prevent long text can break the interface
