### PR TITLE
MOON-479: Fix border styling

### DIFF
--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -35,6 +35,7 @@
     gap: $spacing-icon;
     padding: var(--spacing-nano) var(--spacing-small);
 
+    border: var(--border-selector_invisible);
     border-radius: var(--radius-selector);
     cursor: pointer;
 
@@ -62,8 +63,6 @@
 
     &:hover {
         color: var(--color-accent);
-
-        border: var(--border-selector_hover);
     }
 
     &:focus {
@@ -85,6 +84,10 @@
 
     border: var(--border-selector);
     background-color: var(--background-selector);
+
+    &:hover {
+        border: var(--border-selector_hover);
+    }
 
     &.moonstone-disabled {
         color: var(--color-gray);

--- a/src/components/Input/BaseInput/BaseInput.scss
+++ b/src/components/Input/BaseInput/BaseInput.scss
@@ -19,13 +19,17 @@ $min-width: 40px;
 
     cursor: text;
 
-    &:has(input:hover) {
-        border: var(--border-selector_hover);
+    &:not(:has(input:disabled), :has(input:read-only)) {
+        &:has(input:hover) {
+            border: var(--border-selector_hover);
+        }
+    
+        &:has(input:focus) {
+            border: var(--border-selector_focus);
+        }
     }
 
-    &:has(input:focus) {
-        border: var(--border-selector_focus);
-    }
+
 
     &:has(input:disabled) {
         background-color: var(--color-gray_light40);

--- a/src/components/Input/BaseInput/BaseInput.scss
+++ b/src/components/Input/BaseInput/BaseInput.scss
@@ -23,13 +23,11 @@ $min-width: 40px;
         &:has(input:hover) {
             border: var(--border-selector_hover);
         }
-    
+
         &:has(input:focus) {
             border: var(--border-selector_focus);
         }
     }
-
-
 
     &:has(input:disabled) {
         background-color: var(--color-gray_light40);

--- a/src/components/Textarea/Textarea.scss
+++ b/src/components/Textarea/Textarea.scss
@@ -37,7 +37,7 @@ $minHeight-size: 50px;
         &:hover {
             border: var(--border-selector_hover);
         }
-        
+
         &:focus {
             border: var(--border-selector_focus);
         }

--- a/src/components/Textarea/Textarea.scss
+++ b/src/components/Textarea/Textarea.scss
@@ -33,12 +33,14 @@ $minHeight-size: 50px;
         opacity: 1;
     }
 
-    &:hover {
-        border: var(--border-selector_hover);
-    }
-
-    &:focus {
-        border: var(--border-selector_focus);
+    &:not(:disabled, :read-only) {
+        &:hover {
+            border: var(--border-selector_hover);
+        }
+        
+        &:focus {
+            border: var(--border-selector_focus);
+        }
     }
 
     &:disabled {

--- a/src/globals/_variables.scss
+++ b/src/globals/_variables.scss
@@ -3,6 +3,7 @@
     --border-selector_hover: solid 1px var(--color-gray);
     --border-selector_focus: solid 1px var(--color-accent);
     --border-selector_active: solid 1px var(--color-accent);
+    --border-selector_invisible: solid 1px transparent;
     --background-selector: var(--color-white);
     --radius-selector: var(--radius_small);
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!--
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-479

## Description

- Fix the border style on the `Dropdown` component with `ghost` variant
- Prevent `:hover` and `:focus` styling on `disabled` and `read-only` components
