### PR TITLE
fix: spacing icon in the Chip component

### DIFF
--- a/src/components/Chip/Chip.scss
+++ b/src/components/Chip/Chip.scss
@@ -14,7 +14,7 @@
         opacity: 0.3;
     }
 
-    & > svg:not(:last-child) {
+    & > .moonstone-icon:not(:last-child) {
         margin-right: $spacing-icon;
     }
 }


### PR DESCRIPTION
When the icon was managed by a `img` instead of a `svg` the spacing between the icon and the text wasn't applied

