### PR TITLE
fix: hide consecutive separators

### DIFF
--- a/src/components/Separator/Separator.scss
+++ b/src/components/Separator/Separator.scss
@@ -7,7 +7,7 @@
     &.moonstone-invisible_onlyChild:only-child,
     &.moonstone-invisible_firstOrLastChild:first-child,
     &.moonstone-invisible_firstOrLastChild:last-child,
-    & + & {
+    &:has(+ &) {
         display: none;
     }
 }

--- a/src/components/Separator/Separator.spec.js
+++ b/src/components/Separator/Separator.spec.js
@@ -4,33 +4,33 @@ import {Separator} from './index';
 
 describe('Separator', () => {
     it('should display separator component', () => {
-        render(<Separator data-testid="separator"/>);
-        expect(screen.getByTestId('separator')).toBeInTheDocument();
+        render(<Separator/>);
+        expect(screen.getByRole('separator')).toBeInTheDocument();
     });
 
     it('should display horizontal separator by default', () => {
-        render(<Separator data-testid="separator"/>);
-        expect(screen.getByTestId('separator')).toHaveClass('moonstone-separator_horizontal');
+        render(<Separator/>);
+        expect(screen.getByRole('separator')).toHaveClass('moonstone-separator_horizontal');
     });
 
     it('should display vertical separator', () => {
-        render(<Separator data-testid="separator" variant="vertical"/>);
-        expect(screen.getByTestId('separator')).toHaveClass('moonstone-separator_vertical');
+        render(<Separator variant="vertical"/>);
+        expect(screen.getByRole('separator')).toHaveClass('moonstone-separator_vertical');
     });
 
     it('should set size props', () => {
-        render(<Separator data-testid="separator" size="medium"/>);
-        expect(screen.getByTestId('separator')).toHaveClass('moonstone-size_medium');
+        render(<Separator size="medium"/>);
+        expect(screen.getByRole('separator')).toHaveClass('moonstone-size_medium');
     });
 
     it('should set spacing props', () => {
-        render(<Separator data-testid="separator" spacing="medium"/>);
-        expect(screen.getByTestId('separator')).toHaveClass('moonstone-spacing_medium');
+        render(<Separator spacing="medium"/>);
+        expect(screen.getByRole('separator')).toHaveClass('moonstone-spacing_medium');
     });
 
     it('should add extra attribute', () => {
-        render(<Separator data-testid="separator" data-custom="extra"/>);
-        expect(screen.getByTestId('separator')).toHaveAttribute('data-custom', 'extra');
+        render(<Separator data-custom="extra"/>);
+        expect(screen.getByRole('separator')).toHaveAttribute('data-custom', 'extra');
     });
 
     it('should add extra classname', () => {
@@ -38,23 +38,24 @@ describe('Separator', () => {
         expect(screen.getByTestId('separator')).toHaveClass('extra');
     });
 
+    // TODO: It will be better to test if the element is visible or not with `toBeVisible` but it seems the style is not applied in the test environment
     it('should have the class invisible_firstChild', () => {
-        render(<Separator data-testid="separator" invisible="firstChild"/>);
-        expect(screen.getByTestId('separator')).toHaveClass('moonstone-invisible_firstChild');
+        render(<Separator invisible="firstChild"/>);
+        expect(screen.getByRole('separator')).toHaveClass('moonstone-invisible_firstChild');
     });
 
     it('should have the class invisible_lastChild', () => {
-        render(<Separator data-testid="separator" invisible="lastChild"/>);
-        expect(screen.getByTestId('separator')).toHaveClass('moonstone-invisible_lastChild');
+        render(<Separator invisible="lastChild"/>);
+        expect(screen.getByRole('separator')).toHaveClass('moonstone-invisible_lastChild');
     });
 
     it('should have the class invisible_onlyChild', () => {
-        render(<Separator data-testid="separator" invisible="onlyChild"/>);
-        expect(screen.getByTestId('separator')).toHaveClass('moonstone-invisible_onlyChild');
+        render(<Separator invisible="onlyChild"/>);
+        expect(screen.getByRole('separator')).toHaveClass('moonstone-invisible_onlyChild');
     });
 
     it('should have the class invisible_firstOrLastChild', () => {
-        render(<Separator data-testid="separator" invisible="firstOrLastChild"/>);
-        expect(screen.getByTestId('separator')).toHaveClass('moonstone-invisible_firstOrLastChild');
+        render(<Separator invisible="firstOrLastChild"/>);
+        expect(screen.getByRole('separator')).toHaveClass('moonstone-invisible_firstOrLastChild');
     });
 });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->


## Description

- Automatically hide first items when consecutive selectors are displayed
- Improve tests selector by using `getByRole` to be more semantic
- I don't find a way to test the new behavior because testing with `toBeVisible` is not working. It seems the `scss` is not applied in the test environment.
