### PR TITLE
chore: modify dependabot configuration to fit conventional commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,6 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: "production"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

modify dependabot configuration to fit conventional commit
