### PR TITLE
feat: improve the loading of tree items

### DIFF
--- a/src/components/TreeView/ControlledTreeView.tsx
+++ b/src/components/TreeView/ControlledTreeView.tsx
@@ -3,11 +3,11 @@ import clsx from 'clsx';
 import './TreeView.scss';
 import type {ControlledTreeViewProps, TreeViewData} from './TreeView.types';
 
-import {Loading, ChevronDown, ChevronRight, CheckboxChecked, CheckboxUnchecked} from '~/icons';
-import {Typography} from '~/components/Typography';
+import {ChevronDown, ChevronRight, CheckboxChecked, CheckboxUnchecked} from '~/icons';
+import {Typography, Loader} from '~/components';
 
 // Manage treeView_item's icon
-const displayIcon = (icon: React.ReactElement, size: string, className: string, parentHasIconStart = false) => {
+const displayIcon = (icon: React.ReactElement, size: string, className?: string, parentHasIconStart = false) => {
     if (!icon && !parentHasIconStart) {
         return;
     }
@@ -18,13 +18,6 @@ const displayIcon = (icon: React.ReactElement, size: string, className: string, 
             <icon.type {...icon.props} size={size}/>}
         </i>
     );
-};
-
-// Manage if we display icon or loading
-const displayIconOrLoading = (icon: React.ReactElement, isLoading: boolean) => {
-    const i = isLoading ? <Loading size="big" className="moonstone-icon_isLoading"/> : icon;
-
-    return displayIcon(i, 'default', 'moonstone-treeView_itemIconEnd');
 };
 
 const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElement, ControlledTreeViewProps> = (
@@ -51,6 +44,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
         return nodeData.map(node => {
             const hasChild = Boolean(node.hasChildren || (node.children && node.children.length !== 0));
             const hasIconStart = Boolean(node.iconStart);
+            const hasIconEnd = Boolean(node.iconEnd);
             const isClosable = Boolean(node.isClosable !== false);
             const isOpen = Boolean(openedItems.includes(node.id)) || !isClosable;
             const isLoading = Boolean(node.isLoading);
@@ -123,7 +117,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
                                 className={clsx('flexRow', 'alignCenter', 'moonstone-treeView_itemToggle')}
                                 onClick={toggleNode}
                             >
-                                {isOpen ? <ChevronDown size={size}/> : <ChevronRight size={size}/>}
+                                {isLoading ? <Loader isReversed={isReversed} size="small"/> : isOpen ? <ChevronDown size={size}/> : <ChevronRight size={size}/>}
                             </div>
                         )}
                         {!isFlatData && !hasChild &&
@@ -147,7 +141,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
                             >
                                 {node.label}
                             </Typography>
-                            {displayIconOrLoading(node.iconEnd, isLoading)}
+                            {hasIconEnd && displayIcon(node.iconEnd, 'small')}
                         </div>
                     </div>
                 ),

--- a/src/components/TreeView/TreeView.spec.tsx
+++ b/src/components/TreeView/TreeView.spec.tsx
@@ -57,11 +57,6 @@ describe('TreeView', () => {
         expect(screen.getAllByRole('treeitem')[0]).toHaveAttribute('aria-busy', 'true');
     });
 
-    it('should not display iconEnd if node is loading', () => {
-        render(<TreeView data={[{...tree[0], isLoading: true}]}/>);
-        expect(screen.queryByTestId('test-iconEnd')).not.toBeInTheDocument();
-    });
-
     it('should add specific class if TreeView is reversed', () => {
         const {container} = render(<TreeView isReversed data={tree}/>);
         expect(container.getElementsByClassName('reversed')).toBeTruthy();

--- a/src/components/TreeView/TreeView.stories.jsx
+++ b/src/components/TreeView/TreeView.stories.jsx
@@ -2,7 +2,6 @@ import React, {useState} from 'react';
 
 import {TreeView} from './index';
 import {treeData, treeDataFlat} from '~/data';
-import {Love, NoCloud} from '~/icons';
 
 import markdownNotes from './TreeView.md';
 

--- a/src/components/TreeView/TreeView.stories.jsx
+++ b/src/components/TreeView/TreeView.stories.jsx
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 
 import {TreeView} from './index';
 import {treeData, treeDataFlat} from '~/data';
+import {Love, NoCloud} from '~/icons';
 
 import markdownNotes from './TreeView.md';
 
@@ -78,7 +79,7 @@ export const Highlight = {
         <TreeView
             data={treeData}
             isReversed={theme === 'dark'}
-            highlightedItem="A"
+            highlightedItems={['A']}
             {...args}
         />
     )


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description
Improve the loading of the tree:
- Use the `Loader` component instead of an icon with a spin animation
- The loader is now shown instead of the chevron, as it is the element clicked to trigger the opening.

## Tests

The following are included in this PR

- [X] Unit Tests
- [ ] Accessibility is OK