### PR TITLE
feat: Adjust padding depending on flatness of data and flag value

### DIFF
--- a/src/components/TreeView/ControlledTreeView.tsx
+++ b/src/components/TreeView/ControlledTreeView.tsx
@@ -36,7 +36,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
         component = 'ul',
         itemComponent = 'li',
         size = 'default',
-        padFlatData = false,
+        isPadVirtualizedRow = false,
         ...props
     }, ref) => {
     const isFlatData = data.filter(item => item.children && item.children.length > 0).length === 0;
@@ -124,7 +124,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
                         {!isFlatData && !hasChild &&
                             <div className={clsx('flexRow', 'alignCenter', 'moonstone-treeView_itemToggle')}/>}
 
-                        {padFlatData && isFlatData && !isClosable &&
+                        {isPadVirtualizedRow && isFlatData && !isClosable &&
                             <div className={clsx('flexRow', 'alignCenter', 'moonstone-treeView_itemToggle')}/>}
 
                         {/* TreeViewItem */}

--- a/src/components/TreeView/TreeView.types.ts
+++ b/src/components/TreeView/TreeView.types.ts
@@ -69,9 +69,9 @@ type BasicTreeViewProps = {
      */
     size?: 'small' | 'default';
     /**
-     * Adds padding even if data is flat
+     * When using virtualization row may require padding if they become detached from its parent
      */
-    padFlatData?: boolean
+    isPadVirtualizedRow?: boolean
 };
 
 type ControlledProps = {


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description

Adjust padding depending on flatness of data and flag value.

Allow to have padded tree even if dataset is flat.

Allow to propagate styles from treeItemProps.


## Tests

The following are included in this PR

- [ ] Unit Tests
- [ ] Accessibility is OK


## Checklist
<!--
This section contains a set of non-automated checks; it serves to remind you to consider some business-critical topics.
 - If any are not applicable, they can simply be deleted.
 - If you need to provide more details, please use the description section.
-->

- [ ] All files present (component - scss - spec - stories)
- [ ] All props ok and documented (typescript types)
- [ ] Required props, default values, variants and colors
- [ ] Example in storybook
- [ ] Reversed style (light/dark mode)
- [ ] Allows custom props
