### PR TITLE
fix: color issues with last moonstone release

### DIFF
--- a/src/components/Button/variants/_default.scss
+++ b/src/components/Button/variants/_default.scss
@@ -66,6 +66,8 @@
         }
 
         &:disabled {
+            color: inherit;
+
             border-color: var(--color-gray_light);
             background-color: var(--color-gray_light);
         }
@@ -87,6 +89,8 @@
         }
 
         &:disabled {
+            color: inherit;
+
             border-color: var(--color-gray_light);
             background-color: var(--color-gray_light);
         }

--- a/src/components/ButtonGroup/ButtonGroup.scss
+++ b/src/components/ButtonGroup/ButtonGroup.scss
@@ -19,22 +19,22 @@
     }
 
     // Manage separator
-    .moonstone-variant_default {
-        & + .moonstone-variant_default {
+    .moonstone-button {
+        & + .moonstone-button {
             border-left-color: transparent;
         }
 
-        &.moonstone-color_accent,
-        &.moonstone-color_danger {
-            + .moonstone-color_accent,
-            + .moonstone-color_danger {
+        &.moonstone-button_accent,
+        &.moonstone-button_danger {
+            + .moonstone-button_accent,
+            + .moonstone-button_danger {
                 margin-left: 1px;
             }
         }
     }
 
-    .moonstone-variant_outlined {
-        & + .moonstone-variant_outlined {
+    .moonstone-button_outlined {
+        & + .moonstone-button_outlined {
             border-left-color: transparent;
         }
     }

--- a/src/components/ButtonGroup/ButtonGroup.spec.js
+++ b/src/components/ButtonGroup/ButtonGroup.spec.js
@@ -36,8 +36,8 @@ describe('ButtonGroup', () => {
                 <Button label="One" onClick={() => null}/>
             </ButtonGroup>
         );
-        expect(screen.getByRole('group').firstChild).toHaveClass('moonstone-color_accent');
-        expect(screen.getByRole('group').lastChild).toHaveClass('moonstone-color_accent');
+        expect(screen.getByRole('group').firstChild).toHaveClass('moonstone-button_accent');
+        expect(screen.getByRole('group').lastChild).toHaveClass('moonstone-button_accent');
     });
 
     it('should pass size to buttons', () => {

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -30,10 +30,7 @@ export const Default: StoryObj<ButtonGroupProps> = {
     ),
 
     args: {
-        variant: 'default',
-        color: 'default',
-        size: 'big',
-        isReversed: false
+        size: 'big'
     }
 };
 

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -40,10 +40,6 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = ({
                             variant={variant}
                             isReversed={isReversed}
                             color={color}
-                            className={clsx(
-                                `moonstone-variant_${variant}`,
-                                `moonstone-color_${color}`
-                            )}
                         />
                     );
                 })

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -56,9 +56,9 @@
         outline: none;
     }
 
-    &:hover:not(.moonstone-disabled) {
-        color: var(--color-accent);
-    }
+    // &:hover:not(.moonstone-disabled) {
+    //     color: var(--color-accent);
+    // }
 
     &:not(.moonstone-filled) .moonstone-dropdown_label {
         font-style: italic;

--- a/src/globals/_variants.scss
+++ b/src/globals/_variants.scss
@@ -1,6 +1,6 @@
 // Default style
 %variant_ghost {
-    color: var(--color-gray_dark);
+    // color: var(--color-gray_dark);
 
     border: 1px solid transparent;
 
@@ -80,6 +80,10 @@
         background-color: var(--color-accent_dark);
     }
 
+    &:disabled {
+        color: inherit;
+    }
+
     &.moonstone-reverse {
         &:hover:not(:disabled) {
             color: var(--color-white);
@@ -124,6 +128,10 @@
         color: var(--color-white);
 
         background-color: var(--color-danger);
+    }
+
+    &:disabled {
+        color: inherit;
     }
 
     &.moonstone-reverse {


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description

- Fix color contrast when button is `:disabled`
- Fix the borders button when used in `ButtonGroup`
- Fix color when `Dropdown` is used in reversed context


## Tests

The following are included in this PR

- [X] Unit Tests
- [X] Accessibility is OK