### PR TITLE
fix: background color of ghost dropdown on hover

### DIFF
--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -66,6 +66,14 @@
     }
 }
 
+.moonstone-reversed {
+    .moonstone-dropdown_ghost:hover {
+        color: var(--color-accent);
+
+        background-color: transparent;
+    }
+}
+
 // ---
 // Outlined variant
 // ---


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description

Fix the background color of the ghost dropdown on hover


## Tests

The following are included in this PR

- [ ] Unit Tests
- [X] Accessibility is OK