### PR TITLE
fix: TabItem color text returns to gray

### DIFF
--- a/src/components/Tab/TabItem/TabItem.scss
+++ b/src/components/Tab/TabItem/TabItem.scss
@@ -12,8 +12,9 @@ $selected-line-spacing-big: 20px;
     margin: 0 var(--spacing-nano) calc(#{$selected-line-spacing} - 1px);
     padding: var(--spacing-nano) var(--spacing-small);
 
-    border-radius: var(--radius);
+    color: var(--color-gray);
 
+    border-radius: var(--radius);
     outline: none;
     cursor: pointer;
 }
@@ -48,8 +49,9 @@ $selected-line-spacing-big: 20px;
     color: var(--color-accent);
 
     border-color: transparent;
-
     cursor: default;
+
+    pointer-events: none;
 
     &::after {
         position: absolute;

--- a/src/components/Tab/TabItem/TabItem.spec.js
+++ b/src/components/Tab/TabItem/TabItem.spec.js
@@ -15,10 +15,10 @@ describe('TabItem', () => {
         expect(screen.queryByText('TabItem Toto')).toBeInTheDocument();
     });
 
-    it('should use label variant heading & weight light on size big', () => {
+    it('should use label variant heading & weight semiBold on size big', () => {
         render(<TabItem label="TabItem Toto" size="big"/>);
         expect(screen.getByText('TabItem Toto')).toHaveClass('moonstone-variant_heading');
-        expect(screen.getByText('TabItem Toto')).toHaveClass('moonstone-weight_light');
+        expect(screen.getByText('TabItem Toto')).toHaveClass('moonstone-weight_semiBold');
     });
 
     it('should display the icon', () => {

--- a/src/components/Tab/TabItem/TabItem.tsx
+++ b/src/components/Tab/TabItem/TabItem.tsx
@@ -42,7 +42,7 @@ export const TabItem: React.FC<TabItemProps> = ({
                         isNowrap
                         component="span"
                         variant={size === 'big' ? 'heading' : 'button'}
-                        weight={size === 'big' ? 'light' : 'default'}
+                        weight={size === 'big' ? 'semiBold' : 'default'}
                     >
                         {label}
                     </Typography>


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description

- Returns color text to gray for `TabItem`
- Prevent `:hover` style when a `TabItem` is selected
- Change weight to `semiBold` when a TabItem size is big


## Tests

The following are included in this PR

- [X] Unit Tests
- [X] Accessibility is OK