### PR TITLE
fix: css classes order of ButtonGroup

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.scss
+++ b/src/components/ButtonGroup/ButtonGroup.scss
@@ -1,27 +1,23 @@
 .moonstone-buttonGroup {
-    // Manage border-radius
-    > * + * {
-        &:not(:last-child) {
-            border-radius: 0;
-        }
-    }
-
-    > *:first-child {
-        border-radius: var(--radius) 0 0 var(--radius);
-    }
-
-    > *:last-child {
-        border-radius: 0 var(--radius) var(--radius) 0;
-    }
-
-    > *:only-child {
-        border-radius: var(--radius);
-    }
-
-    // Manage separator
     .moonstone-button {
+        &:first-child {
+            border-radius: var(--radius) 0 0 var(--radius);
+        }
+
+        &:last-child {
+            border-radius: 0 var(--radius) var(--radius) 0;
+        }
+
+        &:only-child {
+            border-radius: var(--radius);
+        }
+
         & + .moonstone-button {
             border-left-color: transparent;
+
+            &:not(:last-child) {
+                border-radius: 0;
+            }
         }
 
         &.moonstone-button_accent,

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -41,6 +41,13 @@ export const ButtonWithActions = () => (
     </ButtonGroup>
 );
 
+export const ButtonOutlinedWithActions = () => (
+    <ButtonGroup color="accent" size="big" variant="outlined">
+        <Button label="Actions" onClick={() => null}/>
+        <Button icon={<ChevronDown/>} onClick={() => null}/>
+    </ButtonGroup>
+);
+
 export const ButtonGroupWith1Button = () => (
     <ButtonGroup color="accent" size="big">
         <Button label="Actions" onClick={() => null}/>


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description

Fix CSS classes order that can provide the wrong style when the style was not loaded in the right order.


## Tests

The following are included in this PR

- [ ] Unit Tests
- [ ] Accessibility is OK
