### PR TITLE
fix: set Button with display inline-flex

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -10,6 +10,10 @@ $button-size_big: 32px;
 .moonstone-button {
     @extend %variant_default;
 
+    // The display `inline-flex` is requiered to align buttons in a table row
+    display: inline-flex;
+    flex-direction: row;
+    justify-content: center;
     width: fit-content;
     height: $button-size_medium;
     padding: 0 var(--spacing-small);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -48,7 +48,6 @@ export const Button = ({
                 {'moonstone-icon-button': !label},
                 {'moonstone-reverse': isReversed},
                 {'moonstone-button_loading': isLoading},
-                'flexRow_center',
                 'alignCenter',
                 className
             )}


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description

We must keep `Button` with `inline-flex` to make inline buttons easy to use.


## Tests

The following are included in this PR

- [ ] Unit Tests
- [ ] Accessibility is OK
