### PR TITLE
fix: outlined dropdown background on hover

### DIFF
--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -85,6 +85,7 @@
 
     &:hover:not(.moonstone-disabled) {
         border: var(--border-selector_hover);
+        background: none;
     }
 
     &.moonstone-disabled {


### PR DESCRIPTION
remove outlined dropdown's background on hover