### PR TITLE
fix: cardSelector disabled style

### DIFF
--- a/src/components/CardSelector/CardSelector.scss
+++ b/src/components/CardSelector/CardSelector.scss
@@ -1,5 +1,8 @@
+$cardSelectorHeight: 58px;
+
 .moonstone-cardSelector {
     width: 100%;
+    height: $cardSelectorHeight;
     padding: var(--spacing-nano);
 
     border: var(--border-selector);
@@ -8,20 +11,25 @@
 
     transition: all 0.2s ease-in-out;
 
-    &:hover {
-        box-shadow: 0 1px 6px var(--color-gray20);
-    }
+    &:not([disabled]) {
+        &:hover {
+            border: var(--border-selector_hover);
+            box-shadow: 0 1px 6px var(--color-gray20);
+        }
 
-    &:active {
-        border: var(--border-selector_hover);
-    }
+        &:active {
+            border: var(--border-selector_active);
+        }
 
-    &:focus-visible {
-        border: var(--border-selector_focus);
+        &:focus-visible {
+            border: var(--border-selector_focus);
+        }
     }
 }
 
 .moonstone-cardSelector_disabled {
+    color: var(--color-dark_plain60);
+
     opacity: 60%;
 
     pointer-events: none;
@@ -82,7 +90,7 @@
 .moonstone-cardSelector_error {
     gap: var(--spacing-nano);
     width: 100%;
-    height: 56px;
+    height: $cardSelectorHeight;
 
     color: var(--color-warning);
 
@@ -93,7 +101,7 @@
 
     transition: all 0.2s ease-in-out;
 
-    &:hover {
+    &:not[disabled]:hover {
         border-color: var(--color-warning);
     }
 }

--- a/src/components/CardSelector/CardSelector.tsx
+++ b/src/components/CardSelector/CardSelector.tsx
@@ -76,7 +76,7 @@ export const CardSelector = React.forwardRef<HTMLButtonElement, CardSelectorProp
             type="button"
             className={classNameProps}
             aria-label={displayName}
-            aria-disabled={isDisabled || isReadOnly}
+            disabled={isDisabled || isReadOnly}
             onClick={e => handleOnClick(e)}
             {...props}
         >
@@ -86,7 +86,7 @@ export const CardSelector = React.forwardRef<HTMLButtonElement, CardSelectorProp
                 ) : <Image size="big" color="gray"/>}
             </figure>
 
-            <div className={clsx('moonstone-cardSelector_body', 'flexCol_nowrap')}>
+            <div className={clsx('moonstone-cardSelector_body', 'flexFluid', 'flexCol_nowrap')}>
                 <div className={clsx('flexRow_nowrap flexFluid')}>
                     {displayName && (
                         <Typography
@@ -105,7 +105,7 @@ export const CardSelector = React.forwardRef<HTMLButtonElement, CardSelectorProp
                         <Typography
                             isNowrap
                             id={id && `${id}-systemName`}
-                            className={clsx('moonstone-cardSelector_systemName')}
+                            className="moonstone-cardSelector_systemName"
                             data-testid="cardSelector-systemName"
                             variant="body"
                             component="span"


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description
- Prevent hover styling when the card is disabled
- Use the `disabled` attribute instead of `aria-disabled`
- Add a scss variable to set the cardSelector height