### PR TITLE
fix: use the same height for CardSelector and EmptyCardSelector

### DIFF
--- a/src/components/CardSelector/CardSelector.scss
+++ b/src/components/CardSelector/CardSelector.scss
@@ -1,8 +1,8 @@
-$cardSelectorHeight: 58px;
+$cardSelector-height: 58px;
 
 .moonstone-cardSelector {
     width: 100%;
-    height: $cardSelectorHeight;
+    height: $cardSelector-height;
     padding: var(--spacing-nano);
 
     border: var(--border-selector);
@@ -90,7 +90,7 @@ $cardSelectorHeight: 58px;
 .moonstone-cardSelector_error {
     gap: var(--spacing-nano);
     width: 100%;
-    height: $cardSelectorHeight;
+    height: $cardSelector-height;
 
     color: var(--color-warning);
 

--- a/src/components/CardSelector/EmptyCardSelector/EmptyCardSelector.scss
+++ b/src/components/CardSelector/EmptyCardSelector/EmptyCardSelector.scss
@@ -1,7 +1,9 @@
+@use '../CardSelector.scss' as *;
+
 .moonstone-emptyCardSelector {
     gap: var(--spacing-nano);
     width: 100%;
-    height: 56px;
+    height: $cardSelector-height;
 
     color: var(--color-dark_plain60);
 


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description

- Use the same height for `CardSelector` and `EmptyCardSelector`
- Review the variable name to follow the naming convention
