### PR TITLE
fix: aria-label on button that toggle the PrimaryNav

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.spec.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.spec.tsx
@@ -16,8 +16,18 @@ describe('PrimaryNav', () => {
         const user = userEvent.setup();
         render(<PrimaryNav {...props}/>);
 
-        await user.click(screen.getByLabelText('primary-nav-control'));
+        await user.click(screen.getByLabelText('Toggle primary navigation'));
         expect(screen.getByRole('navigation')).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('should collapse when click twice on NavButton', async () => {
+        const user = userEvent.setup();
+        render(<PrimaryNav {...props}/>);
+
+        await user.click(screen.getByLabelText('Toggle primary navigation'));
+        await user.click(screen.getByLabelText('Toggle primary navigation'));
+
+        expect(screen.getByRole('navigation')).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('should also work when not displaying modeIcon', () => {

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -24,8 +24,8 @@ const NavButton: React.FC<PrimaryNavButtonProps> = ({isExpanded, toggleExpand, m
                 {isExpanded ? <ArrowLeft size="big"/> : <MenuIcon size="big"/>}
             </button>
         </>
-    )
-}
+    );
+};
 
 const NavHeader: React.FC<PrimaryNavHeaderProps> = ({headerCaption, modeIcon, headerLogo}) => {
     return (

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -6,57 +6,39 @@ import {PrimaryNavContext} from './PrimaryNav.context';
 import {MenuIcon, ArrowLeft} from '~/icons';
 
 const NavButton: React.FC<PrimaryNavButtonProps> = ({isExpanded, toggleExpand, modeIcon}) => {
-    if (isExpanded) {
-        return (
+    return (
+        <>
+            {!isExpanded && modeIcon && (
+                <modeIcon.type
+                    {...modeIcon.props}
+                    className={clsx(modeIcon.props.className, 'moonstone-primaryNav_modeIcon')}
+                />
+            )}
             <button
                 className={clsx('moonstone-primaryNav_button')}
                 type="button"
+                data-testid="primaryNavMenuButton"
                 aria-label="Toggle primary navigation"
                 onClick={toggleExpand}
             >
-                <ArrowLeft size="big"/>
-            </button>
-        );
-    }
-
-    let icon;
-
-    if (modeIcon) {
-        icon = React.cloneElement(modeIcon, {
-            className: clsx('moonstone-primaryNav_modeIcon')
-        });
-    }
-
-    return (
-        <>
-            {icon}
-            <button
-                className={clsx('moonstone-primaryNav_button')}
-                type="button"
-                role="button"
-                aria-label="primary-nav-control"
-                onClick={toggleExpand}
-            >
-                <MenuIcon size="big"/>
+                {isExpanded ? <ArrowLeft size="big"/> : <MenuIcon size="big"/>}
             </button>
         </>
-    );
-};
+    )
+}
 
 const NavHeader: React.FC<PrimaryNavHeaderProps> = ({headerCaption, modeIcon, headerLogo}) => {
-    let icon;
-
-    if (modeIcon) {
-        icon = React.cloneElement(modeIcon, {
-            className: clsx('moonstone-primaryNav_modeIconHeader')
-        });
-    }
-
     return (
         <>
             {headerLogo}
             <div className={clsx('flexRow_nowrap', 'alignCenter', 'moonstone-primaryNav_headerCaption')}>
-                {icon}{headerCaption}
+                {modeIcon && (
+                    <modeIcon.type
+                        {...modeIcon.props}
+                        className={clsx(modeIcon.props.className, 'moonstone-primaryNav_modeIconHeader')}
+                    />
+                )}
+                {headerCaption}
             </div>
         </>
     );


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description
- Refactor the code to use the same button for both the expand and collapse states
- Use a unique `aria-label` to describe the button
- Add the possibility to pass CSS classes to `modeIcon`
- Add a `data-testid` to the button
- Add a test about the collapse


## Tests

The following are included in this PR

- [X] Unit Tests
- [ ] Accessibility is OK
