### PR TITLE
feat: add onArrowNavigation to manage navigation with ArrowDown and ArrowUp

### DIFF
--- a/src/components/CheckboxGroup/CheckboxItem/ControlledCheckboxItem.tsx
+++ b/src/components/CheckboxGroup/CheckboxItem/ControlledCheckboxItem.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, {useRef} from 'react';
 import clsx from 'clsx';
 
 import './CheckboxItem.scss';
 import {Checkbox, Typography} from '~/components';
 import {CheckboxGroupContext} from '../CheckboxGroup.context';
 import type {ControlledCheckboxItemProps} from './CheckboxItem.types';
+import {onArrowNavigation} from '~/hooks/onArrowNavigation';
 
 export const ControlledCheckboxItem: React.FC<ControlledCheckboxItemProps> = ({className, id, value, label, description, isDisabled, isReadOnly, onChange, name, ...props}) => {
     const context = React.useContext(CheckboxGroupContext);
@@ -12,15 +13,19 @@ export const ControlledCheckboxItem: React.FC<ControlledCheckboxItemProps> = ({c
     const isDisabledItem = (typeof context === 'undefined') ? isDisabled : context.isDisabled;
     const isReadOnlyItem = (typeof context === 'undefined') ? isReadOnly : context.isReadOnly;
     const nameItem = (typeof context === 'undefined') ? name : context.name;
+    const containerRef = useRef(null);
 
+    // FIX: Typography doesn't accept refs
     return (
-        <Typography
+        <label
+            ref={containerRef}
             className={clsx('moonstone-checkboxItem flexCol', className)}
             aria-readonly={isReadOnlyItem}
             aria-disabled={isDisabledItem}
-            variant="body"
-            weight="default"
-            component="label"
+            // Variant="body"
+            // weight="default"
+            // component="label"
+            {... onArrowNavigation(containerRef)}
         >
             <div className={clsx('flexRow alignCenter')}>
                 <Checkbox
@@ -61,7 +66,7 @@ export const ControlledCheckboxItem: React.FC<ControlledCheckboxItemProps> = ({c
                     {description}
                 </Typography>
             )}
-        </Typography>
+        </label>
     );
 };
 

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -4,7 +4,7 @@ import './ListItem.scss';
 import {Typography} from '~/components/Typography';
 import {ListItemProps} from './ListItem.types';
 
-export const ListItem: React.FC<ListItemProps> = ({
+const ListItemForwardRef: React.ForwardRefRenderFunction<HTMLLIElement, ListItemProps> = ({
     label,
     description,
     iconStart,
@@ -15,7 +15,7 @@ export const ListItem: React.FC<ListItemProps> = ({
     typographyVariant = 'caption',
     iconSize = 'default',
     ...props
-}) => {
+}, ref) => {
     const cssListItem = clsx(
         'moonstone-listItem',
         'flexRow',
@@ -26,6 +26,7 @@ export const ListItem: React.FC<ListItemProps> = ({
 
     return (
         <li
+            ref={ref}
             className={clsx(cssListItem)}
             {...props}
         >
@@ -74,4 +75,5 @@ export const ListItem: React.FC<ListItemProps> = ({
     );
 };
 
+export const ListItem = React.forwardRef(ListItemForwardRef);
 ListItem.displayName = 'ListItem';

--- a/src/components/ListItem/ListItem.types.ts
+++ b/src/components/ListItem/ListItem.types.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 import type {TypographyVariant} from '~/components/Typography/Typography.types';
 
-export type ListItemProps = Omit<React.ComponentPropsWithoutRef<'li'>, 'className'> & {
+export type ListItemProps = Omit<React.ComponentPropsWithRef<'li'>, 'className'> & {
     /**
      * Additional classname
      */

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, {useRef} from 'react';
 import {ListItem} from '~/components/ListItem';
 import clsx from 'clsx';
 import './MenuItem.scss';
 
 import type {MenuItemProps} from './MenuItem.types';
+import {onArrowNavigation} from '~/hooks/onArrowNavigation';
 
 export const MenuItem: React.FC<MenuItemProps> = ({
     variant = 'default',
@@ -19,8 +20,11 @@ export const MenuItem: React.FC<MenuItemProps> = ({
     className,
     description,
     ...props
-}) => (
-    <ListItem
+}) => {
+    const containerRef = useRef(null);
+    return (
+        <ListItem
+        ref={containerRef}
         tabIndex={isDisabled || variant === 'title' || isSelected ? null : 0}
         aria-disabled={isDisabled}
         className={clsx(
@@ -41,8 +45,10 @@ export const MenuItem: React.FC<MenuItemProps> = ({
         iconStart={iconStart}
         iconEnd={iconEnd}
         description={description}
+        {... onArrowNavigation(containerRef)}
         {...props}
     />
-);
+    );
+};
 
 MenuItem.displayName = 'MenuItem';

--- a/src/components/RadioGroup/RadioItem/RadioItem.tsx
+++ b/src/components/RadioGroup/RadioItem/RadioItem.tsx
@@ -1,17 +1,30 @@
-import React from 'react';
+import React, {useRef} from 'react';
 import clsx from 'clsx';
 import type {RadioItemProps} from './RadioItem.types';
 import './RadioItem.scss';
 import {RadioChecked, RadioUnchecked} from '~/icons';
 import {Typography} from '~/components';
 import {RadioGroupContext} from '~/components/RadioGroup/RadioGroup.context';
+import {onArrowNavigation} from '~/hooks/onArrowNavigation';
 
 export const RadioItem: React.FC<RadioItemProps> = ({className, id, value, label, description, isDisabled, isReadOnly, ...props}) => {
     const context = React.useContext(RadioGroupContext);
     const isDisabledItem = (typeof context.isDisabled === 'undefined') ? isDisabled : context.isDisabled;
     const isReadOnlyItem = (typeof context.isReadOnly === 'undefined') ? isReadOnly : context.isReadOnly;
+    const containerRef = useRef(null);
+
+    // FIX: Typography doesn't accept refs
     return (
-        <Typography className={clsx('moonstone-radio-container flexCol', className)} aria-readonly={isReadOnlyItem} aria-disabled={isDisabledItem} variant="body" weight="default" component="label">
+        <label
+            ref={containerRef}
+            className={clsx('moonstone-radio-container flexCol', className)}
+            aria-readonly={isReadOnlyItem}
+            aria-disabled={isDisabledItem}
+            // Variant="body"
+            // weight="default"
+            // component="label"
+            {... onArrowNavigation(containerRef)}
+        >
             <div className={clsx('flexRow alignCenter')}>
                 <div className={clsx('moonstone-radio')}>
                     <input
@@ -38,7 +51,7 @@ export const RadioItem: React.FC<RadioItemProps> = ({className, id, value, label
             {description && (
                 <Typography id={`${id}-description`} variant="caption" weight="default" component="span" className={clsx('moonstone-radio-description flexRow')}>{description}</Typography>
             )}
-        </Typography>
+        </label>
     );
 };
 

--- a/src/components/TreeView/ControlledTreeView.tsx
+++ b/src/components/TreeView/ControlledTreeView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useRef} from 'react';
 import clsx from 'clsx';
 import './TreeView.scss';
 import type {ControlledTreeViewProps, TreeViewData} from './TreeView.types';
@@ -6,6 +6,7 @@ import type {ControlledTreeViewProps, TreeViewData} from './TreeView.types';
 import {ChevronDown, ChevronRight, CheckboxChecked, CheckboxUnchecked} from '~/icons';
 import {Typography, Loader} from '~/components';
 import {onToggleNode} from '~/hooks/useToggleNode';
+import {onArrowNavigation} from '~/hooks/onArrowNavigation';
 
 // Manage treeView_item's icon
 const displayIcon = (icon: React.ReactElement, size: string, className?: string, parentHasIconStart = false) => {
@@ -41,6 +42,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
         ...props
     }, ref) => {
     const isFlatData = data.filter(item => item.children && item.children.length > 0).length === 0;
+    const containerRef = useRef(null);
 
     function generateLevelJSX(nodeData: TreeViewData[], depth: number, parentHasIconStart: boolean): React.ReactNode[] {
         return nodeData.map(node => {
@@ -106,6 +108,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
                 React.createElement(
                     itemComponent,
                     {
+                        ref: containerRef,
                         role: 'treeitem',
                         'aria-selected': isSelected,
                         'aria-expanded': isOpen,
@@ -116,6 +119,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
                         style: {'--treeItem-depth': depth, ...node?.treeItemProps?.style},
                         onDoubleClick: handleNodeDoubleClick,
                         onContextMenu: handleNodeContextMenu,
+                        ...onArrowNavigation(containerRef),
                         ...onToggleNode(toggleNode, handleNodeClick, !isClickable),
                         ...node.treeItemProps
                     },

--- a/src/components/TreeView/ControlledTreeView.tsx
+++ b/src/components/TreeView/ControlledTreeView.tsx
@@ -7,6 +7,7 @@ import {ChevronDown, ChevronRight, CheckboxChecked, CheckboxUnchecked} from '~/i
 import {Typography, Loader} from '~/components';
 import {onToggleNode} from '~/hooks/useToggleNode';
 import {onArrowNavigation} from '~/hooks/onArrowNavigation';
+import {mergeHandlers} from '~/hooks/mergeHandlers';
 
 // Manage treeView_item's icon
 const displayIcon = (icon: React.ReactElement, size: string, className?: string, parentHasIconStart = false) => {
@@ -131,8 +132,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
                         style: {'--treeItem-depth': depth, ...node?.treeItemProps?.style},
                         onDoubleClick: handleNodeDoubleClick,
                         onContextMenu: handleNodeContextMenu,
-                        ...onArrowNavigation(containerRef),
-                        ...onToggleNode(toggleNode, handleNodeClick, !isClickable),
+                        ...mergeHandlers(onArrowNavigation(containerRef), onToggleNode(toggleNode, handleNodeClick, !isClickable)),
                         ...node.treeItemProps
                     },
                     <div className={cssTreeViewItem}>

--- a/src/components/TreeView/ControlledTreeView.tsx
+++ b/src/components/TreeView/ControlledTreeView.tsx
@@ -42,10 +42,16 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
         ...props
     }, ref) => {
     const isFlatData = data.filter(item => item.children && item.children.length > 0).length === 0;
-    const containerRef = useRef(null);
+    const refs = useRef(new Map<string, React.RefObject<HTMLElement>>());
 
     function generateLevelJSX(nodeData: TreeViewData[], depth: number, parentHasIconStart: boolean): React.ReactNode[] {
         return nodeData.map(node => {
+            let containerRef = refs.current.get(node.id);
+            if (!containerRef) {
+                containerRef = React.createRef<HTMLElement>();
+                refs.current.set(node.id, containerRef);
+            }
+
             const hasChild = Boolean(node.hasChildren || (node.children && node.children.length !== 0));
             const hasIconStart = Boolean(node.iconStart);
             const hasIconEnd = Boolean(node.iconEnd);

--- a/src/hooks/onArrowNavigation.spec.tsx
+++ b/src/hooks/onArrowNavigation.spec.tsx
@@ -1,0 +1,67 @@
+import {useRef} from 'react';
+import {onArrowNavigation} from './onArrowNavigation';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+describe('onArrowNavigation', () => {
+    let TestMenu = () => {
+        const refs = [useRef(null), useRef(null)];
+
+        return (
+            <div
+                data-testid="test-menu"
+            >
+                <div ref={refs[0]} {...onArrowNavigation(refs[0])}>Item 1</div>
+                <div ref={refs[1]} {...onArrowNavigation(refs[1])}>Item 2</div>
+            </div>
+        );
+    };
+
+    it('should focus next sibling when arrowDown is pressed', async () => {
+        const user = userEvent.setup();
+        render(<TestMenu/>);
+        await user.keyboard('[Tab]');
+        await user.keyboard('[ArrowDown]');
+        expect(screen.queryByText('Item 2')).toHaveFocus();
+    });
+
+    it('should focus previous sibling when arrowUp is pressed', async () => {
+        const user = userEvent.setup();
+        render(<TestMenu/>);
+        await user.keyboard('[Tab]');
+        await user.keyboard('[ArrowDown]');
+        await user.keyboard('[ArrowUp]');
+        expect(screen.queryByText('Item 1')).toHaveFocus();
+    });
+
+    TestMenu = () => {
+        const refs = [useRef(null), useRef(null)];
+
+        return (
+            <div
+                data-testid="test-menu"
+            >
+                <div ref={refs[0]} {...onArrowNavigation(refs[0])}>Item 1</div>
+                <div>Not an Item</div>
+                <div ref={refs[1]} {...onArrowNavigation(refs[1])}>Item 2</div>
+            </div>
+        );
+    };
+
+    it('should focus next focusable sibling when arrowDown is pressed', async () => {
+        const user = userEvent.setup();
+        render(<TestMenu/>);
+        await user.keyboard('[Tab]');
+        await user.keyboard('[ArrowDown]');
+        expect(screen.queryByText('Item 2')).toHaveFocus();
+    });
+
+    it('should focus previous focusable sibling when arrowUp is pressed', async () => {
+        const user = userEvent.setup();
+        render(<TestMenu/>);
+        await user.keyboard('[Tab]');
+        await user.keyboard('[ArrowDown]');
+        await user.keyboard('[ArrowUp]');
+        expect(screen.queryByText('Item 1')).toHaveFocus();
+    });
+});

--- a/src/hooks/onArrowNavigation.tsx
+++ b/src/hooks/onArrowNavigation.tsx
@@ -11,27 +11,27 @@ export const onArrowNavigation = (
 ): onArrowNavigationProps => {
     const handleKeyUp = (e: React.KeyboardEvent) => {
         const element = ref.current;
-        if (element) {
-            if (e.code === 'ArrowDown') {
-                e.preventDefault();
-                let next = element.nextSibling as HTMLElement;
-                // Loops through dom elements until it finds another item with the hook
-                while (next && !(next instanceof HTMLElement && next.tabIndex >= 0)) {
-                    next = next.nextSibling as HTMLElement;
-                }
 
-                next?.focus();
-            }
+        if (!element) {
+            return;
+        }
 
-            if (e.code === 'ArrowUp') {
-                e.preventDefault();
-                let prev = element.previousSibling as HTMLElement;
-                while (prev && !(prev instanceof HTMLElement && prev.tabIndex >= 0)) {
-                    prev = prev.previousSibling as HTMLElement;
-                }
+        const container = element.parentElement;
+        if (!container) {
+            return;
+        }
 
-                prev?.focus();
-            }
+        const items = Array.from(container.querySelectorAll<HTMLElement>('[tabindex]')).filter(el => el.tabIndex >= 0);
+        const currentIndex = items.indexOf(element);
+
+        if (e.key === 'ArrowDown' && currentIndex !== -1) {
+            e.preventDefault();
+            items[currentIndex + 1]?.focus();
+        }
+
+        if (e.key === 'ArrowUp' && currentIndex !== -1) {
+            e.preventDefault();
+            items[currentIndex - 1]?.focus();
         }
     };
 

--- a/src/hooks/onArrowNavigation.tsx
+++ b/src/hooks/onArrowNavigation.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+type onArrowNavigationProps = {
+    onKeyUp?: React.KeyboardEventHandler;
+    tabIndex?: number;
+};
+
+export const onArrowNavigation = (
+    ref: React.RefObject<HTMLElement>,
+    tabIndex = 0
+): onArrowNavigationProps => {
+    const handleKeyUp = (e: React.KeyboardEvent) => {
+        const element = ref.current;
+        if (element) {
+            if (e.code === 'ArrowDown') {
+                e.preventDefault();
+                let next = element.nextSibling as HTMLElement;
+                // Loops through dom elements until it finds another item with the hook
+                while (next && !(next instanceof HTMLElement && next.tabIndex >= 0)) {
+                    next = next.nextSibling as HTMLElement;
+                }
+
+                next?.focus();
+            }
+
+            if (e.code === 'ArrowUp') {
+                e.preventDefault();
+                let prev = element.previousSibling as HTMLElement;
+                while (prev && !(prev instanceof HTMLElement && prev.tabIndex >= 0)) {
+                    prev = prev.previousSibling as HTMLElement;
+                }
+
+                prev?.focus();
+            }
+        }
+    };
+
+    return {
+        onKeyUp: handleKeyUp,
+        tabIndex: tabIndex
+    };
+};


### PR DESCRIPTION
- Add `onArrowNavigation` hook
- Add `onArrowNavigation` tests
- Implement `onArrowNavigation` list/tree/menu item type elements
