### PR TITLE
fix: prevent selection on TreeView item when clicking on the chevron

### DIFF
--- a/src/components/TreeView/ControlledTreeView.tsx
+++ b/src/components/TreeView/ControlledTreeView.tsx
@@ -16,7 +16,11 @@ const displayIcon = (icon: React.ReactElement, size: string, className?: string,
     return (
         <i className={clsx('flexRow', 'alignCenter', className)}>
             {icon &&
-            <icon.type {...icon.props} size={size} aria-label={(icon.type as React.ComponentType).name || 'moonstone-treeView-icon'}/>}
+            <icon.type
+                aria-label={(icon.type as React.ComponentType).name || 'moonstone-treeView-icon'}
+                {...icon.props}
+                size={size}
+            />}
         </i>
     );
 };
@@ -58,10 +62,12 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
             // Manage clicks events
             // ---
             const toggleNode = (e: React.MouseEvent) => {
-                if (isOpen) {
-                    onCloseItem(node, e);
-                } else {
-                    onOpenItem(node, e);
+                if (onOpenItem && onCloseItem) {
+                    if (isOpen) {
+                        onCloseItem(node, e);
+                    } else {
+                        onOpenItem(node, e);
+                    }
                 }
             };
 
@@ -124,6 +130,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
                         {isClosable && hasChild && (
                             <div
                                 className={clsx('flexRow', 'alignCenter', 'moonstone-treeView_itemToggle')}
+                                data-testid="treeitem-toggle-icon"
                                 onClick={toggleNode}
                             >
                                 {isLoading ? <Loader isReversed={isReversed} size="small"/> : isOpen ? <ChevronDown size={size}/> : <ChevronRight size={size}/>}
@@ -138,6 +145,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
                         {/* TreeViewItem */}
                         <div
                             className={clsx('flexRow_nowrap', 'alignCenter', 'flexFluid', 'moonstone-treeView_itemLabel', node.className)}
+                            onClick={isClickable ? handleNodeClick : undefined}
                         >
                             {showCheckbox ?
                                 (isSelected ? <CheckboxChecked className="moonstone-treeView_itemIconStart" role="checkbox" color="blue" aria-checked="true"/> : <CheckboxUnchecked className="moonstone-treeView_itemIconStart" role="checkbox" aria-checked="false"/>) :

--- a/src/components/TreeView/TreeView.spec.tsx
+++ b/src/components/TreeView/TreeView.spec.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -125,6 +126,36 @@ describe('TreeView', () => {
         await user.click(screen.getByText('A level1'));
 
         expect(clickHandler).not.toHaveBeenCalled();
+    });
+
+    it('should not select the item when clicking on the toggle icon', async () => {
+        const user = userEvent.setup();
+
+        // Create a wrapper component to use hooks
+        function Wrapper() {
+            const [selectedItems, setSelectedItems] = useState<string[]>([]);
+            const handleClick = (node: TreeViewData) => {
+                if (selectedItems.includes(node.id)) {
+                    setSelectedItems(selectedItems.filter(item => item !== node.id));
+                } else {
+                    setSelectedItems([node.id]);
+                }
+            };
+            return (
+                <TreeView
+                    openedItems={['A']}
+                    data={tree}
+                    onClickItem={handleClick}
+                    selectedItems={selectedItems}
+                />
+            );
+        }
+
+        render(<Wrapper />);
+        
+        await user.click(screen.getByTestId('treeitem-toggle-icon'));
+        
+        expect(screen.queryAllByRole('treeitem', {selected: true})).toHaveLength(0);
     });
 
     it('should not call onClick when clicking on an readonly item', async () => {

--- a/src/components/TreeView/TreeView.spec.tsx
+++ b/src/components/TreeView/TreeView.spec.tsx
@@ -132,7 +132,7 @@ describe('TreeView', () => {
         const user = userEvent.setup();
 
         // Create a wrapper component to use hooks
-        function Wrapper() {
+        const Wrapper = () => {
             const [selectedItems, setSelectedItems] = useState<string[]>([]);
             const handleClick = (node: TreeViewData) => {
                 if (selectedItems.includes(node.id)) {
@@ -141,20 +141,21 @@ describe('TreeView', () => {
                     setSelectedItems([node.id]);
                 }
             };
+
             return (
                 <TreeView
                     openedItems={['A']}
                     data={tree}
-                    onClickItem={handleClick}
                     selectedItems={selectedItems}
+                    onClickItem={handleClick}
                 />
             );
-        }
+        };
 
-        render(<Wrapper />);
-        
+        render(<Wrapper/>);
+
         await user.click(screen.getByTestId('treeitem-toggle-icon'));
-        
+
         expect(screen.queryAllByRole('treeitem', {selected: true})).toHaveLength(0);
     });
 

--- a/src/hooks/useToggleNode.spec.tsx
+++ b/src/hooks/useToggleNode.spec.tsx
@@ -31,13 +31,6 @@ describe('onToggleNode', () => {
         );
     };
 
-    it('should call onClick', async () => {
-        const user = userEvent.setup();
-        render(<ToggleableDiv isClickable/>);
-        await user.click(screen.getByTestId('toggleable-div'));
-        expect(screen.queryByText('clicked')).toBeInTheDocument();
-    });
-
     it('should call onToggle when spacebar is pressed', async () => {
         const user = userEvent.setup();
         render(<ToggleableDiv isClickable/>);

--- a/src/hooks/useToggleNode.tsx
+++ b/src/hooks/useToggleNode.tsx
@@ -40,7 +40,6 @@ export const onToggleNode = (
     };
 
     return {
-        onClick: isDisabled ? undefined : onClick,
         onKeyUp: handleKeyUp,
         disabled: isDisabled,
         tabIndex: tabIndex


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description

- Prevent selection when clicking on the toggle icon (chevron) of the tree item
- Add `data-testid` on the toggle icon to help tests
- Add a test about this issue
- `useToggleNode` hook must not return the `onClick` function as its role is to manage the toggle state / function


## Tests

The following are included in this PR

- [X] Unit Tests
- [ ] Accessibility is OK