### PR TITLE
fix: Prevent focus style after clicking or selecting an item

### DIFF
--- a/src/components/Accordion/AccordionItem/AccordionItem.scss
+++ b/src/components/Accordion/AccordionItem/AccordionItem.scss
@@ -40,7 +40,7 @@ $accordionHeader_height: 48px;
 
         cursor: default;
 
-        &:focus {
+        &:focus-visible {
             color: var(--color-light);
 
             background-color: var(--color-dark60);
@@ -51,7 +51,7 @@ $accordionHeader_height: 48px;
         background-color: var(--color-gray40);
     }
 
-    &:focus,
+    &:focus-visible,
     &:not(.moonstone-selected):not(:active):hover {
         color: var(--color-dark);
 
@@ -74,7 +74,7 @@ $accordionHeader_height: 48px;
             background-color: var(--color-black);
         }
 
-        &:focus,
+        &:focus-visible,
         &:not(.moonstone-selected):not(:active):hover {
             color: var(--color-light);
 

--- a/src/components/ButtonToggle/ButtonToggle.scss
+++ b/src/components/ButtonToggle/ButtonToggle.scss
@@ -4,7 +4,7 @@
     border: 1px solid transparent;
     background: none;
 
-    &:focus {
+    &:focus-visible {
         color: var(--color-accent_dark);
 
         border-color: var(--color-accent_dark);
@@ -31,7 +31,7 @@
 
     background-color: var(--color-accent_light20);
 
-    &:focus {
+    &:focus-visible {
         background-color: var(--color-accent_light20);
     }
 
@@ -53,7 +53,7 @@
 
     &:hover,
     &:active,
-    &:focus,
+    &:focus-visible,
     &:disabled {
         box-shadow: var(--shadow);
     }

--- a/src/components/CardSelector/EmptyCardSelector/EmptyCardSelector.scss
+++ b/src/components/CardSelector/EmptyCardSelector/EmptyCardSelector.scss
@@ -18,7 +18,7 @@
         border: var(--border-selector_hover);
     }
 
-    &:focus {
+    &:focus-visible {
         border: var(--border-selector_focus);
     }
 }

--- a/src/components/Input/BaseInput/BaseInput.scss
+++ b/src/components/Input/BaseInput/BaseInput.scss
@@ -97,7 +97,7 @@ $min-width: 40px;
         opacity: 1;
     }
 
-    &:focus {
+    &:focus-visible {
         outline: none;
 
         ~ .moonstone-baseInput_icon {

--- a/src/components/Menu/MenuItem.scss
+++ b/src/components/Menu/MenuItem.scss
@@ -32,7 +32,7 @@
         background-color: var(--color-gray60);
     }
 
-    &:focus {
+    &:focus-visible {
         outline: none;
         box-shadow: inset 0 0 0 2px var(--color-accent);
     }

--- a/src/components/RadioGroup/RadioItem/RadioItem.scss
+++ b/src/components/RadioGroup/RadioItem/RadioItem.scss
@@ -86,7 +86,7 @@ $radio-sizeDefault: 16px;
         fill: var(--color-accent_dark);
     }
 
-    &:focus ~ .moonstone-radio_icon {
+    &:focus-visible ~ .moonstone-radio_icon {
         fill: var(--color-accent_dark_contrast);
     }
 }

--- a/src/components/Textarea/Textarea.scss
+++ b/src/components/Textarea/Textarea.scss
@@ -38,7 +38,7 @@ $minHeight-size: 50px;
             border: var(--border-selector_hover);
         }
 
-        &:focus {
+        &:focus-visible {
             border: var(--border-selector_focus);
         }
     }


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description
Replace `:focus` with `:focus-visible` to only display focus style when the element is focused by keyboard and not with a simple click.
