### PR TITLE
feat: allow icon component as thumbnail

### DIFF
--- a/src/components/CardSelector/CardSelector.spec.tsx
+++ b/src/components/CardSelector/CardSelector.spec.tsx
@@ -1,6 +1,7 @@
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Chip} from '~/index';
+import {Love} from '~/icons';
 
 import {CardSelector} from './index';
 
@@ -30,16 +31,25 @@ describe('CardSelector', () => {
         expect(screen.queryByText('this information')).toBeInTheDocument();
     });
 
-    it('should display the image with thumbnailURL', () => {
-        const {container} = render(<CardSelector {...requiredProps} thumbnailURL="thumbnail.png"/>);
+    it('should display the image with thumbnail', () => {
+        const {container} = render(<CardSelector {...requiredProps} thumbnail="thumbnail.png"/>);
         expect(
             container.querySelector('img[src="thumbnail.png"]')
         ).toBeInTheDocument();
     });
 
+    it('should display the icon passed with thumbnail', () => {
+        const {container} = render(
+            <CardSelector {...requiredProps} thumbnail={<Love id="thumbnail-icon"/>}/>
+        );
+        expect(
+            container.querySelector('#thumbnail-icon')
+        ).toBeInTheDocument();
+    });
+
     it('should display img as icon when thumbnailType is icon', () => {
         const {container} = render(
-            <CardSelector {...requiredProps} thumbnailType="icon" thumbnailURL="thumbnail.png"/>
+            <CardSelector {...requiredProps} thumbnailType="icon" thumbnail="thumbnail.png"/>
         );
         expect(
             container.querySelector('.moonstone-cardSelector_thumbnail_icon')
@@ -51,7 +61,7 @@ describe('CardSelector', () => {
             <CardSelector
                 {...requiredProps}
                 thumbnailType="preview"
-                thumbnailURL="thumbnail.png"
+                thumbnail="thumbnail.png"
             />
         );
         expect(
@@ -64,7 +74,7 @@ describe('CardSelector', () => {
             <CardSelector
                 {...requiredProps}
                 thumbnailAlt="thumbnail-alt"
-                thumbnailURL="thumbnail.png"
+                thumbnail="thumbnail.png"
             />
         );
         expect(

--- a/src/components/CardSelector/CardSelector.stories.tsx
+++ b/src/components/CardSelector/CardSelector.stories.tsx
@@ -2,7 +2,7 @@ import {StoryObj, Meta} from '@storybook/react';
 
 import {CardSelector} from './index';
 import {Button, Chip} from '~/index';
-import {Close, FileImage, Lock} from '~/icons';
+import {Close, FileImage, Lock, Love} from '~/icons';
 import type {CardSelectorProps} from './CardSelector.types';
 
 const meta: Meta<typeof CardSelector> = {
@@ -34,7 +34,7 @@ export const Default: Story = {
 export const Image: Story = {
     args: {
         ...Default.args,
-        thumbnailURL: 'https://picsum.photos/100/300',
+        thumbnail: 'https://picsum.photos/100/300',
         thumbnailAlt: 'preview-img',
         thumbnailType: 'preview',
         information: 'more information',
@@ -46,7 +46,16 @@ export const Image: Story = {
 export const Icon: Story = {
     args: {
         ...Image.args,
-        thumbnailURL: 'http://www.google.com/s2/favicons?domain=www.jahia.com',
+        thumbnail: 'http://www.google.com/s2/favicons?domain=www.jahia.com',
+        thumbnailType: 'icon'
+    },
+    render: Template
+};
+
+export const IconComponent: Story = {
+    args: {
+        ...Image.args,
+        thumbnail: <Love id="test" className="test"/>,
         thumbnailType: 'icon'
     },
     render: Template

--- a/src/components/CardSelector/CardSelector.tsx
+++ b/src/components/CardSelector/CardSelector.tsx
@@ -2,16 +2,42 @@ import React from 'react';
 import clsx from 'clsx';
 
 import './CardSelector.scss';
-import type {CardSelectorProps} from './CardSelector.types';
+import type {CardSelectorProps, ThumbnailProps} from './CardSelector.types';
 import {Typography} from '~/components';
 import {FileBroken, Image} from '~/icons/components';
+
+const ThumbnailCmp: React.FC<ThumbnailProps> = ({thumbnail, thumbnailType, thumbnailAlt}) => {
+    console.log(thumbnail);
+    if (!thumbnail) {
+        return <Image size="big" color="gray" data-testid="cardSelector-thumbnail"/>;
+    }
+
+    if (typeof thumbnail === 'string') {
+        return (
+            <img
+                className={clsx(`moonstone-cardSelector_thumbnail_${thumbnailType}`)}
+                src={thumbnail}
+                alt={thumbnailAlt}
+                data-testid="cardSelector-thumbnail"
+            />
+        );
+    }
+
+    return (
+        <thumbnail.type
+            {...thumbnail.props}
+            className={clsx(`moonstone-cardSelector_thumbnail_${thumbnailType}`, thumbnail.props.className)}
+            data-testid="cardSelector-thumbnail"
+        />
+    );
+};
 
 export const CardSelector = React.forwardRef<HTMLButtonElement, CardSelectorProps>(({
     displayName,
     systemName,
     chips,
     information,
-    thumbnailURL,
+    thumbnail,
     thumbnailType = 'preview',
     thumbnailAlt,
     id,
@@ -81,9 +107,7 @@ export const CardSelector = React.forwardRef<HTMLButtonElement, CardSelectorProp
             {...props}
         >
             <figure className={clsx('moonstone-cardSelector_thumbnail', 'flexRow_center', 'alignCenter')}>
-                {thumbnailURL ? (
-                    <img className={clsx(`moonstone-cardSelector_thumbnail_${thumbnailType}`)} src={thumbnailURL} alt={thumbnailAlt} data-testid="cardSelector-thumbnail"/>
-                ) : <Image size="big" color="gray"/>}
+                <ThumbnailCmp thumbnail={thumbnail} thumbnailType={thumbnailType} thumbnailAlt={thumbnailAlt}/>
             </figure>
 
             <div className={clsx('moonstone-cardSelector_body', 'flexFluid', 'flexCol_nowrap')}>

--- a/src/components/CardSelector/CardSelector.tsx
+++ b/src/components/CardSelector/CardSelector.tsx
@@ -7,7 +7,6 @@ import {Typography} from '~/components';
 import {FileBroken, Image} from '~/icons/components';
 
 const ThumbnailCmp: React.FC<ThumbnailProps> = ({thumbnail, thumbnailType, thumbnailAlt}) => {
-    console.log(thumbnail);
     if (!thumbnail) {
         return <Image size="big" color="gray" data-testid="cardSelector-thumbnail"/>;
     }

--- a/src/components/CardSelector/CardSelector.types.ts
+++ b/src/components/CardSelector/CardSelector.types.ts
@@ -1,6 +1,26 @@
 import React from 'react';
 
-type BasicProps = Omit<React.ComponentPropsWithRef<'button'>, 'className' | 'id' | 'onClick'> & {
+export type ThumbnailProps = {
+    /**
+     * Url of the thumbnail or icon component
+     * If a string is provided, it will be used as the src of an img element.
+     * If a React element is provided, it will be rendered as the thumbnail.
+     */
+    thumbnail?: string | React.ReactElement;
+
+    /**
+     * Alt attribute for thumbnail
+     */
+    thumbnailAlt?: string;
+
+    /**
+     * Thumbnail type
+     * @default 'preview'
+     */
+    thumbnailType?: 'preview' | 'icon';
+}
+
+type BasicProps = Omit<React.ComponentPropsWithRef<'button'>, 'className' | 'id' | 'onClick'> & ThumbnailProps & {
     /**
      * Required id
      */
@@ -45,21 +65,6 @@ type BasicProps = Omit<React.ComponentPropsWithRef<'button'>, 'className' | 'id'
      * Define if the item is readOnly
      */
     isReadOnly?: boolean;
-
-    /**
-     * Image url as thumbnail
-     */
-    thumbnailURL?: string;
-
-    /**
-     * Alt attribute for thumbnail
-     */
-    thumbnailAlt?: string;
-
-    /**
-     * Thumbnail type
-     */
-    thumbnailType?: 'icon' | 'preview';
 
     /**
      * Error cardSelector variant


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description

- Rename `thumbnailURL` to `thumbnail`
- Allow passing an icon component as a thumbnail
- UPdate stories
- Update the test


## Tests

The following are included in this PR

- [X] Unit Tests
- [ ] Accessibility is OK