### PR TITLE
feat: Add new utils function to merge all handlers

### DIFF
--- a/src/hooks/mergeHandlers.spec.tsx
+++ b/src/hooks/mergeHandlers.spec.tsx
@@ -1,0 +1,45 @@
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { mergeHandlers } from './mergeHandlers';
+
+describe('mergeHandlers', () => {
+    const Mock = (props: React.HTMLAttributes<HTMLDivElement>) => {
+        return (
+            <div data-testid="test" role="button" {...props}> label</div>
+        );
+    };
+
+    it('should call all merged onClick handlers when multiple are provided', async () => {
+        const user = userEvent.setup();
+        const firstHandler = vi.fn();
+        const secondHandler = vi.fn();
+
+        render(<Mock {...mergeHandlers({onClick: firstHandler}, {onClick: secondHandler})}/>);
+
+        await user.click(screen.getByTestId('test'));
+        expect(firstHandler).toHaveBeenCalled();
+        expect(secondHandler).toHaveBeenCalled();
+    });
+
+    it('should call the onClick handler when only one is provided', async () => {
+        const user = userEvent.setup();
+        const onClick = vi.fn();
+
+        render(<Mock {...mergeHandlers({onClick: onClick})}/>);
+
+        await user.click(screen.getByTestId('test'));
+        expect(onClick).toHaveBeenCalled();
+    });
+
+    it('should stop calling subsequent handlers if event.preventDefault() is called', async () => {
+        const user = userEvent.setup();
+        const firstHandler = vi.fn(e => e.preventDefault());
+        const secondHandler = vi.fn();
+
+        render(<Mock {...mergeHandlers({onClick: firstHandler}, {onClick: secondHandler})}/>);
+
+        await user.click(screen.getByTestId('test'));
+        expect(firstHandler).toHaveBeenCalled();
+        expect(secondHandler).not.toHaveBeenCalled();
+    });
+});

--- a/src/hooks/mergeHandlers.tsx
+++ b/src/hooks/mergeHandlers.tsx
@@ -1,0 +1,43 @@
+type mergeHandlersProps = {
+    [key: string]: any;
+};
+
+// mergeHandlers merges multiple sets of props, combining event handlers (on*) and overriding other props (last one wins).
+// - Event handlers with the same name are chained: each is called in order until event.defaultPrevented is true.
+// - Non-event props (aria-*, role, tabIndex, etc.) are simply overwritten by the last value provided.
+export function mergeHandlers(...props: mergeHandlersProps[]): mergeHandlersProps {
+    const merged: mergeHandlersProps = {};
+    const handlerMap: Record<string, Function[]> = {};
+
+    // Collect all event handlers (keys starting with 'on') and other props from each props object
+    props.forEach(propsObj => {
+        Object.entries(propsObj).forEach(([key, value]) => {
+            // If the key is an event handler (on*) and a function, collect it for merging
+            if (key.startsWith('on') && typeof value === 'function') {
+                if (!handlerMap[key]) handlerMap[key] = [];
+                handlerMap[key].push(value);
+            } else {
+                // For non-event props, just assign (last one wins)
+                merged[key] = value;
+            }
+        });
+    });
+
+    // Merge all collected event handlers for each event type
+    Object.entries(handlerMap).forEach(([key, handlers]) => {
+        if (handlers.length === 1) {
+            // Only one handler: assign directly
+            merged[key] = handlers[0];
+        } else if (handlers.length > 1) {
+            // Multiple handlers: chain them, stopping if event.defaultPrevented is set
+            merged[key] = (event: any) => {
+                for (const handler of handlers) {
+                    handler(event);
+                    if (event.defaultPrevented) break;
+                }
+            };
+        }
+    });
+
+    return merged;
+}


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description
Add new function `mergeHandlers` to merge all handlers function when we use multiple accessible hooks that add the same handler.


## Tests

The following are included in this PR

- [X] Unit Tests
- [ ] Accessibility is OK