### PR TITLE
chore: update AccordionItem to meet W3C standards

### DIFF
--- a/src/components/Accordion/AccordionItem/AccordionItem.tsx
+++ b/src/components/Accordion/AccordionItem/AccordionItem.tsx
@@ -4,11 +4,12 @@ import './AccordionItem.scss';
 import {Typography} from '~/components/Typography';
 import {AccordionContext} from '~/components/Accordion/Accordion.context';
 import type {AccordionItemProps} from './AccordionItem.types';
-import {onAccessibleClick} from '~/hooks';
+import {onAccessibleClick, mergeHandlers, onArrowNavigation} from '~/hooks';
 
 export const AccordionItem: React.FC<AccordionItemProps> = ({id, label, icon = null, onClick = () => undefined, className, children, ...props}) => {
     const context = React.useContext(AccordionContext);
     const open = context.currentItem === id;
+    const ref = React.useRef(null);
 
     const handleClick = (e: React.MouseEvent | React.KeyboardEvent, isOpen: boolean) => {
         onClick(e, !isOpen);
@@ -17,7 +18,7 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({id, label, icon = n
 
     return (
         <section
-            {...props}
+            ref={ref}
             className={clsx(
                 'moonstone-accordionItem',
                 {'moonstone-reversed': context.isReversed},
@@ -25,8 +26,11 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({id, label, icon = n
                 open ? 'flexFluid' : null,
                 className
             )}
+            {...mergeHandlers(onArrowNavigation({ref: ref}), onAccessibleClick({onClick: e => handleClick(e, open)}))}
+            role="none"
+            {...props}
         >
-            <header
+            <h3
                 className={clsx(
                     'moonstone-accordionItem_header',
                     {
@@ -38,8 +42,7 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({id, label, icon = n
                 )}
                 aria-controls={id}
                 aria-expanded={open}
-                {...onAccessibleClick(e => handleClick(e, open))}
-                role="accordion-item"
+                data-testid="accordion-item"
             >
                 {icon &&
                     (
@@ -60,7 +63,7 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({id, label, icon = n
                 >
                     {label}
                 </Typography>
-            </header>
+            </h3>
 
             {/* Accordion content */}
             {open &&

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -14,13 +14,13 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({children, className, ...p
     return (
         <nav className={clsx('moonstone-breadcrumb', className)} aria-label="breadcrumb" {...props}>
             <ol className={clsx('flexRow_nowrap', 'alignCenter')}>
-                {
-                    allItems.map((item: React.ReactElement, index) => (
-                        <Fragment key={item.key}>
-                            {item}
+                {allItems.map((item: React.ReactElement, index) => (
+                            index < allItems.length - 1 ? (
+                                <Fragment key={item.key}>
 
-                            {index < allItems.length - 1 && (
-                                <li
+                                    {item}
+
+                                    <li
                                     className={
                                         clsx(
                                             'moonstone-breadcrumb_separator',
@@ -28,13 +28,17 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({children, className, ...p
                                             'alignCenter'
                                         )
                                     }
-                                >
-                                    <ChevronRight aria-hidden/>
-                                </li>
-                            )}
-                        </Fragment>
-                    ))
-                }
+                                    >
+                                        <ChevronRight aria-hidden/>
+                                    </li>
+                                </Fragment>
+                            ) : (
+                                <Fragment key={item.key}>
+                                    {React.cloneElement(item, {'aria-current': 'page'})}
+                                </Fragment>
+                            )
+                ))}
+
             </ol>
         </nav>
     );

--- a/src/components/CheckboxGroup/CheckboxItem/ControlledCheckboxItem.tsx
+++ b/src/components/CheckboxGroup/CheckboxItem/ControlledCheckboxItem.tsx
@@ -24,7 +24,7 @@ export const ControlledCheckboxItem: React.FC<ControlledCheckboxItemProps> = ({c
             variant="body"
             weight="default"
             component="label"
-            {... onArrowNavigation(containerRef)}
+            {... onArrowNavigation({ref: containerRef})}
         >
             <div className={clsx('flexRow alignCenter')}>
                 <Checkbox

--- a/src/components/Dropdown/DropdownMenu.tsx
+++ b/src/components/Dropdown/DropdownMenu.tsx
@@ -41,7 +41,7 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
             isSelected={value === item.value}
             image={item.image}
             imageSize={imageSize}
-            {...onAccessibleClick(e => handleSelect(e, item), item.isDisabled, 'option')}
+            {...onAccessibleClick({onClick: e => handleSelect(e, item), disabled: item.isDisabled, role: 'option'})}
             {...item.attributes as MenuItemProps}
         />
     );

--- a/src/components/ListSelector/ValueList/ValueList.tsx
+++ b/src/components/ListSelector/ValueList/ValueList.tsx
@@ -58,11 +58,11 @@ export const ValueList: React.FC<ValueListProps> = ({
                                       className={clsx(...classNames)}
                                       typographyVariant="body"
                                       label={v.label}
-                                      {...onAccessibleClick((e:React.MouseEvent) => {
+                                      {...onAccessibleClick({onClick: (e:React.MouseEvent) => {
                                         if (!isReadOnly && role === 'left-list') {
                                             onClick(e, v);
                                         }
-                                    }, isReadOnly, role)}
+                                    }, disabled: isReadOnly, role: role})}
                                       onDragOver={(e:React.DragEvent) => {
                                           if (!isReadOnly) {
                                               onDragOver(e, v);

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -45,7 +45,7 @@ export const MenuItem: React.FC<MenuItemProps> = ({
         iconStart={iconStart}
         iconEnd={iconEnd}
         description={description}
-        {... onArrowNavigation(containerRef)}
+        {... onArrowNavigation({ref: containerRef})}
         {...props}
     />
     );

--- a/src/components/PrimaryNav/PrimaryNavItem/PrimaryNavItem.tsx
+++ b/src/components/PrimaryNav/PrimaryNavItem/PrimaryNavItem.tsx
@@ -84,13 +84,13 @@ export const PrimaryNavItem: React.FC<PrimaryNavItemProps> = ({
                 className
             )}
             title={label}
-            {...onAccessibleClick((e: React.MouseEvent) => {
+            {...onAccessibleClick({onClick: (e: React.MouseEvent) => {
                 if (typeof primaryNavContext.collapse === 'function') {
                     primaryNavContext.collapse();
                 }
 
                 onClick(e);
-            })}
+            }})}
             {...props}
         >
             <ItemTypeResolver icon={icon} label={label} subtitle={subtitle} url={url} button={button}/>

--- a/src/components/RadioGroup/RadioItem/RadioItem.tsx
+++ b/src/components/RadioGroup/RadioItem/RadioItem.tsx
@@ -22,7 +22,7 @@ export const RadioItem: React.FC<RadioItemProps> = ({className, id, value, label
             variant="body"
             weight="default"
             component="label"
-            {... onArrowNavigation(containerRef)}
+            {... onArrowNavigation({ref: containerRef})}
         >
             <div className={clsx('flexRow alignCenter')}>
                 <div className={clsx('moonstone-radio')}>

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -17,6 +17,7 @@ export const Tab: React.FC<TabProps> = ({children, className = '', ...props}) =>
                 'alignCenter',
                 className
             )}
+            role="tablist"
         >
             {children}
         </div>

--- a/src/components/Tab/TabItem/TabItem.spec.tsx
+++ b/src/components/Tab/TabItem/TabItem.spec.tsx
@@ -6,7 +6,7 @@ import {Love} from '~/icons';
 describe('TabItem', () => {
     it('should render', () => {
         render(<TabItem/>);
-        expect(screen.getByRole('button')).toHaveClass('moonstone-tabItem');
+        expect(screen.getByRole('tab')).toHaveClass('moonstone-tabItem');
     });
 
     it('should have the specified label', () => {

--- a/src/components/Tab/TabItem/TabItem.tsx
+++ b/src/components/Tab/TabItem/TabItem.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, {useRef} from 'react';
 import clsx from 'clsx';
 import './TabItem.scss';
 import type {TabItemProps} from './TabItem.types';
 import {Typography} from '~/components/Typography';
+import {onArrowNavigation} from '~/hooks';
 
 export const TabItem: React.FC<TabItemProps> = ({
     component = 'button',
@@ -15,29 +16,35 @@ export const TabItem: React.FC<TabItemProps> = ({
     isSelected = false,
     onClick,
     ...props
-}) =>
-    React.createElement(
-        component,
-        {
-            className: clsx(
-                'moonstone-tabItem',
-                `moonstone-tabItem_${size}`,
-                {'moonstone-tabItem_noLabel': !label},
-                {'moonstone-tabItem_selected': isSelected},
-                {'moonstone-reverse': isReversed},
-                'flexRow_center',
-                'alignCenter',
-                className
-            ),
-            disabled: isDisabled,
-            onClick,
-            ...props
-        },
-        (
-            <>
-                {icon && <icon.type {...icon.props} className={clsx('moonstone-tabItem_icon', icon.props.className)} size={(size === 'big') ? 'default' : size}/>}
+}) => {
+    const ref = useRef(null);
+    return (
+        React.createElement(
+            component,
+            {
+                className: clsx(
+                    'moonstone-tabItem',
+                    `moonstone-tabItem_${size}`,
+                    {'moonstone-tabItem_noLabel': !label},
+                    {'moonstone-tabItem_selected': isSelected},
+                    {'moonstone-reverse': isReversed},
+                    'flexRow_center',
+                    'alignCenter',
+                    className
+                ),
+                ref: ref,
+                role: 'tab',
+                'aria-selected': isSelected,
+                disabled: isDisabled,
+                onClick,
+                ...onArrowNavigation({ref: ref, direction: 'horizontal'}),
+                ...props
+            },
+            (
+                <>
+                    {icon && <icon.type {...icon.props} className={clsx('moonstone-tabItem_icon', icon.props.className)} size={(size === 'big') ? 'default' : size}/>}
 
-                {label && (
+                    {label && (
                     <Typography
                         isNowrap
                         component="span"
@@ -46,9 +53,10 @@ export const TabItem: React.FC<TabItemProps> = ({
                     >
                         {label}
                     </Typography>
-                )}
-            </>
-        )
-    );
+                    )}
+                </>
+            )
+        ));
+};
 
 TabItem.displayName = 'TabItem';

--- a/src/components/TreeView/ControlledTreeView.tsx
+++ b/src/components/TreeView/ControlledTreeView.tsx
@@ -130,7 +130,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
                         style: {'--treeItem-depth': depth, ...node?.treeItemProps?.style},
                         onDoubleClick: handleNodeDoubleClick,
                         onContextMenu: handleNodeContextMenu,
-                        ...mergeHandlers(onArrowNavigation(containerRef), onToggleNode(toggleNode, handleNodeClick, !isClickable)),
+                        ...mergeHandlers(onArrowNavigation({ref: containerRef}), onToggleNode(toggleNode, handleNodeClick, !isClickable)),
                         ...node.treeItemProps
                     },
                     <div className={cssTreeViewItem}>

--- a/src/hooks/onArrowNavigation.spec.tsx
+++ b/src/hooks/onArrowNavigation.spec.tsx
@@ -3,16 +3,18 @@ import {onArrowNavigation} from './onArrowNavigation';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+type TestMenuProps = {readonly direction?: 'vertical' | 'horizontal' | 'both'};
+
 describe('onArrowNavigation', () => {
-    let TestMenu = () => {
+    const TestMenu = ({direction}: TestMenuProps) => {
         const refs = [useRef(null), useRef(null)];
 
         return (
             <div
                 data-testid="test-menu"
             >
-                <div ref={refs[0]} {...onArrowNavigation(refs[0])}>Item 1</div>
-                <div ref={refs[1]} {...onArrowNavigation(refs[1])}>Item 2</div>
+                <div ref={refs[0]} {...onArrowNavigation({ref: refs[0], direction: direction, tabIndex: 3})}>Item 1</div>
+                <div ref={refs[1]} {...onArrowNavigation({ref: refs[1], direction: direction, tabIndex: 3})}>Item 2</div>
             </div>
         );
     };
@@ -25,6 +27,11 @@ describe('onArrowNavigation', () => {
         expect(screen.queryByText('Item 2')).toHaveFocus();
     });
 
+    it('should have the right tabIndex', () => {
+        render(<TestMenu/>);
+        expect(screen.queryByText('Item 2')).toHaveAttribute('tabindex', '3');
+    });
+
     it('should focus previous sibling when arrowUp is pressed', async () => {
         const user = userEvent.setup();
         render(<TestMenu/>);
@@ -34,23 +41,40 @@ describe('onArrowNavigation', () => {
         expect(screen.queryByText('Item 1')).toHaveFocus();
     });
 
-    TestMenu = () => {
+    it('should focus next sibling when arrowRight is pressed', async () => {
+        const user = userEvent.setup();
+        render(<TestMenu direction="horizontal"/>);
+        await user.keyboard('[Tab]');
+        await user.keyboard('[ArrowRight]');
+        expect(screen.queryByText('Item 2')).toHaveFocus();
+    });
+
+    it('should focus previous sibling when arrowLeft is pressed', async () => {
+        const user = userEvent.setup();
+        render(<TestMenu direction="horizontal"/>);
+        await user.keyboard('[Tab]');
+        await user.keyboard('[ArrowRight]');
+        await user.keyboard('[ArrowLeft]');
+        expect(screen.queryByText('Item 1')).toHaveFocus();
+    });
+
+    const TestMenuWithUnfocusableSiblings = () => {
         const refs = [useRef(null), useRef(null)];
 
         return (
             <div
                 data-testid="test-menu"
             >
-                <div ref={refs[0]} {...onArrowNavigation(refs[0])}>Item 1</div>
+                <div ref={refs[0]} {...onArrowNavigation({ref: refs[0]})}>Item 1</div>
                 <div>Not an Item</div>
-                <div ref={refs[1]} {...onArrowNavigation(refs[1])}>Item 2</div>
+                <div ref={refs[1]} {...onArrowNavigation({ref: refs[1]})}>Item 2</div>
             </div>
         );
     };
 
     it('should focus next focusable sibling when arrowDown is pressed', async () => {
         const user = userEvent.setup();
-        render(<TestMenu/>);
+        render(<TestMenuWithUnfocusableSiblings/>);
         await user.keyboard('[Tab]');
         await user.keyboard('[ArrowDown]');
         expect(screen.queryByText('Item 2')).toHaveFocus();
@@ -58,10 +82,15 @@ describe('onArrowNavigation', () => {
 
     it('should focus previous focusable sibling when arrowUp is pressed', async () => {
         const user = userEvent.setup();
-        render(<TestMenu/>);
+        render(<TestMenuWithUnfocusableSiblings/>);
         await user.keyboard('[Tab]');
         await user.keyboard('[ArrowDown]');
         await user.keyboard('[ArrowUp]');
         expect(screen.queryByText('Item 1')).toHaveFocus();
+    });
+
+    it('should have the default tabIndex', () => {
+        render(<TestMenuWithUnfocusableSiblings/>);
+        expect(screen.queryByText('Item 2')).toHaveAttribute('tabindex', '0');
     });
 });

--- a/src/hooks/onArrowNavigation.tsx
+++ b/src/hooks/onArrowNavigation.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 
 type onArrowNavigationProps = {
     onKeyUp?: React.KeyboardEventHandler;
+    ref: React.RefObject<HTMLElement>;
+    direction?: 'vertical' | 'horizontal' | 'both';
     tabIndex?: number;
 };
 
-export const onArrowNavigation = (
-    ref: React.RefObject<HTMLElement>,
-    tabIndex = 0
-): onArrowNavigationProps => {
+export const onArrowNavigation = ({
+    ref,
+    direction = 'vertical',
+    tabIndex = 0} :
+    onArrowNavigationProps) => {
     const handleKeyUp = (e: React.KeyboardEvent) => {
         const element = ref.current;
 
@@ -24,14 +27,28 @@ export const onArrowNavigation = (
         const items = Array.from(container.querySelectorAll<HTMLElement>('[tabindex]')).filter(el => el.tabIndex >= 0);
         const currentIndex = items.indexOf(element);
 
-        if (e.key === 'ArrowDown' && currentIndex !== -1) {
-            e.preventDefault();
-            items[currentIndex + 1]?.focus();
+        if (direction === 'both' || direction === 'vertical') {
+            if (e.key === 'ArrowDown' && currentIndex !== -1) {
+                e.preventDefault();
+                items[currentIndex + 1]?.focus();
+            }
+
+            if (e.key === 'ArrowUp' && currentIndex !== -1) {
+                e.preventDefault();
+                items[currentIndex - 1]?.focus();
+            }
         }
 
-        if (e.key === 'ArrowUp' && currentIndex !== -1) {
-            e.preventDefault();
-            items[currentIndex - 1]?.focus();
+        if (direction === 'both' || direction === 'horizontal') {
+            if (e.key === 'ArrowRight' && currentIndex !== -1) {
+                e.preventDefault();
+                items[currentIndex + 1]?.focus();
+            }
+
+            if (e.key === 'ArrowLeft' && currentIndex !== -1) {
+                e.preventDefault();
+                items[currentIndex - 1]?.focus();
+            }
         }
     };
 

--- a/src/hooks/useAccessibleClick.spec.tsx
+++ b/src/hooks/useAccessibleClick.spec.tsx
@@ -14,7 +14,7 @@ describe('useAccessibleClick', () => {
             <div
                 data-testid="clickable-div"
                 aria-disabled={isDisabled}
-                {...onAccessibleClick(() => setLabel('clicked'), isDisabled)}
+                {...onAccessibleClick({onClick: () => setLabel('clicked'), disabled: isDisabled})}
             >
                 {label}
             </div>

--- a/src/hooks/useAccessibleClick.tsx
+++ b/src/hooks/useAccessibleClick.tsx
@@ -15,15 +15,15 @@ const handleKeyUp = (e: React.KeyboardEvent, onClick: onClickProp) => {
     }
 };
 
-export const onAccessibleClick = (
-    onClick: onClickProp,
+export const onAccessibleClick = ({
+    onClick,
     disabled = false,
     role = 'button',
     tabIndex = 0
-): onAccessibleClickProps => {
+}: onAccessibleClickProps) => {
     return {
         onClick: disabled ? undefined : onClick,
-        onKeyUp: disabled ? undefined : e => handleKeyUp(e, onClick),
+        onKeyUp: disabled ? undefined : (e: React.KeyboardEvent) => handleKeyUp(e, onClick),
         disabled: disabled,
         role: role,
         tabIndex: disabled ? -1 : tabIndex};


### PR DESCRIPTION
- Replace `header` element with `h3`
- Move `onAccessibleClick` & `onArrowNavigation` hooks higher in component's structure
- Replace `role="accordion-item"` with `data-testid="accordion-item"`