### PR TITLE
feat: add is-focused mixin to unify focusable components style

### DIFF
--- a/src/components/Accordion/AccordionItem/AccordionItem.scss
+++ b/src/components/Accordion/AccordionItem/AccordionItem.scss
@@ -1,4 +1,5 @@
 @use "../../../tokens/spacings/spacings" as *;
+@use "../../../utils/mixins" as *;
 
 $accordionHeader_height: 48px;
 
@@ -21,6 +22,10 @@ $accordionHeader_height: 48px;
     &.moonstone-reversed {
         border-color: var(--color-gray);
     }
+
+    &:has(.moonstone-accordionItem_header:focus-visible) {
+        @extend %is-focused;
+    }
 }
 
 // ---
@@ -39,23 +44,14 @@ $accordionHeader_height: 48px;
         border-bottom: 1px solid var(--color-gray_light);
 
         cursor: default;
-
-        &:focus-visible {
-            color: var(--color-light);
-
-            background-color: var(--color-dark60);
-        }
     }
 
     &:active {
         background-color: var(--color-gray40);
     }
 
-    &:focus-visible,
-    &:not(.moonstone-selected):not(:active):hover {
-        color: var(--color-dark);
-
-        background-color: var(--color-gray_light);
+    &:focus-visible {
+        outline: none;
     }
 
     &.moonstone-reversed {
@@ -72,13 +68,6 @@ $accordionHeader_height: 48px;
 
         &:active {
             background-color: var(--color-black);
-        }
-
-        &:focus-visible,
-        &:not(.moonstone-selected):not(:active):hover {
-            color: var(--color-light);
-
-            background-color: var(--color-gray40);
         }
     }
 }

--- a/src/components/Accordion/AccordionItem/AccordionItem.scss
+++ b/src/components/Accordion/AccordionItem/AccordionItem.scss
@@ -22,10 +22,6 @@ $accordionHeader_height: 48px;
     &.moonstone-reversed {
         border-color: var(--color-gray);
     }
-
-    &:has(.moonstone-accordionItem_header:focus-visible) {
-        @extend %is-focused;
-    }
 }
 
 // ---
@@ -46,12 +42,20 @@ $accordionHeader_height: 48px;
         cursor: default;
     }
 
+    &:focus-visible {
+        @extend %is-focused;
+
+        outline-offset: -2px;
+    }
+
     &:active {
         background-color: var(--color-gray40);
     }
 
-    &:focus-visible {
-        outline: none;
+    &:not(.moonstone-selected):not(:active):hover {
+        color: var(--color-dark);
+
+        background-color: var(--color-gray_light);
     }
 
     &.moonstone-reversed {
@@ -68,6 +72,12 @@ $accordionHeader_height: 48px;
 
         &:active {
             background-color: var(--color-black);
+        }
+
+        &:not(.moonstone-selected):not(:active):hover {
+            color: var(--color-light);
+
+            background-color: var(--color-gray40);
         }
     }
 }

--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.scss
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.scss
@@ -8,5 +8,9 @@
 
     > * {
         max-width: 100%;
+
+        &:focus-visible {
+            outline-offset: -2px;
+        }
     }
 }

--- a/src/components/Button/variants/_default.scss
+++ b/src/components/Button/variants/_default.scss
@@ -1,3 +1,5 @@
+@use "../../../utils/mixins" as *;
+
 %variant_default {
     color: var(--color-gray_dark);
 
@@ -11,9 +13,7 @@
     }
 
     &:focus-visible {
-        color: var(--color-accent_dark);
-
-        border-color: var(--color-accent_dark);
+        @extend %is-focused;
     }
 
     &:active {
@@ -52,10 +52,7 @@
         }
 
         &:focus-visible {
-            color: var(--color-white);
-
-            border-color: transparent;
-            background-color: var(--color-accent_dark);
+            @extend %is-focused;
         }
 
         &:active {

--- a/src/components/Button/variants/_outlined.scss
+++ b/src/components/Button/variants/_outlined.scss
@@ -1,3 +1,5 @@
+@use "../../../utils/mixins" as *;
+
 %variant_outlined_disabled {
     color: var(--color-gray_dark);
 
@@ -18,9 +20,7 @@
         }
 
         &:focus-visible:not(:disabled) {
-            color: var(--color-accent_dark);
-
-            border-color: var(--color-accent_dark);
+            @extend %is-focused;
         }
 
         &:active:not(:disabled) {
@@ -48,9 +48,7 @@
 
         &:hover:not(:disabled),
         &:focus-visible:not(:disabled) {
-            color: var(--color-accent_dark);
-
-            border-color: var(--color-accent_dark);
+            @extend %is-focused;
         }
 
         &:active:not(:disabled) {
@@ -72,9 +70,7 @@
 
         &:hover:not(:disabled),
         &:focus-visible:not(:disabled) {
-            color: var(--color-danger);
-
-            border-color: var(--color-danger);
+            @extend %is-focused;
         }
 
         &:active:not(:disabled) {

--- a/src/components/Button/variants/_outlined.scss
+++ b/src/components/Button/variants/_outlined.scss
@@ -46,7 +46,12 @@
 
         border-color: var(--color-accent);
 
-        &:hover:not(:disabled),
+        &:hover:not(:disabled) {
+            color: var(--color-accent_dark);
+
+            border-color: var(--color-accent_dark);
+        }
+
         &:focus-visible:not(:disabled) {
             @extend %is-focused;
         }
@@ -68,7 +73,12 @@
 
         border-color: var(--color-danger);
 
-        &:hover:not(:disabled),
+        &:hover:not(:disabled) {
+            color: var(--color-danger);
+
+            border-color: var(--color-danger);
+        }
+
         &:focus-visible:not(:disabled) {
             @extend %is-focused;
         }

--- a/src/components/CardSelector/CardSelector.scss
+++ b/src/components/CardSelector/CardSelector.scss
@@ -1,3 +1,5 @@
+@use "../../utils/mixins" as *;
+
 $cardSelector-height: 58px;
 
 .moonstone-cardSelector {
@@ -22,7 +24,7 @@ $cardSelector-height: 58px;
         }
 
         &:focus-visible {
-            border: var(--border-selector_focus);
+            @extend %is-focused;
         }
     }
 }
@@ -101,7 +103,13 @@ $cardSelector-height: 58px;
 
     transition: all 0.2s ease-in-out;
 
-    &:not[disabled]:hover {
-        border-color: var(--color-warning);
+    &:not([disabled]) {
+        &:hover {
+            border-color: var(--color-warning);
+        }
+
+        &:focus-visible {
+            @extend %is-focused;
+        }
     }
 }

--- a/src/components/CardSelector/EmptyCardSelector/EmptyCardSelector.scss
+++ b/src/components/CardSelector/EmptyCardSelector/EmptyCardSelector.scss
@@ -19,7 +19,7 @@
     }
 
     &:focus-visible {
-        border: var(--border-selector_focus);
+        @extend %is-focused;
     }
 }
 

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -1,3 +1,5 @@
+@use "../../utils/mixins" as *;
+
 $checkbox-sizeDefault: 16px;
 $checkbox-sizeBig: 20px;
 
@@ -59,7 +61,7 @@ $checkbox-sizeBig: 20px;
 
     // Only triggered when the input is focus with tab
     &:focus-visible {
-        border: 2px solid var(--color-accent_dark_contrast);
+        @extend %is-focused;
     }
 
     &[aria-checked="true"],

--- a/src/components/CheckboxGroup/CheckboxItem/CheckboxItem.scss
+++ b/src/components/CheckboxGroup/CheckboxItem/CheckboxItem.scss
@@ -1,3 +1,5 @@
+@use "../../../utils/mixins" as *;
+
 .moonstone-checkboxItem[aria-disabled="true"],
 .moonstone-checkboxItem[aria-readonly="true"] {
     cursor: default;
@@ -11,6 +13,10 @@
 
     & + .moonstone-checkboxItem {
         margin-top: var(--spacing-medium);
+    }
+
+    &:focus-visible {
+        @extend %is-focused;
     }
 }
 

--- a/src/components/Collapsible/Collapsible.scss
+++ b/src/components/Collapsible/Collapsible.scss
@@ -1,4 +1,5 @@
 @use "../../tokens/spacings/spacings" as *;
+@use "../../utils/mixins" as *;
 
 .moonstone-collapsible {
     position: relative;
@@ -20,6 +21,10 @@
 
     &:hover {
         color: var(--color-gray_dark);
+    }
+
+    &:focus-visible {
+        @extend %is-focused;
     }
 }
 

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -1,6 +1,7 @@
 @use '../../utils/index' as *;
 @use "../../tokens/spacings/spacings" as *;
 @use "../../globals/variants";
+@use "../../utils/mixins" as *;
 
 .moonstone-dropdown_container {
     position: relative;
@@ -52,8 +53,7 @@
     }
 
     &:focus-visible {
-        border: var(--border-selector_focus);
-        outline: none;
+        @extend %is-focused;
     }
 
     // &:hover:not(.moonstone-disabled) {

--- a/src/components/Input/BaseInput/BaseInput.scss
+++ b/src/components/Input/BaseInput/BaseInput.scss
@@ -1,4 +1,5 @@
 @use '../../../utils/index';
+@use "../../../utils/mixins" as *;
 
 $default-size: 24px;
 $big-size: 32px;
@@ -35,6 +36,10 @@ $min-width: 40px;
 
     .moonstone-reversed & {
         background-color: transparent;
+    }
+
+    &:has(input:focus-visible) {
+        @extend %is-focused;
     }
 }
 

--- a/src/components/Input/BaseInput/BaseInput.scss
+++ b/src/components/Input/BaseInput/BaseInput.scss
@@ -25,6 +25,10 @@ $min-width: 40px;
         @extend %is-disabled;
     }
 
+    &:has(input:focus-visible) {
+        @extend %is-focused;
+    }
+
     &.moonstone-big {
         min-height: $big-size;
     }
@@ -36,10 +40,6 @@ $min-width: 40px;
 
     .moonstone-reversed & {
         background-color: transparent;
-    }
-
-    &:has(input:focus-visible) {
-        @extend %is-focused;
     }
 }
 

--- a/src/components/ListSelector/ValueList/ValueList.scss
+++ b/src/components/ListSelector/ValueList/ValueList.scss
@@ -1,3 +1,5 @@
+@use "../../../utils/mixins" as *;
+
 .moonstone-valueList {
     flex-grow: 1;
     height: 300px;
@@ -36,6 +38,12 @@
 
     &:hover > div > div > .moonstone-displayNone {
         display: block;
+    }
+
+    &:focus-visible {
+        @extend %is-focused;
+
+        outline-offset: -1px;
     }
 }
 

--- a/src/components/PrimaryNav/PrimaryNavItem/PrimaryNavItem.scss
+++ b/src/components/PrimaryNav/PrimaryNavItem/PrimaryNavItem.scss
@@ -1,3 +1,5 @@
+@use "../../../utils/mixins" as *;
+
 .moonstone-primaryNavItem {
     position: relative;
 
@@ -19,6 +21,12 @@
 
         background-color: var(--color-accent);
         cursor: default;
+    }
+
+    &:focus-visible {
+        @extend %is-focused;
+
+        border-radius: var(--radius_rounded);
     }
 
     &:not(.moonstone-selected):hover {

--- a/src/components/PrimaryNav/PrimaryNavItem/PrimaryNavItem.scss
+++ b/src/components/PrimaryNav/PrimaryNavItem/PrimaryNavItem.scss
@@ -25,8 +25,6 @@
 
     &:focus-visible {
         @extend %is-focused;
-
-        border-radius: var(--radius_rounded);
     }
 
     &:not(.moonstone-selected):hover {

--- a/src/components/Tab/TabItem/TabItem.scss
+++ b/src/components/Tab/TabItem/TabItem.scss
@@ -1,5 +1,6 @@
 @use "../../../globals/variants";
 @use "../../../tokens/spacings/spacings" as *;
+@use "../../../utils/mixins" as *;
 
 $big-tab-height: 32px;
 $selected-line-spacing: 6px;
@@ -17,6 +18,10 @@ $selected-line-spacing-big: 20px;
     border-radius: var(--radius);
     outline: none;
     cursor: pointer;
+
+    &:focus-visible {
+        @extend %is-focused;
+    }
 }
 
 .moonstone-tabItem_icon {

--- a/src/components/Textarea/Textarea.scss
+++ b/src/components/Textarea/Textarea.scss
@@ -1,4 +1,5 @@
 @use '../../utils/index';
+@use "../../utils/mixins" as *;
 
 $minHeight-size: 50px;
 
@@ -39,7 +40,7 @@ $minHeight-size: 50px;
         }
 
         &:focus-visible {
-            border: var(--border-selector_focus);
+            @extend %is-focused;
         }
     }
 

--- a/src/components/TreeView/TreeView.scss
+++ b/src/components/TreeView/TreeView.scss
@@ -1,4 +1,5 @@
 @use "../../tokens/spacings/spacings" as *;
+@use "../../utils/mixins" as *;
 
 [role='treeitem'] {
     --treeItem-indent: calc((var(--spacing-medium) + var(--spacing-nano)) * var(--treeItem-depth, 0) + var(--spacing-small));
@@ -12,6 +13,10 @@
     --treeItem-background_selected: var(--color-accent);
     --treeItem-background_selected_hover: var(--color-accent);
     --treeItem-background_highlighted: var(--color-gray60);
+
+    &:focus-visible {
+        @extend %is-focused;
+    }
 }
 
 .moonstone-treeView_item {

--- a/src/globals/_variants.scss
+++ b/src/globals/_variants.scss
@@ -1,3 +1,4 @@
+@use "../utils/mixins" as *;
 // Default style
 %variant_ghost {
     // color: var(--color-gray_dark);
@@ -13,10 +14,7 @@
     }
 
     &:focus-visible:not(:disabled) {
-        color: var(--color-accent_dark);
-
-        border-color: var(--color-accent_dark);
-        background-color: transparent;
+        @extend %is-focused;
     }
 
     &:active:not(:disabled) {
@@ -27,7 +25,10 @@
     &.moonstone-reverse {
         color: var(--color-light);
 
-        &:focus-visible:not(:disabled),
+        &:focus-visible:not(:disabled) {
+            @extend %is-focused;
+        }
+
         &:hover:not(:disabled) {
             color: var(--color-accent_light);
 
@@ -69,9 +70,7 @@
     }
 
     &:focus-visible:not(:disabled) {
-        color: var(--color-accent_dark);
-
-        border-color: var(--color-accent_dark);
+        @extend %is-focused;
     }
 
     &:active:not(:disabled) {
@@ -92,10 +91,7 @@
         }
 
         &:focus-visible:not(:disabled) {
-            color: var(--color-white);
-
-            border-color: var(--color-white);
-            background-color: var(--color-accent60);
+            @extend %is-focused;
         }
 
         &:active:not(:disabled) {
@@ -119,9 +115,7 @@
     }
 
     &:focus-visible:not(:disabled) {
-        color: var(--color-danger);
-
-        border-color: var(--color-danger);
+        @extend %is-focused;
     }
 
     &:active:not(:disabled) {
@@ -142,10 +136,7 @@
         }
 
         &:focus-visible:not(:disabled) {
-            color: var(--color-white);
-
-            border-color: var(--color-white);
-            background-color: var(--color-danger60);
+            @extend %is-focused;
         }
 
         &:active:not(:disabled) {

--- a/src/globals/_variants.scss
+++ b/src/globals/_variants.scss
@@ -1,4 +1,5 @@
 @use "../utils/mixins" as *;
+
 // Default style
 %variant_ghost {
     // color: var(--color-gray_dark);

--- a/src/utils/_mixins.scss
+++ b/src/utils/_mixins.scss
@@ -19,3 +19,9 @@
     cursor: not-allowed;
     opacity: 0.6;
 }
+
+%is-focused {
+    border-radius: 4px;
+    outline: 2px solid var(--color-accent_light);
+    outline-offset: 2px;
+}

--- a/src/utils/_mixins.scss
+++ b/src/utils/_mixins.scss
@@ -21,7 +21,6 @@
 }
 
 %is-focused {
-    border-radius: 4px;
     outline: 2px solid var(--color-accent_light);
     outline-offset: 2px;
 }


### PR DESCRIPTION
- Add `%is-focused` mixin to `/utils/_mixins.scss`
- Add `%is-focused` to unify focus style on focusable components