### PR TITLE
chore: deprecate onKeyPress with onKeyUp

### DIFF
--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -360,17 +360,6 @@ describe('DropdownMenu', () => {
             screen.queryByTestId('moonstone-dropdownMenu')
         ).not.toBeInTheDocument();
     });
-
-    // Should be uncomment when components' attribute onKeyPress is replaced with onKeyUp
-    // it('should call handleKeyUp', async () => {
-    //     let dData = dropdownDataGrouped;
-    //     const user = userEvent.setup();
-    //     const handleKeyUp = vi.fn();
-
-    //     render(<DropdownMenu isDisplayed hasSearch data={dData} handleKeyUp={handleKeyUp}/>);
-    //     await user.keyboard('{Tab}');
-    //     expect(handleKeyUp).toHaveBeenCalled();
-    // });
 });
 
 const TreeViewMenuSizes = ['minWidth', 'maxWidth', 'maxHeight'];

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -200,7 +200,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
                 className={clsx(cssDropdown)}
                 tabIndex={0}
                 onClick={!isDisabled && handleOpenMenu}
-                onKeyPress={e => {
+                onKeyUp={e => {
                     if (e.key === 'Enter' && !isDisabled) {
                         handleOpenMenu(e);
                     }

--- a/src/components/Dropdown/TreeViewMenu.tsx
+++ b/src/components/Dropdown/TreeViewMenu.tsx
@@ -173,7 +173,7 @@ export const TreeViewMenu: React.FC<TreeViewMenuProps> = ({
                         <SearchInput
                             value={inputValue}
                             onChange={e => setInputValue(e.target.value)}
-                            onKeyPress={e => {
+                            onKeyUp={e => {
                                 if (e.key === 'Enter' && treeData.length > 0) {
                                     const item = find(data => !data.isDisabled, treeData[0]);
                                     if (item) {

--- a/src/components/Input/BaseInput/BaseInput.types.ts
+++ b/src/components/Input/BaseInput/BaseInput.types.ts
@@ -68,9 +68,14 @@ type BasicBaseInputProps = Omit<React.ComponentPropsWithRef<'input'>, 'size' | '
     onClick?: React.MouseEventHandler;
 
     /**
-     * Function
+     * @deprecated onKeyPress is deprecated and will be removed in a future release. You should use onKeyUp instead.
      */
     onKeyPress?: React.KeyboardEventHandler;
+
+    /**
+     * Function
+     */
+    onKeyUp?: React.KeyboardEventHandler;
 
     /**
      * Function - when passed in, the Cancel icon appears at the end of the input and its click event is passed back when the Cancel icon is clicked

--- a/src/components/Input/BaseInput/ControlledBaseInput.tsx
+++ b/src/components/Input/BaseInput/ControlledBaseInput.tsx
@@ -20,6 +20,7 @@ export const ControlledBaseInput: React.FC<ControlledBaseInputProps> = ({
     prefixComponents,
     onClick,
     onKeyPress,
+    onKeyUp,
     onClear,
     onChange,
     onBlur,
@@ -74,7 +75,11 @@ export const ControlledBaseInput: React.FC<ControlledBaseInputProps> = ({
                     onChange={onChange}
                     onBlur={onBlur}
                     onFocus={onFocus}
-                    onKeyPress={onKeyPress}
+                    onKeyPress={e => {
+                        console.warn('onKeyPress is deprecated and will be removed in a future release. You should use onKeyUp instead.');
+                        onKeyPress(e);
+                    }}
+                    onKeyUp={onKeyUp}
                     {...props}
                 />
             </div>

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -127,7 +127,7 @@ export const Menu: React.FC<MenuProps> = ({
                             focusOnField
                             value={inputValue}
                             onChange={e => setInputValue(e.target.value)}
-                            onKeyPress={e => {
+                            onKeyUp={e => {
                                 if (e.key === 'Enter') {
                                     const list = React.Children.toArray(filteredChildren);
                                     if (list.length > 0) {

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -19,6 +19,8 @@ export const MenuItem: React.FC<MenuItemProps> = ({
     imageSize,
     className,
     description,
+    onKeyPress,
+    onKeyUp,
     ...props
 }) => {
     const containerRef = useRef(null);
@@ -45,6 +47,11 @@ export const MenuItem: React.FC<MenuItemProps> = ({
         iconStart={iconStart}
         iconEnd={iconEnd}
         description={description}
+        onKeyPress={e => {
+                        console.warn('onKeyPress is deprecated and will be removed in a future release. You should use onKeyUp instead.');
+                        onKeyPress(e);
+                    }}
+        onKeyUp={onKeyUp}
         {... onArrowNavigation({ref: containerRef})}
         {...props}
     />

--- a/src/components/Menu/MenuItem.types.ts
+++ b/src/components/Menu/MenuItem.types.ts
@@ -49,9 +49,14 @@ export type MenuItemProps = Omit<ListItemProps, 'onClick' | 'onMouseEnter' | 'on
     onMouseLeave?: React.MouseEventHandler,
 
     /**
-     * Function triggered when a key is pressed
+     * @deprecated onKeyPress is deprecated and will be removed in a future release. You should use onKeyUp instead.
      */
     onKeyPress?: React.KeyboardEventHandler
+
+    /**
+     * Function triggered when a key is pressed
+     */
+    onKeyUp?: React.KeyboardEventHandler
 
     /**
      * Which icon size to render. The default is small


### PR DESCRIPTION
- add `onKeyUp` prop where there is a `onKeyPress` prop
- deprecate `onKeyPress` in types
- console warn deprecation message when `onKeyPress` is called