### PR TITLE
feat: fixes and improvements for CE integration

### DIFF
--- a/src/components/Input/BaseInput/BaseInput.scss
+++ b/src/components/Input/BaseInput/BaseInput.scss
@@ -24,17 +24,21 @@ $min-width: 40px;
         @extend %selector_disabled;
     }
 
-    &:has(input:focus-visible) {
-        @extend %is-focused;
-    }
-
     &.moonstone-big {
         min-height: $big-size;
+    }
+
+    &:has(input:focus-visible) {
+        @extend %is-focused;
     }
 
     &.moonstone-outlined {
         border: var(--border-selector);
         border-radius: var(--radius-selector);
+
+        &:hover {
+            border: var(--border-selector_hover);
+        }
     }
 
     .moonstone-reversed & {

--- a/src/components/Input/BaseInput/BaseInput.types.ts
+++ b/src/components/Input/BaseInput/BaseInput.types.ts
@@ -58,9 +58,14 @@ type BasicBaseInputProps = Omit<React.ComponentPropsWithRef<'input'>, 'size' | '
     isShowClearButton?: boolean;
 
     /**
-     * Component
+     * Component(s) to render before the input field.
      */
     prefixComponents?: React.ReactElement[];
+
+    /**
+     * Component(s) to render after the input field.
+     */
+    postfixComponents?: React.ReactElement[];
 
     /**
      * Function

--- a/src/components/Input/BaseInput/ControlledBaseInput.tsx
+++ b/src/components/Input/BaseInput/ControlledBaseInput.tsx
@@ -18,6 +18,7 @@ export const ControlledBaseInput: React.FC<ControlledBaseInputProps> = ({
     variant = 'outlined',
     isShowClearButton,
     prefixComponents,
+    postfixComponents,
     onClick,
     onKeyPress,
     onKeyUp,
@@ -84,6 +85,7 @@ export const ControlledBaseInput: React.FC<ControlledBaseInputProps> = ({
                     onKeyUp={onKeyUp}
                     {...props}
                 />
+                {postfixComponents}
             </div>
             {onClear && isFilled && !isDisabled && !isReadOnly && (
                 <Button


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description

With this PR (https://github.com/Jahia/jcontent/pull/1893/files) I updated the disabled styles in jcontent, as well as switched from using MUI inputs in CE to fully using Moonstone inputs for everything. 

- Postfix components needed for inputs with pickers (color picker/date picker)
- The focus styling fix for textareas and outlined inputs is needed because once input is focused, it displays a large thick blue border around the input, margined as well, so it is even bigger than the input. You could extend this fix to all variants of input if needed, but jcontent is only using outlined
- 


## Tests

The following are included in this PR

- [ ] Unit Tests
- [ ] Accessibility is OK


## Checklist
<!--
This section contains a set of non-automated checks; it serves to remind you to consider some business-critical topics.
 - If any are not applicable, they can simply be deleted.
 - If you need to provide more details, please use the description section.
-->

- [ ] All files present (component - scss - spec - stories)
- [ ] All props ok and documented (typescript types)
- [ ] Required props, default values, variants and colors
- [ ] Example in storybook
- [ ] Reversed style (light/dark mode)
- [ ] Allows custom props
