### PR TITLE
fix: height of SecondaryNavHeader

### DIFF
--- a/src/components/SecondaryNav/SecondaryNavHeader/SecondaryNavHeader.scss
+++ b/src/components/SecondaryNav/SecondaryNavHeader/SecondaryNavHeader.scss
@@ -4,7 +4,7 @@
     @include truncate;
 
     width: 100%;
-    min-height: 3em;
+    min-height: 65px;
 
     padding: var(--spacing-nano);
 

--- a/src/components/SecondaryNav/SecondaryNavHeader/SecondaryNavHeader.tsx
+++ b/src/components/SecondaryNav/SecondaryNavHeader/SecondaryNavHeader.tsx
@@ -5,7 +5,7 @@ import {Typography} from '~/components/Typography';
 import {SecondaryNavHeaderProps} from './SecondaryNavHeader.types';
 
 export const SecondaryNavHeader: React.FC<SecondaryNavHeaderProps> = ({children}) => (
-    <Typography component="div"
+    <Typography component="header"
                 aria-label="moonstone-secondaryNavHeader"
                 className={clsx('moonstone-secondaryNavHeader', 'flexCol_center', 'alignCenter')}
                 variant="heading"


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description
- Set the height to `65px` instead of `3em` to align the height to the separator of the burger menu
- Replace the tag with `header` instead of `div`