### PR TITLE
fix: use `hasChild` to define if the item is a node

### DIFF
--- a/src/components/TreeView/ControlledTreeView.tsx
+++ b/src/components/TreeView/ControlledTreeView.tsx
@@ -123,7 +123,7 @@ const ControlledTreeViewForwardRef: React.ForwardRefRenderFunction<HTMLUListElem
                         ref: containerRef,
                         role: 'treeitem',
                         'aria-selected': isSelected,
-                        'aria-expanded': node.children?.length > 0 ? isOpen : null,
+                        'aria-expanded': hasChild ? isOpen : null,
                         'aria-busy': isLoading,
                         'aria-current': isHighlighted ? 'page' : null,
                         'aria-level': depth + 1,


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description
Use `hasChild` to define if the item is a node.


## Tests

The following are included in this PR

- [ ] Unit Tests
- [ ] Accessibility is OK
