### PR TITLE
fix: Fix Pill overflow in DropdownMenu

### DIFF
--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -37,7 +37,7 @@ const ListItemForwardRef: React.ForwardRefRenderFunction<HTMLLIElement, ListItem
             )}
             {iconStart && (
                 <div className="moonstone-listItem_iconStart flexRow_center alignCenter">
-                    <iconStart.type {...iconStart.props} size={iconSize} className={clsx(iconStart.props.className)}/>
+                    <iconStart.type {...iconStart.props} size={iconSize} className={clsx(`moonstone-icon_${iconSize}`, iconStart.props.className)}/>
                 </div>
             )}
 
@@ -68,7 +68,7 @@ const ListItemForwardRef: React.ForwardRefRenderFunction<HTMLLIElement, ListItem
 
             {iconEnd && (
                 <div className="moonstone-listItem_iconEnd">
-                    <iconEnd.type {...iconEnd.props} size={iconSize} className={clsx(iconEnd.props.className)}/>
+                    <iconEnd.type {...iconEnd.props} size={iconSize} className={clsx(`moonstone-icon_${iconSize}`, iconEnd.props.className)}/>
                 </div>
             )}
         </li>

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -37,7 +37,7 @@ const ListItemForwardRef: React.ForwardRefRenderFunction<HTMLLIElement, ListItem
             )}
             {iconStart && (
                 <div className="moonstone-listItem_iconStart flexRow_center alignCenter">
-                    <iconStart.type {...iconStart.props} size={iconSize} className={clsx(`moonstone-icon_${iconSize}`, iconStart.props.className)}/>
+                    <iconStart.type {...iconStart.props} size={iconSize} className={clsx(iconStart.props.className)}/>
                 </div>
             )}
 
@@ -68,7 +68,7 @@ const ListItemForwardRef: React.ForwardRefRenderFunction<HTMLLIElement, ListItem
 
             {iconEnd && (
                 <div className="moonstone-listItem_iconEnd">
-                    <iconEnd.type {...iconEnd.props} size={iconSize} className={clsx(`moonstone-icon_${iconSize}`, iconEnd.props.className)}/>
+                    <iconEnd.type {...iconEnd.props} size={iconSize} className={clsx(iconEnd.props.className)}/>
                 </div>
             )}
         </li>

--- a/src/components/Pill/Pill.scss
+++ b/src/components/Pill/Pill.scss
@@ -1,5 +1,6 @@
-// empty
 .moonstone-pill {
+    width: auto;
+    height: auto;
     padding: 0 var(--spacing-nano);
 
     border-radius: var(--radius_small);


### PR DESCRIPTION
- Remove `moonstone-icon_${iconSize}` from `ListItem`'s `iconStart` & `iconEnd` props as if the passed component is an `Icon` it would already have the className