### PR TITLE
fix: avoid warning with onClick function on Dropdown and DropdownCustom components

### DIFF
--- a/src/components/Dropdown/CustomDropdown/CustomDropdown.tsx
+++ b/src/components/Dropdown/CustomDropdown/CustomDropdown.tsx
@@ -82,7 +82,7 @@ export const CustomDropdown: React.FC<CustomDropdownProps> = ({
                 aria-busy={isLoading ? true : undefined}
                 className={clsx('moonstone-custom-dropdown-button', {'moonstone-opened': isOpened}, className)}
                 tabIndex={0}
-                onClick={!isDisabled && !isLoading && handleOpenMenu}
+                onClick={(!isDisabled && !isLoading) ? handleOpenMenu : undefined}
                 onKeyUp={e => {
                     if (e.key === 'Enter' && !isDisabled && !isLoading) {
                         handleOpenMenu(e);

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -215,7 +215,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
                 aria-busy={isLoading ? true : undefined}
                 className={clsx(cssDropdown)}
                 tabIndex={0}
-                onClick={!isDisabled && !isLoading && handleOpenMenu}
+                onClick={(!isDisabled && !isLoading) ? handleOpenMenu : undefined}
                 onKeyUp={e => {
                     if (e.key === 'Enter' && !isDisabled && !isLoading) {
                         handleOpenMenu(e);


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description

When in dev mode in jcontent, we get the following warnings in the console:

```
react-dom.development.js:86 Warning: Expected `onClick` listener to be a function, instead got `false`.

If you used to conditionally omit it with onClick={condition && value}, pass onClick={condition ? value : undefined} instead.
    at div
    at div
    at Dn (webpack-internal:///./node_modules/@jahia/moonstone/dist/index.js:1480:9)
    at LanguageSwitcher (webpack-internal:///./src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.jsx:38:5)
    at div
[...]
```