### PR TITLE
chore: remove `NPM_TOKEN` from the publish workflow

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Release and publish
         env:
           GITHUB_TOKEN: ${{ secrets.GH_API_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
         shell: bash
         run: |
           git fetch --tags


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description
Remove the `NPM_TOKEN` from the publication workflow, as we use [trusted publisher](https://docs.npmjs.com/trusted-publishers)