### PR TITLE
refactor: Manage no rendering for `Field` and `Fieldset`

### DIFF
--- a/src/components/Field/Field.spec.tsx
+++ b/src/components/Field/Field.spec.tsx
@@ -2,6 +2,7 @@ import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {Field} from './index';
+import type {FieldProps} from './Field.types';
 import {FieldSelector} from './FieldSelector';
 import {Button, Chip} from '~/index';
 import {Add, Love} from '~/icons';
@@ -12,6 +13,12 @@ const requiredProps = {
 };
 
 describe('Field', () => {
+    it('should render nothing when no children are provided', () => {
+        const incompleteProps = {...requiredProps, children: undefined} as FieldProps;
+        const {container} = render(<Field {...incompleteProps}/>);
+        expect(container).toBeEmptyDOMElement();
+    });
+
     it('should display additional class names', () => {
         render(
             <Field {...requiredProps} data-testid="field" className="extra">

--- a/src/components/Field/Field.types.ts
+++ b/src/components/Field/Field.types.ts
@@ -29,7 +29,7 @@ export type FieldProps = Omit<React.ComponentPropsWithRef<'div'>, 'className' | 
     /**
      * Define field selector(s)
      */
-    children?: React.ReactElement | React.ReactElement[];
+    children: React.ReactElement | React.ReactElement[];
 
     /**
      * Field action(s)

--- a/src/components/Field/FieldSelector/FieldSelector.spec.tsx
+++ b/src/components/Field/FieldSelector/FieldSelector.spec.tsx
@@ -2,10 +2,17 @@ import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {FieldSelector} from './index';
+import type {FieldSelectorProps} from './FieldSelector.types';
 import {Button} from '~/components';
 import {Add, Love} from '~/icons';
 
 describe('FieldSelector', () => {
+    it('should render nothing when no selector is provided', () => {
+        const incompleteProps = {selector: undefined} as FieldSelectorProps;
+        const {container} = render(<FieldSelector {...incompleteProps}/>);
+        expect(container).toBeEmptyDOMElement();
+    });
+
     it('should display additional class names', () => {
         render(
             <FieldSelector

--- a/src/components/Field/FieldSelector/FieldSelector.types.ts
+++ b/src/components/Field/FieldSelector/FieldSelector.types.ts
@@ -19,5 +19,5 @@ export type FieldSelectorProps = Omit<React.ComponentPropsWithRef<'div'>, 'class
     /**
      * FieldSelector selector
      */
-    selector?: React.ReactElement;
+    selector: React.ReactElement;
 };

--- a/src/components/Fieldset/Fieldset.spec.tsx
+++ b/src/components/Fieldset/Fieldset.spec.tsx
@@ -1,6 +1,7 @@
 import {render, screen} from '@testing-library/react';
 
 import {Fieldset} from './index';
+import type {FieldsetProps} from './Fieldset.types';
 import {Button, Input, Field, FieldSelector} from '~/components';
 import {Add, Love} from '~/icons';
 
@@ -45,7 +46,8 @@ describe('Fieldset', () => {
         expect(screen.getAllByText('Click me')).toHaveLength(2);
     });
     it('should render nothing when no children are provided', () => {
-        const {container} = render(<Fieldset {...requiredProps}/>);
+        const incompleteProps = {...requiredProps, children: undefined} as FieldsetProps;
+        const {container} = render(<Fieldset {...incompleteProps}/>);
         expect(container).toBeEmptyDOMElement();
     });
 });

--- a/src/components/Fieldset/Fieldset.types.ts
+++ b/src/components/Fieldset/Fieldset.types.ts
@@ -24,7 +24,7 @@ export type FieldsetProps = {
     /**
      * Define fieldset field(s)
      */
-    children?: React.ReactNode;
+    children: React.ReactNode;
 
     /**
      * Fieldset action(s)


### PR DESCRIPTION
Return null when children/selector props are falsy to keep the DOM cleaner.

- Make `children` optional in Field and Fieldset components
- Make `selector` optional in FieldSelector component
- Add early return `null` for all three components when props are falsy