### PR TITLE
feat: Add the possibility to manage the size of each column in the DataTable Component 

### DIFF
--- a/src/components/DataTable/DataTable.spec.tsx
+++ b/src/components/DataTable/DataTable.spec.tsx
@@ -246,4 +246,47 @@ describe('DataTable', () => {
 
         expect(screen.queryByText('Child')).not.toBeInTheDocument();
     });
+
+    it('should apply column width when specified', () => {
+        const columnsWithWidth = [
+            {
+                key: 'name',
+                label: 'Name',
+                width: '200px',
+                ...stringColumn((row: TestData) => row.name)
+            },
+            {
+                key: 'age',
+                label: 'Age',
+                ...numberColumn((row: TestData) => row.age)
+            }
+        ] as const;
+
+        render(
+            <DataTable<TestData>
+                data={data}
+                columns={columnsWithWidth}
+                primaryKey="id"
+            />
+        );
+
+        const nameHeader = screen.getByText('Name').closest('th');
+        expect(nameHeader).toHaveStyle({width: '200px'});
+
+        const aliceCell = screen.getByText('Alice').closest('td');
+        expect(aliceCell).toHaveStyle({width: '200px'});
+    });
+
+    it('should not set width style when width is undefined', () => {
+        render(
+            <DataTable<TestData>
+                data={data}
+                columns={columns}
+                primaryKey="id"
+            />
+        );
+
+        const nameHeader = screen.getByText('Name').closest('th');
+        expect(nameHeader).not.toHaveStyle({width: '200px'});
+    });
 });

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -155,6 +155,7 @@ export const DataTable = <T extends NonNullable<unknown>>({
                             <TableStructuredCell
                                 key={cell.id}
                                 align={meta?.align ?? 'left'}
+                                width={meta?.width}
                                 depth={row.depth}
                                 isExpandable={row.getCanExpand()}
                                 isExpanded={row.getIsExpanded()}
@@ -169,6 +170,7 @@ export const DataTable = <T extends NonNullable<unknown>>({
                         <TableCell
                             key={cell.id}
                             align={meta?.align ?? 'left'}
+                            width={meta?.width}
                         >
                             {cellContent}
                         </TableCell>
@@ -234,6 +236,7 @@ export const DataTable = <T extends NonNullable<unknown>>({
                                 return (
                                     <TableHeadCell
                                         key={header.id}
+                                        width={meta?.width}
                                         sorting={isColumnSortable ? {
                                             direction: sortDirection === 'desc' ? 'descending' : 'ascending',
                                             isActive: Boolean(sortDirection)

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -11,6 +11,7 @@ export type SubRowKey = 'subRows';
 export type CustomColumnMeta = {
     isSortable?: boolean;
     align?: 'left' | 'center' | 'right';
+    width?: string;
 };
 
 export type TableProps = Omit<React.ComponentPropsWithoutRef<'table'>, 'children' | 'className'> & {
@@ -62,6 +63,12 @@ export type DataTableColumn<T extends NonNullable<unknown>> = {
      * Content alignment for the column
      */
     align?: 'left' | 'center' | 'right';
+
+    /**
+     * Column width as a CSS string (e.g., '250px', '20%').
+     * When undefined, the column takes all available space.
+     */
+    width?: string;
 };
 
 export type DataTableBaseProps<T extends NonNullable<unknown>> = {

--- a/src/data/dataTable/dataColumnsUser.tsx
+++ b/src/data/dataTable/dataColumnsUser.tsx
@@ -44,7 +44,8 @@ export const dataColumnsUser: DataTableColumn<DataUser>[] = [
     {
         key: 'date',
         label: 'Last Login',
-        ...dateColumn<DataUser>(row => row.date, {locale: 'fr-FR'})
+        ...dateColumn<DataUser>(row => row.date, {locale: 'fr-FR'}),
         // Align comes from dateColumn helper
+        width: '150px'
     }
 ];

--- a/src/utils/dataTable/tableHelpers.tsx
+++ b/src/utils/dataTable/tableHelpers.tsx
@@ -18,7 +18,8 @@ export const createTableColumns = <T extends Record<string, unknown>>(
 
         meta: {
             isSortable: col.isSortable ?? false,
-            align: col.align ?? 'left'
+            align: col.align ?? 'left',
+            width: col.width
         },
         enableSorting: col.isSortable ?? false,
 


### PR DESCRIPTION
- Add width string prop to DataTableColumn type for custom column widths
- Add tests for column width styling behavior
- Apply width to TableHeadCell TableCell and TableStructuredCell
-  Add example width to dataColumnsUser Last Login column