### PR TITLE
fix: prevent z-index collision with the Collapsible component

### DIFF
--- a/.chachalog/jBFnSAas.md
+++ b/.chachalog/jBFnSAas.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/moonstone": patch
+---
+
+Prevent z-index issue with the Collapsible component (#1276)

--- a/src/components/Collapsible/Collapsible.scss
+++ b/src/components/Collapsible/Collapsible.scss
@@ -35,17 +35,15 @@
 }
 
 .moonstone-collapsible_button_expanded {
-    position: sticky;
-    top: 0;
-
-    background: var(--color-white);
-
     transition: box-shadow 0.2s ease-in-out 0s;
 }
 
 .moonstone-collapsible_button_sticky {
+    position: sticky;
+    top: 0;
     z-index: 10;
 
+    background: var(--color-white);
     box-shadow: -4px 4px 4px -4px var(--color-gray60);
 }
 

--- a/src/components/Collapsible/Collapsible.scss
+++ b/src/components/Collapsible/Collapsible.scss
@@ -37,7 +37,6 @@
 .moonstone-collapsible_button_expanded {
     position: sticky;
     top: 0;
-    z-index: 10;
 
     background: var(--color-white);
 
@@ -45,6 +44,8 @@
 }
 
 .moonstone-collapsible_button_sticky {
+    z-index: 10;
+
     box-shadow: -4px 4px 4px -4px var(--color-gray60);
 }
 


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description
- Only set z-index when collapsible component is sticky


## Tests

The following are included in this PR

- [ ] Unit Tests
- [ ] Accessibility is OK


## Checklist
<!--
This section contains a set of non-automated checks; it serves to remind you to consider some business-critical topics.
 - If any are not applicable, they can simply be deleted.
 - If you need to provide more details, please use the description section.
-->

- [ ] All files present (component - scss - spec - stories)
- [ ] All props ok and documented (typescript types)
- [ ] Required props, default values, variants and colors
- [ ] Example in storybook
- [ ] Reversed style (light/dark mode)
- [ ] Allows custom props
