### PR TITLE
fix: prevent hover styles on thead row

### DIFF
--- a/.chachalog/05IG6eFh.md
+++ b/.chachalog/05IG6eFh.md
@@ -1,0 +1,5 @@
+---
+"@jahia/moonstone": patch
+---
+
+Prevent hover style on DataTable header

--- a/src/components/DataTable/TableRow/TableRow.module.scss
+++ b/src/components/DataTable/TableRow/TableRow.module.scss
@@ -11,7 +11,7 @@ $background-highlight-hover: var(--color-accent_light_plain40);
     border-bottom: 1px solid var(--color-gray_light);
     background-color: var(--moon-row-background);
 
-    &:not(.header) {
+    &:not(.head) {
         &:focus-within,
         &:hover {
             --moon-row-background: #{$background-hover};


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description

Prevent hover styles on `thead`'s row