### PR TITLE
fix: Fix repositioning on context menu

### DIFF
--- a/.chachalog/1P6lxSvc.md
+++ b/.chachalog/1P6lxSvc.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/moonstone": patch
+---
+
+Fix context menu repositioning on resize (#1376)

--- a/src/components/ListItem/ListItem.stories.tsx
+++ b/src/components/ListItem/ListItem.stories.tsx
@@ -20,7 +20,7 @@ export default {
 
 export const Default: StoryObj<ListItemProps> = {
     render: args => (
-        <ul style={{ padding: 0, margin: 0 }}>
+        <ul style={{padding: 0, margin: 0}}>
             <ListItem {...args}/>
         </ul>
     ),
@@ -32,7 +32,7 @@ export const Default: StoryObj<ListItemProps> = {
 
 export const IconText: StoryObj<ListItemProps> = {
     render: args => (
-        <ul style={{ padding: 0, margin: 0 }}>
+        <ul style={{padding: 0, margin: 0}}>
             <ListItem {...args}/>
         </ul>
     ),
@@ -47,7 +47,7 @@ export const IconText: StoryObj<ListItemProps> = {
 
 export const IconTextIcon: StoryObj<ListItemProps> = {
     render: args => (
-        <ul style={{ padding: 0 }}>
+        <ul style={{padding: 0}}>
             <ListItem {...args}/>
         </ul>
     ),
@@ -63,7 +63,7 @@ export const IconTextIcon: StoryObj<ListItemProps> = {
 
 export const WithBigImage: StoryObj<ListItemProps> = {
     render: args => (
-        <ul style={{ padding: 0 }}>
+        <ul style={{padding: 0}}>
             <ListItem
                 image={<img src={imgVertical} alt="vertical big image"/>}
                 {...args}
@@ -87,7 +87,7 @@ export const WithBigImage: StoryObj<ListItemProps> = {
 
 export const WithSmallImage: StoryObj<ListItemProps> = {
     render: args => (
-        <ul style={{ padding: 0 }}>
+        <ul style={{padding: 0}}>
             <ListItem
                 image={<img src={imgVertical} alt="vertical small image"/>}
                 {...args}

--- a/src/components/RadioGroup/RadioItem/RadioItem.tsx
+++ b/src/components/RadioGroup/RadioItem/RadioItem.tsx
@@ -27,7 +27,7 @@ export const RadioItem: React.FC<RadioItemProps> = ({className, id, value, label
             weight="default"
             component="label"
         >
-            <div className={clsx('flexRow', layout.flexRow, 'alignCenter', layout.alignCenter, styles['radioItem_wrapper'])}>
+            <div className={clsx('flexRow', layout.flexRow, 'alignCenter', layout.alignCenter, styles.radioItem_wrapper)}>
                 <div className={clsx('moonstone-radio', styles['moonstone-radio'])}>
                     <input
                         {...props}

--- a/src/hooks/usePositioning.spec.tsx
+++ b/src/hooks/usePositioning.spec.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import {render, act, waitFor} from '@testing-library/react';
+import {usePositioning} from './usePositioning';
+
+const defaultAnchorElOrigin = {horizontal: 'left' as const, vertical: 'bottom' as const};
+const defaultTransformElOrigin = {horizontal: 'left' as const, vertical: 'top' as const};
+const defaultAnchorPosition = {top: 0, left: 0};
+
+type TestComponentProps = {
+    isDisplayed: boolean;
+    anchorEl: React.RefObject<HTMLElement>;
+};
+
+const TestComponent = ({isDisplayed, anchorEl}: TestComponentProps) => {
+    const [style, menuRef] = usePositioning(
+        isDisplayed,
+        defaultAnchorPosition,
+        anchorEl as React.MutableRefObject<HTMLElement>,
+        defaultAnchorElOrigin,
+        defaultTransformElOrigin,
+        'fixed'
+    );
+    return <div ref={menuRef} style={style as React.CSSProperties} data-testid="menu"/>;
+};
+
+describe('usePositioning - ResizeObserver', () => {
+    let observeMock: ReturnType<typeof vi.fn>;
+    let disconnectMock: ReturnType<typeof vi.fn>;
+    let capturedResizeCallback: ResizeObserverCallback | null;
+
+    beforeEach(() => {
+        observeMock = vi.fn();
+        disconnectMock = vi.fn();
+        capturedResizeCallback = null;
+
+        // vi.fn().mockImplementation produces an arrow function which can't be used with `new`.
+        // Use a class that closes over the mocks instead.
+        class ResizeObserverMock {
+            constructor(cb: ResizeObserverCallback) {
+                capturedResizeCallback = cb;
+            }
+
+            observe = observeMock;
+            disconnect = disconnectMock;
+            unobserve = vi.fn();
+        }
+
+        global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    const makeAnchorEl = () => {
+        const el = document.createElement('div');
+        return {current: el};
+    };
+
+    it('should observe the menu element when displayed', () => {
+        const anchorEl = makeAnchorEl();
+        render(<TestComponent isDisplayed anchorEl={anchorEl}/>);
+        expect(observeMock).toHaveBeenCalled();
+        expect(capturedResizeCallback).not.toBeNull();
+    });
+
+    it('should not observe when not displayed', () => {
+        const anchorEl = makeAnchorEl();
+        render(<TestComponent isDisplayed={false} anchorEl={anchorEl}/>);
+        expect(observeMock).not.toHaveBeenCalled();
+    });
+
+    it('should disconnect the observer when isDisplayed changes to false', () => {
+        const anchorEl = makeAnchorEl();
+        const {rerender} = render(<TestComponent isDisplayed anchorEl={anchorEl}/>);
+        expect(disconnectMock).not.toHaveBeenCalled();
+
+        rerender(<TestComponent isDisplayed={false} anchorEl={anchorEl}/>);
+        expect(disconnectMock).toHaveBeenCalled();
+    });
+
+    it('should disconnect and reconnect the observer when isDisplayed toggles back to true', () => {
+        const anchorEl = makeAnchorEl();
+        const {rerender} = render(<TestComponent isDisplayed anchorEl={anchorEl}/>);
+
+        rerender(<TestComponent isDisplayed={false} anchorEl={anchorEl}/>);
+        expect(disconnectMock).toHaveBeenCalledTimes(1);
+
+        rerender(<TestComponent isDisplayed anchorEl={anchorEl}/>);
+        expect(observeMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should invoke computePosition when the resize callback fires', () => {
+        const anchorElement = document.createElement('div');
+        const getBoundingClientRectMock = vi.fn().mockReturnValue({
+            top: 0, bottom: 100, left: 75, right: 175, width: 100, height: 50
+        } as DOMRect);
+        anchorElement.getBoundingClientRect = getBoundingClientRectMock;
+        const anchorEl = {current: anchorElement};
+
+        render(<TestComponent isDisplayed anchorEl={anchorEl}/>);
+
+        // computePosition ran once on mount
+        const callsAfterMount = getBoundingClientRectMock.mock.calls.length;
+        expect(callsAfterMount).toBeGreaterThan(0);
+
+        // Fire the resize observer callback — should trigger computePosition again
+        expect(capturedResizeCallback).not.toBeNull();
+        act(() => {
+            capturedResizeCallback?.([], null as unknown as ResizeObserver);
+        });
+
+        expect(getBoundingClientRectMock.mock.calls.length).toBeGreaterThan(callsAfterMount);
+    });
+
+    it('should not invoke computePosition when not displayed', () => {
+        const anchorEl = makeAnchorEl();
+        const getBoundingClientRectMock = vi.fn().mockReturnValue({
+            top: 0, bottom: 100, left: 75, right: 175, width: 100, height: 50
+        } as DOMRect);
+        anchorEl.current!.getBoundingClientRect = getBoundingClientRectMock;
+
+        render(<TestComponent isDisplayed={false} anchorEl={anchorEl}/>);
+
+        // computePosition should not run when not displayed — menu stays off-screen
+        expect(getBoundingClientRectMock).not.toHaveBeenCalled();
+    });
+});

--- a/src/hooks/usePositioning.spec.tsx
+++ b/src/hooks/usePositioning.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, act, waitFor} from '@testing-library/react';
+import {render, act} from '@testing-library/react';
 import {usePositioning} from './usePositioning';
 
 const defaultAnchorElOrigin = {horizontal: 'left' as const, vertical: 'bottom' as const};
@@ -7,8 +7,8 @@ const defaultTransformElOrigin = {horizontal: 'left' as const, vertical: 'top' a
 const defaultAnchorPosition = {top: 0, left: 0};
 
 type TestComponentProps = {
-    isDisplayed: boolean;
-    anchorEl: React.RefObject<HTMLElement>;
+    readonly isDisplayed: boolean;
+    readonly anchorEl: React.RefObject<HTMLElement>;
 };
 
 const TestComponent = ({isDisplayed, anchorEl}: TestComponentProps) => {
@@ -33,7 +33,7 @@ describe('usePositioning - ResizeObserver', () => {
         disconnectMock = vi.fn();
         capturedResizeCallback = null;
 
-        // vi.fn().mockImplementation produces an arrow function which can't be used with `new`.
+        // Vi.fn().mockImplementation produces an arrow function which can't be used with `new`.
         // Use a class that closes over the mocks instead.
         class ResizeObserverMock {
             constructor(cb: ResizeObserverCallback) {
@@ -45,7 +45,7 @@ describe('usePositioning - ResizeObserver', () => {
             unobserve = vi.fn();
         }
 
-        global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+        window.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
     });
 
     afterEach(() => {
@@ -100,7 +100,7 @@ describe('usePositioning - ResizeObserver', () => {
 
         render(<TestComponent isDisplayed anchorEl={anchorEl}/>);
 
-        // computePosition ran once on mount
+        // ComputePosition ran once on mount
         const callsAfterMount = getBoundingClientRectMock.mock.calls.length;
         expect(callsAfterMount).toBeGreaterThan(0);
 
@@ -122,7 +122,7 @@ describe('usePositioning - ResizeObserver', () => {
 
         render(<TestComponent isDisplayed={false} anchorEl={anchorEl}/>);
 
-        // computePosition should not run when not displayed — menu stays off-screen
+        // ComputePosition should not run when not displayed — menu stays off-screen
         expect(getBoundingClientRectMock).not.toHaveBeenCalled();
     });
 });

--- a/src/hooks/usePositioning.tsx
+++ b/src/hooks/usePositioning.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import toPX from 'to-px';
 
 type Position = {
@@ -279,13 +279,21 @@ export const usePositioning = (
     const [stylePosition, setStylePosition] = useState<React.CSSProperties>(initialPosition as React.CSSProperties);
     const itemRef = useRef(null);
 
+    const computePosition = useCallback(() => {
+        if (!itemRef.current) {
+            return;
+        }
+
+        const resolvedAnchorEl = (anchorEl && anchorEl.current ? anchorEl.current : anchorEl) as HTMLDivElement;
+        const _stylePosition = (position === 'absolute' || hasTransform(resolvedAnchorEl)) ?
+            getAbsolutePosition(itemRef, anchorElOrigin, transformElOrigin, anchorPosition) :
+            getFixedPosition(itemRef, anchorEl, anchorElOrigin, transformElOrigin, anchorPosition);
+        setStylePosition(_stylePosition);
+    }, [anchorEl, anchorPosition, anchorElOrigin, transformElOrigin, position]);
+
     useEffect(() => {
         if (isDisplayed) {
-            const resolvedAnchorEl = (anchorEl && anchorEl.current ? anchorEl.current : anchorEl) as HTMLDivElement;
-            const _stylePosition = (position === 'absolute' || hasTransform(resolvedAnchorEl)) ?
-                getAbsolutePosition(itemRef, anchorElOrigin, transformElOrigin, anchorPosition) :
-                getFixedPosition(itemRef, anchorEl, anchorElOrigin, transformElOrigin, anchorPosition);
-            setStylePosition(_stylePosition);
+            computePosition();
         } else {
             setStylePosition(initialPosition);
         }
@@ -295,11 +303,24 @@ export const usePositioning = (
         anchorElOrigin.vertical,
         anchorElOrigin.horizontal,
         isDisplayed,
-        itemRef,
         anchorElOrigin,
         transformElOrigin,
-        position
+        position,
+        computePosition
     ]);
+
+    // Reposition when the menu resizes (e.g. loading items resolve and some become invisible)
+    useEffect(() => {
+        if (!isDisplayed || !itemRef.current) {
+            return;
+        }
+
+        const observer = new ResizeObserver(() => {
+            computePosition();
+        });
+        observer.observe(itemRef.current);
+        return () => observer.disconnect();
+    }, [isDisplayed, computePosition]);
 
     return [stylePosition, itemRef];
 };


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description

Fix an issue where menu (In this case context menu) loses anchor when menu resizes.

We now add a `ResizeObserver` so that position is recomputed when size of menu changes.

- Refactored existing useEffect and created a `computePosition` method to be able to reuse in the resize observer as well.
- Added test for usePositioning hook, covering resize scenario

## Tests

The following are included in this PR

- [x] Unit Tests
- [ ] Accessibility is OK


## Checklist
<!--
This section contains a set of non-automated checks; it serves to remind you to consider some business-critical topics.
 - If any are not applicable, they can simply be deleted.
 - If you need to provide more details, please use the description section.
-->

- [ ] All files present (component - scss - spec - stories)
- [ ] All props ok and documented (typescript types)
- [ ] Required props, default values, variants and colors
- [ ] Example in storybook
- [ ] Reversed style (light/dark mode)
- [ ] Allows custom props
