### PR TITLE
fix: improve controlled DataTable features

### DIFF
--- a/.chachalog/lNFAy4J-.md
+++ b/.chachalog/lNFAy4J-.md
@@ -2,4 +2,6 @@
 "@jahia/moonstone": patch
 ---
 
-Improved DataTable controlled sorting, pagination, and row expansion behavior
+Changed DataTable row and cell callbacks to use a stable context object instead of internal table rows, and improved controlled sorting, pagination, and row expansion behavior.
+
+If you customize DataTable row or cell rendering, update your callbacks to use the new `id`, `data`, `meta`, and `render` fields.

--- a/.chachalog/lNFAy4J-.md
+++ b/.chachalog/lNFAy4J-.md
@@ -2,4 +2,4 @@
 "@jahia/moonstone": patch
 ---
 
-Improve controlled features of DataTable
+Improved DataTable controlled sorting, pagination, and row expansion behavior

--- a/.chachalog/lNFAy4J-.md
+++ b/.chachalog/lNFAy4J-.md
@@ -1,0 +1,5 @@
+---
+"@jahia/moonstone": patch
+---
+
+Improve controlled features of DataTable

--- a/src/components/DataTable/DataTable.spec.tsx
+++ b/src/components/DataTable/DataTable.spec.tsx
@@ -82,13 +82,11 @@ const sortableColumns = [
     {
         key: 'name',
         label: 'Name',
-        isSortable: true,
         ...stringColumn((row: TestData) => row.name)
     },
     {
         key: 'age',
         label: 'Age',
-        isSortable: true,
         ...numberColumn((row: TestData) => row.age)
     }
 ] as const;
@@ -201,6 +199,42 @@ describe('DataTable', () => {
         rows.forEach(row => {
             expect(row.tagName).toBe('TR');
         });
+    });
+
+    it('should apply rowProps function per row', () => {
+        render(
+            <DataTable<TestData>
+                data={data}
+                columns={columns}
+                primaryKey="id"
+                rowProps={row => ({'data-testid': `row-${row.id}`})}
+            />
+        );
+
+        expect(screen.getByTestId('row-1')).toBeInTheDocument();
+        expect(screen.getByTestId('row-2')).toBeInTheDocument();
+        expect(screen.getByTestId('row-3')).toBeInTheDocument();
+    });
+
+    it('should apply conditional className via rowProps function', () => {
+        render(
+            <DataTable<TestData>
+                data={data}
+                columns={columns}
+                primaryKey="id"
+                rowProps={row => ({
+                    'data-testid': 'conditional-row',
+                    className: row.age >= 30 ? 'senior' : 'junior'
+                })}
+            />
+        );
+
+        const rows = screen.getAllByTestId('conditional-row');
+        expect(rows).toHaveLength(3);
+        // Alice (30) and Charlie (35) are senior, Bob (25) is junior
+        expect(rows[0]).toHaveClass('senior'); // Alice
+        expect(rows[1]).toHaveClass('junior'); // Bob
+        expect(rows[2]).toHaveClass('senior'); // Charlie
     });
 
     it('should render both before and after custom cells', () => {

--- a/src/components/DataTable/DataTable.spec.tsx
+++ b/src/components/DataTable/DataTable.spec.tsx
@@ -137,12 +137,12 @@ describe('DataTable', () => {
                 data={data}
                 columns={columns}
                 primaryKey="id"
-                renderRow={(row, defaultRender) => (
-                    <TableRow key={row.id} data-testid={row.id}>
-                        {defaultRender({
+                renderRow={({id, data: rowData, render: renderCells}) => (
+                    <TableRow key={id} data-testid={id}>
+                        {renderCells({
                             after: (
-                                <TableCell data-testid={`after-${row.id}`}>
-                                    {row.original.name}
+                                <TableCell data-testid={`after-${id}`}>
+                                    {rowData.name}
                                 </TableCell>
                             )
                         })}
@@ -164,12 +164,12 @@ describe('DataTable', () => {
                 data={data}
                 columns={columns}
                 primaryKey="id"
-                renderRow={(row, defaultRender) => (
-                    <TableRow key={row.id} data-testid={row.id}>
-                        {defaultRender({
+                renderRow={({id, data: rowData, render: renderCells}) => (
+                    <TableRow key={id} data-testid={id}>
+                        {renderCells({
                             before: (
-                                <TableCell data-testid={`before-${row.id}`}>
-                                    {row.original.name}
+                                <TableCell data-testid={`before-${id}`}>
+                                    {rowData.name}
                                 </TableCell>
                             )
                         })}
@@ -207,7 +207,7 @@ describe('DataTable', () => {
                 data={data}
                 columns={columns}
                 primaryKey="id"
-                rowProps={row => ({'data-testid': `row-${row.id}`})}
+                rowProps={({id}) => ({'data-testid': `row-${id}`})}
             />
         );
 
@@ -222,9 +222,9 @@ describe('DataTable', () => {
                 data={data}
                 columns={columns}
                 primaryKey="id"
-                rowProps={row => ({
+                rowProps={({data: rowData}) => ({
                     'data-testid': 'conditional-row',
-                    className: row.age >= 30 ? 'senior' : 'junior'
+                    className: rowData.age >= 30 ? 'senior' : 'junior'
                 })}
             />
         );
@@ -243,17 +243,17 @@ describe('DataTable', () => {
                 data={data}
                 columns={columns}
                 primaryKey="id"
-                renderRow={(row, defaultRender) => (
-                    <TableRow key={row.id}>
-                        {defaultRender({
+                renderRow={({id, render: renderCells}) => (
+                    <TableRow key={id}>
+                        {renderCells({
                             before: (
-                                <TableCell data-testid={`before-${row.id}`}>
-                                    {`before-${row.id}`}
+                                <TableCell data-testid={`before-${id}`}>
+                                    {`before-${id}`}
                                 </TableCell>
                             ),
                             after: (
-                                <TableCell data-testid={`after-${row.id}`}>
-                                    {`after-${row.id}`}
+                                <TableCell data-testid={`after-${id}`}>
+                                    {`after-${id}`}
                                 </TableCell>
                             )
                         })}
@@ -520,9 +520,9 @@ describe('DataTable', () => {
             {
                 key: 'name',
                 label: 'Name',
-                cellProps: (row: TestData) => ({
+                cellProps: ({data: cellData}: {data: TestData}) => ({
                     'data-testid': 'fn-cell',
-                    className: row.age >= 30 ? 'senior' : 'junior'
+                    className: cellData.age >= 30 ? 'senior' : 'junior'
                 }),
                 ...stringColumn((row: TestData) => row.name)
             },
@@ -554,7 +554,7 @@ describe('DataTable', () => {
             {
                 key: 'name',
                 label: 'Name',
-                cellProps: (row: TestData) => ({'data-testid': `name-cell-${row.id}`}),
+                cellProps: ({data: cellData}: {data: TestData}) => ({'data-testid': `name-cell-${cellData.id}`}),
                 ...stringColumn((row: TestData) => row.name)
             },
             {
@@ -946,9 +946,9 @@ describe('DataTable custom cells', () => {
                 data={statusBarData}
                 columns={statusBarColumns}
                 primaryKey="id"
-                renderRow={(row, defaultRender) => (
-                    <TableRow key={row.id}>
-                        {defaultRender({
+                renderRow={({id, render: renderCells}) => (
+                    <TableRow key={id}>
+                        {renderCells({
                             before: <TableCellStatus color="success">test</TableCellStatus>
                         })}
                     </TableRow>

--- a/src/components/DataTable/DataTable.spec.tsx
+++ b/src/components/DataTable/DataTable.spec.tsx
@@ -607,7 +607,7 @@ describe('DataTable', () => {
     it('should respect controlled pagination', () => {
         // Controlled (server-side) pagination: the caller provides only the current page's items.
         // With manualPagination=true TanStack renders data as-is without client-side slicing.
-        const page2Data = [data[1]]; // only Bob, the single item for page 2
+        const page2Data = [data[1]]; // Only Bob, the single item for page 2
         render(
             <DataTable<TestData>
                 enablePagination

--- a/src/components/DataTable/DataTable.spec.tsx
+++ b/src/components/DataTable/DataTable.spec.tsx
@@ -255,6 +255,113 @@ describe('DataTable', () => {
         expect(screen.getByText('Child')).toBeInTheDocument();
     });
 
+    it('should not reset expansion state when data reference changes', async () => {
+        // Regression: useEffect with [data] was calling toggleAllRowsExpanded on every data change,
+        // reverting any manual collapse done by the user.
+        const user = userEvent.setup();
+        const {rerender} = render(
+            <DataTable<TestData>
+                isStructured
+                data={structuredData}
+                columns={columns}
+                primaryKey="id"
+            />
+        );
+
+        // Collapse the parent row
+        await user.click(screen.getByText('Parent'));
+        expect(screen.queryByText('Child')).not.toBeInTheDocument();
+
+        // Simulate a data reference change with same content (e.g. re-fetch, filter)
+        rerender(
+            <DataTable<TestData>
+                isStructured
+                data={[...structuredData]}
+                columns={columns}
+                primaryKey="id"
+            />
+        );
+
+        // Expansion state must be preserved — child must remain hidden
+        expect(screen.queryByText('Child')).not.toBeInTheDocument();
+    });
+
+    it('should expand only specified rows via defaultExpandedRows', () => {
+        const multiParentData: TestData[] = [
+            {id: '1', name: 'Parent A', age: 50, subRows: [{id: '1.1', name: 'Child A', age: 10}]},
+            {id: '2', name: 'Parent B', age: 60, subRows: [{id: '2.1', name: 'Child B', age: 20}]}
+        ];
+
+        render(
+            <DataTable<TestData>
+                isStructured
+                data={multiParentData}
+                columns={columns}
+                primaryKey="id"
+                defaultExpandedRows={['1']}
+            />
+        );
+
+        expect(screen.getByText('Child A')).toBeInTheDocument();
+        expect(screen.queryByText('Child B')).not.toBeInTheDocument();
+    });
+
+    it('should respect controlled expandedRows prop', () => {
+        const multiParentData: TestData[] = [
+            {id: '1', name: 'Parent A', age: 50, subRows: [{id: '1.1', name: 'Child A', age: 10}]},
+            {id: '2', name: 'Parent B', age: 60, subRows: [{id: '2.1', name: 'Child B', age: 20}]}
+        ];
+
+        const {rerender} = render(
+            <DataTable<TestData>
+                isStructured
+                data={multiParentData}
+                columns={columns}
+                primaryKey="id"
+                expandedRows={['1']}
+                onExpandChange={() => { }}
+            />
+        );
+
+        expect(screen.getByText('Child A')).toBeInTheDocument();
+        expect(screen.queryByText('Child B')).not.toBeInTheDocument();
+
+        // Parent updates controlled state to expand second parent
+        rerender(
+            <DataTable<TestData>
+                isStructured
+                data={multiParentData}
+                columns={columns}
+                primaryKey="id"
+                expandedRows={['2']}
+                onExpandChange={() => { }}
+            />
+        );
+
+        expect(screen.queryByText('Child A')).not.toBeInTheDocument();
+        expect(screen.getByText('Child B')).toBeInTheDocument();
+    });
+
+    it('should call onExpandChange when a row is toggled', async () => {
+        const onExpandChange = vi.fn();
+        const user = userEvent.setup();
+
+        render(
+            <DataTable<TestData>
+                isStructured
+                data={structuredData}
+                columns={columns}
+                primaryKey="id"
+                onExpandChange={onExpandChange}
+            />
+        );
+
+        await user.click(screen.getByText('Parent'));
+        // When collapsing parent "1", TanStack transitions from `true` (all expanded) to an explicit
+        // record; child "1.1" remains listed as expanded in the record even though it is hidden.
+        expect(onExpandChange).toHaveBeenCalledWith(['1.1']);
+    });
+
     it('should toggle row when clicking on the expandable node', async () => {
         const user = userEvent.setup();
         render(
@@ -374,6 +481,68 @@ describe('DataTable', () => {
         expect(nameCells.length).toBeGreaterThan(0);
     });
 
+    it('should apply cellProps function to regular cells per row', () => {
+        const columnsWithFnCellProps = [
+            {
+                key: 'name',
+                label: 'Name',
+                cellProps: (row: TestData) => ({
+                    'data-testid': 'fn-cell',
+                    className: row.age >= 30 ? 'senior' : 'junior'
+                }),
+                ...stringColumn((row: TestData) => row.name)
+            },
+            {
+                key: 'age',
+                label: 'Age',
+                ...numberColumn((row: TestData) => row.age)
+            }
+        ] as const;
+
+        render(
+            <DataTable<TestData>
+                data={data}
+                columns={columnsWithFnCellProps}
+                primaryKey="id"
+            />
+        );
+
+        const nameCells = screen.getAllByTestId('fn-cell');
+        expect(nameCells).toHaveLength(data.length);
+        // Alice (30) and Charlie (35) are senior, Bob (25) is junior
+        expect(nameCells[0]).toHaveClass('senior'); // Alice
+        expect(nameCells[1]).toHaveClass('junior'); // Bob
+        expect(nameCells[2]).toHaveClass('senior'); // Charlie
+    });
+
+    it('should apply cellProps function to structured cells per row', () => {
+        const columnsWithFnCellProps = [
+            {
+                key: 'name',
+                label: 'Name',
+                cellProps: (row: TestData) => ({'data-testid': `name-cell-${row.id}`}),
+                ...stringColumn((row: TestData) => row.name)
+            },
+            {
+                key: 'age',
+                label: 'Age',
+                ...numberColumn((row: TestData) => row.age)
+            }
+        ] as const;
+
+        render(
+            <DataTable
+                isStructured
+                data={structuredData}
+                columns={columnsWithFnCellProps}
+                primaryKey="id"
+            />
+        );
+
+        expect(screen.getByTestId('name-cell-1')).toBeInTheDocument();
+        expect(screen.getByTestId('name-cell-1.1')).toBeInTheDocument();
+    });
+
     it('should display controlled selection from selection prop', () => {
         render(
             <DataTable<TestData>
@@ -436,12 +605,13 @@ describe('DataTable', () => {
     });
 
     it('should respect controlled pagination', () => {
-        // Controlled pagination: state is managed externally, but TanStack still handles client-side slicing.
-        // Pass full data and TanStack will display the correct page based on currentPage/itemsPerPage.
+        // Controlled (server-side) pagination: the caller provides only the current page's items.
+        // With manualPagination=true TanStack renders data as-is without client-side slicing.
+        const page2Data = [data[1]]; // only Bob, the single item for page 2
         render(
             <DataTable<TestData>
                 enablePagination
-                data={data}
+                data={page2Data}
                 columns={columns}
                 primaryKey="id"
                 currentPage={2}
@@ -456,6 +626,39 @@ describe('DataTable', () => {
         expect(screen.getByText('Bob')).toBeInTheDocument();
         expect(screen.queryByText('Alice')).not.toBeInTheDocument();
         expect(screen.queryByText('Charlie')).not.toBeInTheDocument();
+    });
+
+    it('should display server-side page data without client-side slicing on page 2', () => {
+        // Regression test: when currentPage=2 and data contains only the 5 items returned by the server
+        // for that page, all 5 items should be visible (not sliced to an empty set by TanStack).
+        const serverPage2Data: TestData[] = [
+            {id: '6', name: 'Frank', age: 28},
+            {id: '7', name: 'Grace', age: 33},
+            {id: '8', name: 'Hank', age: 41},
+            {id: '9', name: 'Ivy', age: 22},
+            {id: '10', name: 'Jack', age: 37}
+        ];
+
+        render(
+            <DataTable<TestData>
+                enablePagination
+                data={serverPage2Data}
+                columns={columns}
+                primaryKey="id"
+                currentPage={2}
+                itemsPerPage={5}
+                totalItems={10}
+                itemsPerPageOptions={[5, 10]}
+                onPageChange={() => { }}
+                onItemsPerPageChange={() => { }}
+            />
+        );
+
+        expect(screen.getByText('Frank')).toBeInTheDocument();
+        expect(screen.getByText('Grace')).toBeInTheDocument();
+        expect(screen.getByText('Hank')).toBeInTheDocument();
+        expect(screen.getByText('Ivy')).toBeInTheDocument();
+        expect(screen.getByText('Jack')).toBeInTheDocument();
     });
 
     it('should allow custom attributes to the Pagination component', () => {
@@ -576,6 +779,60 @@ describe('DataTable sorting feature', () => {
         expect(within(rows[1]).getByText('Charlie')).toBeVisible();
         expect(within(rows[2]).getByText('Bob')).toBeVisible();
         expect(within(rows[3]).getByText('Alice')).toBeVisible();
+    });
+
+    it('should respect controlled sorting and not re-sort server-sorted data', () => {
+        // Server returns data already sorted descending by age; TanStack must not re-sort locally.
+        const serverSortedData: TestData[] = [
+            {id: '3', name: 'Charlie', age: 35},
+            {id: '1', name: 'Alice', age: 30},
+            {id: '2', name: 'Bob', age: 25}
+        ];
+
+        render(
+            <DataTable<TestData>
+                enableSorting
+                data={serverSortedData}
+                columns={sortableColumns}
+                primaryKey="id"
+                sortBy="age"
+                sortDirection="descending"
+                onSortChange={() => { }}
+            />
+        );
+
+        const rows = screen.getAllByRole('row');
+        expect(within(rows[1]).getByText('Charlie')).toBeVisible();
+        expect(within(rows[2]).getByText('Alice')).toBeVisible();
+        expect(within(rows[3]).getByText('Bob')).toBeVisible();
+    });
+
+    it('should call onSortChange and not mutate order when controlled', async () => {
+        const onSortChange = vi.fn();
+        const user = userEvent.setup();
+
+        // Server returns data in a fixed order; clicking a header must fire onSortChange only.
+        render(
+            <DataTable<TestData>
+                enableSorting
+                data={data}
+                columns={sortableColumns}
+                primaryKey="id"
+                sortBy="name"
+                sortDirection="ascending"
+                onSortChange={onSortChange}
+            />
+        );
+
+        await user.click(screen.getByText('Age'));
+
+        expect(onSortChange).toHaveBeenCalledWith('age', expect.any(String));
+
+        // Order must remain unchanged (server hasn't responded yet)
+        const rows = screen.getAllByRole('row');
+        expect(within(rows[1]).getByText('Alice')).toBeVisible();
+        expect(within(rows[2]).getByText('Bob')).toBeVisible();
+        expect(within(rows[3]).getByText('Charlie')).toBeVisible();
     });
 });
 

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -121,15 +121,15 @@ export const InsertCells: Story = {
         return (
             <DataTable
                 {...args}
-                renderRow={(row, renderCells) => (
+                renderRow={({id, data, render: renderCells}) => (
                     <TableRow
-                        key={row.id}
+                        key={id}
                     >
                         {renderCells({
                             before: (
-                                <TableCellStatus color={getStatus(row.original.status).color}>
+                                <TableCellStatus color={getStatus(data.status).color}>
                                     <>
-                                        {getStatus(row.original.status).iconStart} {getStatus(row.original.status).text}
+                                        {getStatus(data.status).iconStart} {getStatus(data.status).text}
                                     </>
                                 </TableCellStatus>
                             ),

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -6,9 +6,9 @@ import {
     getPaginationRowModel
 } from '@tanstack/react-table';
 import {toNodeArray} from '~/utils/helpers';
-import type {ExpandedState, Row} from '@tanstack/react-table';
-import React, {useState, useEffect, useMemo, useCallback} from 'react';
-import {useCustomCells, usePagination, useSelection, useSorting} from './hooks';
+import type {Row} from '@tanstack/react-table';
+import React, {useMemo, useCallback} from 'react';
+import {useCustomCells, useExpansion, usePagination, useSelection, useSorting} from './hooks';
 import type {DataTableProps, RenderOptions} from './DataTable.types';
 import {createTableColumns} from './shared';
 import {renderCell, renderHeadCell} from './utils';
@@ -42,6 +42,9 @@ export const DataTable = <T extends NonNullable<unknown>>({
     defaultSortBy,
     defaultSortDirection = 'ascending',
     defaultSelection = [],
+    expandedRows,
+    defaultExpandedRows,
+    onExpandChange,
     renderRow,
     onClickTableHeadCell,
     selectionCellProps,
@@ -60,7 +63,12 @@ export const DataTable = <T extends NonNullable<unknown>>({
     rowProps,
     ...props
 }: DataTableProps<T>) => {
-    const [expanded, setExpanded] = useState<ExpandedState>({});
+    const {expanded, handleExpandedChange} = useExpansion({
+        expandedRows,
+        defaultExpandedRows: defaultExpandedRows ?? (isStructured ? true : undefined),
+        onExpandChange
+    });
+
     const {
         customBeforeCount,
         customAfterCount,
@@ -73,7 +81,7 @@ export const DataTable = <T extends NonNullable<unknown>>({
         renderRow
     });
 
-    const {sorting, handleSortingChange} = useSorting<T>({
+    const {sorting, isSortingControlled, handleSortingChange} = useSorting<T>({
         sortBy,
         sortDirection,
         defaultSortBy,
@@ -109,12 +117,15 @@ export const DataTable = <T extends NonNullable<unknown>>({
             ...(enablePagination && {pagination})
         },
         onSortingChange: handleSortingChange,
-        onExpandedChange: setExpanded,
+        onExpandedChange: handleExpandedChange,
         onRowSelectionChange: handleRowSelectionChange,
         getCoreRowModel: getCoreRowModel(),
         getSortedRowModel: enableSorting ? getSortedRowModel() : undefined,
+        manualSorting: isSortingControlled,
         getExpandedRowModel: getExpandedRowModel(),
         getPaginationRowModel: enablePagination ? getPaginationRowModel() : undefined,
+        manualPagination: isPaginationControlled,
+        rowCount: isPaginationControlled ? totalItems : undefined,
         // Enables hierarchical/structured table rendering by allowing TanStack to access nested subRows
         getSubRows: (row: T) => (row as T & { subRows?: T[] }).subRows,
         onPaginationChange: enablePagination ? handlePaginationChange : undefined,
@@ -124,12 +135,6 @@ export const DataTable = <T extends NonNullable<unknown>>({
         enableRowSelection: enableSelection,
         getRowId: (row: T) => String(row[primaryKey])
     });
-
-    useEffect(() => {
-        if (isStructured && data.length > 0) {
-            table.toggleAllRowsExpanded(true);
-        }
-    }, [data, isStructured, table]);
 
     const renderRowContent = useCallback(
         (row: Row<T>, options?: RenderOptions) => {

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -175,15 +175,25 @@ export const DataTable = <T extends NonNullable<unknown>>({
         (row: Row<T>) => {
             const render = (options?: RenderOptions) => renderRowContent(row, options);
 
+            const rowContext = {
+                id: row.id,
+                data: row.original as T,
+                meta: {
+                    index: row.index,
+                    isSelected: row.getIsSelected(),
+                    isExpanded: row.getIsExpanded()
+                }
+            };
+
             if (renderRow) {
-                return renderRow(row, render);
+                return renderRow({...rowContext, render});
             }
 
             return (
                 <TableRow
                     key={row.id}
                     aria-selected={row.getIsSelected() || undefined}
-                    {...(typeof rowProps === 'function' ? rowProps(row.original as T) : rowProps)}
+                    {...(typeof rowProps === 'function' ? rowProps(rowContext) : rowProps)}
                 >
                     {render()}
                 </TableRow>

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -183,7 +183,7 @@ export const DataTable = <T extends NonNullable<unknown>>({
                 <TableRow
                     key={row.id}
                     aria-selected={row.getIsSelected() || undefined}
-                    {...rowProps}
+                    {...(typeof rowProps === 'function' ? rowProps(row.original as T) : rowProps)}
                 >
                     {render()}
                 </TableRow>

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -100,9 +100,12 @@ export type DataTableBaseProps<T extends NonNullable<unknown>> = {
     onClickTableHeadCell?: (columnKey: string) => void;
 
     /**
-     * Custom HTML attributes to add to each row element
+     * Custom HTML attributes to add to each row element.
+     * Can be a static object or a function receiving the row data to compute props per-row.
      */
-    rowProps?: React.HTMLAttributes<HTMLTableRowElement> & Record<string, unknown>;
+    rowProps?:
+        | (React.HTMLAttributes<HTMLTableRowElement> & Record<string, unknown>)
+        | ((row: T) => React.HTMLAttributes<HTMLTableRowElement> & Record<string, unknown>);
 };
 
 export type SortDirection = 'ascending' | 'descending';

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -91,11 +91,6 @@ export type DataTableBaseProps<T extends NonNullable<unknown>> = {
     columns: ReadonlyArray<DataTableColumn<T>>;
 
     /**
-     * Whether the table data has a hierarchical structure with subRows
-     */
-    isStructured?: boolean;
-
-    /**
      * Callback fired when a table header cell is clicked
      * @param columnKey - The key of the clicked column
      */
@@ -199,9 +194,46 @@ type RenderRowProps<T extends NonNullable<unknown>> = {
     ) => React.ReactNode;
 };
 
+type StructuredProps =
+    | {
+          /** Whether the table data has a hierarchical structure with subRows */
+          isStructured: true;
+          /**
+           * IDs of currently expanded rows (controlled).
+           * When provided, the component no longer manages expansion state internally.
+           */
+          expandedRows: string[];
+          /**
+           * Callback fired when expanded rows change (required in controlled mode).
+           */
+          onExpandChange: (expandedRows: string[]) => void;
+          defaultExpandedRows?: never;
+      }
+    | {
+          /** Whether the table data has a hierarchical structure with subRows */
+          isStructured: true;
+          expandedRows?: never;
+          /**
+           * Callback fired when expanded rows change (uncontrolled).
+           */
+          onExpandChange?: (expandedRows: string[]) => void;
+          /**
+           * IDs of rows expanded at mount (uncontrolled).
+           * Pass `true` to expand all rows (default when `isStructured` is set).
+           */
+          defaultExpandedRows?: true | string[];
+      }
+    | {
+          isStructured?: false;
+          expandedRows?: never;
+          onExpandChange?: never;
+          defaultExpandedRows?: never;
+      };
+
 export type DataTableProps<T extends NonNullable<unknown>> = Omit<TableProps, 'children'> &
     DataTableBaseProps<T> &
     SortingProps<T> &
     SelectionProps &
+    StructuredProps &
     RenderRowProps<T> &
     DataTablePaginationProps;

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-import type {Row} from '@tanstack/react-table';
 import type {TableCellProps} from '~/components/DataTable/cells';
 import type {DataTablePaginationProps} from './pagination';
 export type {PaginationUncontrolledProps} from './pagination';
@@ -7,105 +6,113 @@ export type {PaginationUncontrolledProps} from './pagination';
 export type SubRowKey = 'subRows';
 
 export type TableProps = Omit<React.ComponentPropsWithoutRef<'table'>, 'children' | 'className'> & {
-    /**
-     * Define HTML tag used to render the table
-     */
+    /** Define HTML tag used to render the table */
     component?: string;
-
-    /**
-     * Additional classname
-     */
+    /** Additional classname */
     className?: string;
-
-    /**
-     * The content of the table
-     */
+    /** The content of the table */
     children: React.ReactNode;
 };
 
+// ---------------------------------------------------------------------------
+// Row context — shared base for all row-level callbacks
+// ---------------------------------------------------------------------------
+
+/**
+ * Metadata about a row's current state in the table.
+ * Includes position and interaction state.
+ */
+export type RenderMeta = {
+    /** The zero-based index of this row in the current data set */
+    index: number;
+    /** Whether this row is currently selected */
+    isSelected: boolean;
+    /** Whether this row is currently expanded (for hierarchical tables) */
+    isExpanded: boolean;
+};
+
+/**
+ * Base context passed to all row-level callbacks (renderRow, cellProps, rowProps).
+ * Provides direct access to the row data and its table state without exposing
+ * any underlying library internals.
+ */
+export type RowContext<T extends NonNullable<unknown>> = {
+    /** The unique identifier of this row (value of primaryKey) */
+    id: string;
+    /** The raw row data */
+    data: T;
+    /** Row metadata: position and interaction state */
+    meta: RenderMeta;
+};
+
+/**
+ * Context for column render functions.
+ * Extends RowContext with the cell value.
+ */
+export type RenderCellContext<T extends NonNullable<unknown>, K extends Exclude<keyof T, SubRowKey> = Exclude<keyof T, SubRowKey>> = RowContext<T> & {
+    /** The value of this specific cell */
+    value: T[K];
+};
+
+// ---------------------------------------------------------------------------
+// Column definition
+// ---------------------------------------------------------------------------
+
 export type DataTableColumn<T extends NonNullable<unknown>> = {
-    /**
-     * The key of the data property to display in this column
-     */
+    /** The key of the data property to display in this column */
     key: Exclude<keyof T, SubRowKey>;
-
-    /**
-     * The label to display in the column header
-     */
+    /** The label to display in the column header */
     label: string;
-
     /**
-     * Optional custom render function for the cell content
-     * @param value - The value of the cell
-     * @param row - The entire row data
+     * Optional custom render function for the cell content.
+     * @param context - Cell context with value, data, id, and meta.
      */
-    render?: (value: T[Exclude<keyof T, SubRowKey>], row: T) => React.ReactNode;
-
-    /**
-     * Whether this column can be sorted
-     */
+    render?: (context: RenderCellContext<T, Exclude<keyof T, SubRowKey>>) => React.ReactNode;
+    /** Whether this column can be sorted */
     isSortable?: boolean;
-
-    /**
-     * Custom sort function for the column
-     */
+    /** Custom sort function for the column */
     sortFn?: (a: T, b: T) => number;
-
-    /**
-     * Alignment of the column content
-     */
+    /** Alignment of the column content */
     align?: 'left' | 'center' | 'right';
-
     /**
      * Column width as a CSS string (e.g., '250px', '20%').
      * When undefined, the column takes all available space.
      */
     width?: string;
-
     /**
      * Whether the cell content is scrollable on hover
      * @default false
      */
     isScrollable?: boolean;
-
     /**
-     * Custom HTML attributes added to TableCell or TableStructuredCell.
-     * Can be a static object or a function receiving the row data to compute props per-row.
+     * Custom HTML attributes added to the cell element.
+     * Use the function form to compute props per row.
      */
     cellProps?:
         | (React.TdHTMLAttributes<HTMLTableCellElement> & Record<string, unknown>)
-        | ((row: T) => React.TdHTMLAttributes<HTMLTableCellElement> & Record<string, unknown>);
+        | ((context: RowContext<T>) => React.TdHTMLAttributes<HTMLTableCellElement> & Record<string, unknown>);
 };
 
+// ---------------------------------------------------------------------------
+// Table props
+// ---------------------------------------------------------------------------
+
 export type DataTableBaseProps<T extends NonNullable<unknown>> = {
-    /**
-     * Define which key is used as unique identifier for each row.
-     */
+    /** Define which key is used as unique identifier for each row. */
     primaryKey: Extract<Exclude<keyof T, SubRowKey>, string>;
-
-    /**
-     * The array of data to display
-     */
+    /** The array of data to display */
     data: T[];
-
-    /**
-     * The column definitions
-     */
+    /** The column definitions */
     columns: ReadonlyArray<DataTableColumn<T>>;
-
-    /**
-     * Callback fired when a table header cell is clicked
-     * @param columnKey - The key of the clicked column
-     */
+    /** Callback fired when a table header cell is clicked */
     onClickTableHeadCell?: (columnKey: string) => void;
-
     /**
      * Custom HTML attributes to add to each row element.
-     * Can be a static object or a function receiving the row data to compute props per-row.
+     * Use the function form to compute props per row.
      */
     rowProps?:
         | (React.HTMLAttributes<HTMLTableRowElement> & Record<string, unknown>)
-        | ((row: T) => React.HTMLAttributes<HTMLTableRowElement> & Record<string, unknown>);
+        | ((context: RowContext<T>) => React.HTMLAttributes<HTMLTableRowElement> & Record<string, unknown>);
 };
 
 export type SortDirection = 'ascending' | 'descending';
@@ -180,7 +187,6 @@ export type RenderOptions = {
      * Each direct child becomes its own column with automatic header alignment.
      */
     before?: React.ReactNode;
-
     /**
      * Custom cells to render after the data cells.
      * Each direct child becomes its own column with automatic header alignment.
@@ -188,30 +194,33 @@ export type RenderOptions = {
     after?: React.ReactNode;
 };
 
+/**
+ * Context passed to the renderRow callback.
+ * Extends RowContext with a render function.
+ */
+export type RenderRowContext<T extends NonNullable<unknown>> = RowContext<T> & {
+    /**
+     * Function to render the default row content.
+     * Accepts options to inject custom cells before or after the data cells.
+     */
+    render: (options?: RenderOptions) => React.ReactNode;
+};
+
 type RenderRowProps<T extends NonNullable<unknown>> = {
     /**
-     * Custom render function for rows (e.g. styling, wrapper).
-     * @param row - The row object from TanStack Table. Use row.original to access the raw row data.
-     * @param render - Function to render the default row content. Accepts options to inject actions per row.
+     * Custom render function for rows (e.g. custom styling, wrapper elements).
+     * @param context - Row context with id, data, meta, and render function.
      */
-    renderRow?: (
-        row: Row<T>,
-        render: (options?: RenderOptions) => React.ReactNode
-    ) => React.ReactNode;
+    renderRow?: (context: RenderRowContext<T>) => React.ReactNode;
 };
 
 type StructuredProps =
     | {
           /** Whether the table data has a hierarchical structure with subRows */
           isStructured: true;
-          /**
-           * IDs of currently expanded rows (controlled).
-           * When provided, the component no longer manages expansion state internally.
-           */
+          /** IDs of currently expanded rows (controlled). */
           expandedRows: string[];
-          /**
-           * Callback fired when expanded rows change (required in controlled mode).
-           */
+          /** Callback fired when expanded rows change (required in controlled mode). */
           onExpandChange: (expandedRows: string[]) => void;
           defaultExpandedRows?: never;
       }
@@ -219,9 +228,7 @@ type StructuredProps =
           /** Whether the table data has a hierarchical structure with subRows */
           isStructured: true;
           expandedRows?: never;
-          /**
-           * Callback fired when expanded rows change (uncontrolled).
-           */
+          /** Callback fired when expanded rows change (uncontrolled). */
           onExpandChange?: (expandedRows: string[]) => void;
           /**
            * IDs of rows expanded at mount (uncontrolled).

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -69,9 +69,12 @@ export type DataTableColumn<T extends NonNullable<unknown>> = {
     isScrollable?: boolean;
 
     /**
-     * Custom HTML attributes added to TableCell or TableStructuredCell
+     * Custom HTML attributes added to TableCell or TableStructuredCell.
+     * Can be a static object or a function receiving the row data to compute props per-row.
      */
-    cellProps?: React.TdHTMLAttributes<HTMLTableCellElement> & Record<string, unknown>;
+    cellProps?:
+        | (React.TdHTMLAttributes<HTMLTableCellElement> & Record<string, unknown>)
+        | ((row: T) => React.TdHTMLAttributes<HTMLTableCellElement> & Record<string, unknown>);
 };
 
 export type DataTableBaseProps<T extends NonNullable<unknown>> = {

--- a/src/components/DataTable/MIGRATION.md
+++ b/src/components/DataTable/MIGRATION.md
@@ -50,7 +50,7 @@ type RenderRowContext<T> = RowContext<T> & {
 
 ```ts
 type RenderCellContext<T> = RowContext<T> & {
-    value: T[key]; // The value of this specific cell
+    value: T[keyof T]; // The value of this specific cell
 };
 ```
 

--- a/src/components/DataTable/MIGRATION.md
+++ b/src/components/DataTable/MIGRATION.md
@@ -1,0 +1,198 @@
+# DataTable API Migration Guide
+
+## Why we changed the API
+
+The previous `renderRow` API exposed the internal row object from the underlying table library directly to consumers:
+
+```tsx
+// Old API
+renderRow={(row, renderCells) => {
+    const release = row.original; // ← leaked internal structure
+    return <TableRow>{renderCells()}</TableRow>;
+}}
+```
+
+This created two problems:
+
+1. **Tight coupling to the table library.** If we ever swap the underlying table library, every consumer that used `row.original`, `row.getIsSelected()`, or any other internal method would break. The public API should be stable regardless of what runs underneath.
+
+2. **Poor ergonomics.** The most common need — accessing the row data — required knowing an internal detail (`.original`). The same inconsistency existed across `render`, `cellProps`, and `rowProps`, each with different callback signatures.
+
+The new API gives you a **stable, library-agnostic context object** that will remain consistent regardless of any internal implementation changes.
+
+---
+
+## New API: the context object
+
+All row-level callbacks now receive a **single context object** with the same shape:
+
+```ts
+type RowContext<T> = {
+    id: string;        // Unique row identifier (value of primaryKey)
+    data: T;           // Your row data — no .original needed
+    meta: {
+        index: number;        // Position in the current dataset
+        isSelected: boolean;  // Whether the row is selected
+        isExpanded: boolean;  // Whether the row is expanded (hierarchical tables)
+    };
+};
+```
+
+`renderRow` extends this with a `render` function:
+
+```ts
+type RenderRowContext<T> = RowContext<T> & {
+    render: (options?: RenderOptions) => React.ReactNode;
+};
+```
+
+`render` (column cell render) extends it with a `value` field:
+
+```ts
+type RenderCellContext<T> = RowContext<T> & {
+    value: T[key]; // The value of this specific cell
+};
+```
+
+---
+
+## Migration examples
+
+### renderRow
+
+**Before:**
+```tsx
+renderRow={(row, renderCells) => (
+    <TableRow
+        key={row.id}
+        className={clsx(row.original.items?.length === 0 && styles.disabled)}
+    >
+        {renderCells({
+            after: <MenuAction release={row.original} />
+        })}
+    </TableRow>
+)}
+```
+
+**After:**
+```tsx
+renderRow={({id, data, render}) => (
+    <TableRow
+        key={id}
+        className={clsx(data.items?.length === 0 && styles.disabled)}
+    >
+        {render({
+            after: <MenuAction release={data} />
+        })}
+    </TableRow>
+)}
+```
+
+### Column render function
+
+**Before:**
+```tsx
+{
+    key: 'status',
+    label: 'Status',
+    render: (value, row) => (
+        <Badge className={row.status === 'draft' ? styles.draft : ''}>
+            {value}
+        </Badge>
+    )
+}
+```
+
+**After:**
+```tsx
+{
+    key: 'status',
+    label: 'Status',
+    render: ({value, data}) => (
+        <Badge className={data.status === 'draft' ? styles.draft : ''}>
+            {value}
+        </Badge>
+    )
+}
+```
+
+### cellProps
+
+**Before:**
+```tsx
+{
+    key: 'name',
+    label: 'Name',
+    cellProps: (row) => ({
+        'data-id': row.id,
+        className: row.status === 'active' ? styles.active : ''
+    })
+}
+```
+
+**After:**
+```tsx
+{
+    key: 'name',
+    label: 'Name',
+    cellProps: ({id, data, meta}) => ({
+        'data-id': id,
+        className: data.status === 'active' ? styles.active : '',
+        'aria-selected': meta.isSelected
+    })
+}
+```
+
+### rowProps
+
+**Before:**
+```tsx
+<DataTable
+    rowProps={(row) => ({
+        className: row.status === 'draft' ? styles.disabled : ''
+    })}
+/>
+```
+
+**After:**
+```tsx
+<DataTable
+    rowProps={({data, meta}) => ({
+        className: data.status === 'draft' ? styles.disabled : '',
+        'aria-selected': meta.isSelected || undefined
+    })}
+/>
+```
+
+---
+
+## Summary of changes
+
+| Callback | Before | After |
+|---|---|---|
+| `renderRow` | `(row, renderCells) => ...` | `({id, data, meta, render}) => ...` |
+| column `render` | `(value, row) => ...` | `({value, id, data, meta}) => ...` |
+| `cellProps` | `(row) => ...` | `({id, data, meta}) => ...` |
+| `rowProps` | `(row) => ...` | `({id, data, meta}) => ...` |
+| Row data access | `row.original.field` | `data.field` |
+| Row identifier | `row.id` | `id` |
+
+---
+
+## TypeScript
+
+All context types are exported and can be used to type extracted render functions:
+
+```tsx
+import type {RenderRowContext, RenderCellContext, RowContext, RenderMeta} from '@jahia/moonstone/DataTable';
+
+// Type a render function separately
+const renderRelease = ({id, data, render}: RenderRowContext<Release>) => (
+    <TableRow key={id}>{render()}</TableRow>
+);
+
+// Type a cellProps function
+const nameProps = ({data}: RowContext<Release>) => ({
+    className: data.status === 'draft' ? styles.draft : ''
+});
+```

--- a/src/components/DataTable/TableRow/TableRow.module.scss
+++ b/src/components/DataTable/TableRow/TableRow.module.scss
@@ -12,7 +12,7 @@ $background-highlight-hover: var(--moon-color-accent_light_plain40);
     background-color: var(--moon-row-background);
 
     &:not(.head) {
-        &:focus-within,
+        &:focus-visible,
         &:hover {
             --moon-row-background: #{$background-hover};
             --moon-cellAction-visibility: visible;
@@ -25,7 +25,7 @@ $background-highlight-hover: var(--moon-color-accent_light_plain40);
 
     // color: var(--color-light);
 
-    &:focus-within,
+    &:focus-visible,
     &:hover {
         --moon-row-background: #{$background-highlight-hover};
     }

--- a/src/components/DataTable/hooks/index.ts
+++ b/src/components/DataTable/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useCustomCells';
+export * from './useExpansion';
 export * from './usePagination';
 export * from './useSelection';
 export * from './useSorting';

--- a/src/components/DataTable/hooks/useCustomCells.ts
+++ b/src/components/DataTable/hooks/useCustomCells.ts
@@ -44,6 +44,9 @@ export function useCustomCells<T extends NonNullable<unknown>>({
         setCustomHeaderWidths(defaultHeaderWidths());
     }, [data, primaryKey, renderRow]);
 
+    // This effect intentionally runs after every render to flush ref-collected counts
+    // (written during render) into state without triggering setState during render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     useEffect(() => {
         if (!renderRow) {
             return;

--- a/src/components/DataTable/hooks/useExpansion.ts
+++ b/src/components/DataTable/hooks/useExpansion.ts
@@ -1,0 +1,51 @@
+import {useState} from 'react';
+import type {ExpandedState} from '@tanstack/react-table';
+import React from 'react';
+
+type UseExpansionProps = {
+    expandedRows?: string[];
+    defaultExpandedRows?: true | string[];
+    onExpandChange?: (expandedRows: string[]) => void;
+};
+
+function toExpandedState(ids: string[]): ExpandedState {
+    return ids.reduce<Record<string, boolean>>((acc, id) => ({...acc, [id]: true}), {});
+}
+
+function toRowIds(state: ExpandedState): string[] {
+    if (state === true) {
+        return [];
+    }
+
+    return Object.keys(state).filter(id => (state as Record<string, boolean>)[id]);
+}
+
+export function useExpansion({expandedRows, defaultExpandedRows, onExpandChange}: UseExpansionProps) {
+    const isExpansionControlled = expandedRows !== undefined;
+
+    const [state, setState] = useState<ExpandedState>(() => {
+        if (defaultExpandedRows === true) {
+            return true;
+        }
+
+        if (defaultExpandedRows) {
+            return toExpandedState(defaultExpandedRows);
+        }
+
+        return {};
+    });
+
+    const expanded: ExpandedState = isExpansionControlled ? toExpandedState(expandedRows) : state;
+
+    const handleExpandedChange = (updater: React.SetStateAction<ExpandedState>) => {
+        const next = typeof updater === 'function' ? updater(expanded) : updater;
+
+        if (!isExpansionControlled) {
+            setState(next);
+        }
+
+        onExpandChange?.(toRowIds(next));
+    };
+
+    return {expanded, isExpansionControlled, handleExpandedChange};
+}

--- a/src/components/DataTable/hooks/useExpansion.ts
+++ b/src/components/DataTable/hooks/useExpansion.ts
@@ -8,7 +8,7 @@ type UseExpansionProps = {
 };
 
 function toExpandedState(ids: string[]): ExpandedState {
-    return ids.reduce<Record<string, boolean>>((acc, id) => ({...acc, [id]: true}), {});
+    return Object.fromEntries(ids.map(id => [id, true]));
 }
 
 function toRowIds(state: ExpandedState): string[] {

--- a/src/components/DataTable/hooks/useExpansion.ts
+++ b/src/components/DataTable/hooks/useExpansion.ts
@@ -1,6 +1,5 @@
-import {useState} from 'react';
+import React, {useState} from 'react';
 import type {ExpandedState} from '@tanstack/react-table';
-import React from 'react';
 
 type UseExpansionProps = {
     expandedRows?: string[];

--- a/src/components/DataTable/shared/columnHelpers.tsx
+++ b/src/components/DataTable/shared/columnHelpers.tsx
@@ -21,21 +21,21 @@ type ColumnOptions = Omit<LocaleOptions, 'value'> & {
  * ];
  */
 export const stringColumn = <T, >(get: (row: T) => string, options?: ColumnOptions) => ({
-    render: (_value: unknown, row: T) => renderString(get(row)),
+    render: ({data}: {data: T}) => renderString(get(data)),
     isSortable: true,
     sortFn: (a: T, b: T) => get(a).localeCompare(get(b)),
     align: options?.align
 });
 
 export const numberColumn = <T, >(get: (row: T) => number, options?: ColumnOptions) => ({
-    render: (_value: unknown, row: T) => renderNumber({value: get(row), locale: options?.locale, localeOptions: options?.localeOptions}),
+    render: ({data}: {data: T}) => renderNumber({value: get(data), locale: options?.locale, localeOptions: options?.localeOptions}),
     isSortable: true,
     sortFn: (a: T, b: T) => get(a) - get(b),
     align: options?.align ?? 'right'
 });
 
 export const dateColumn = <T, >(get: (row: T) => Date, options?: ColumnOptions) => ({
-    render: (_value: unknown, row: T) => renderDate({value: get(row), locale: options?.locale, localeOptions: options?.localeOptions}),
+    render: ({data}: {data: T}) => renderDate({value: get(data), locale: options?.locale, localeOptions: options?.localeOptions}),
     isSortable: true,
     sortFn: (a: T, b: T) => get(a).getTime() - get(b).getTime(),
     align: options?.align ?? 'right'

--- a/src/components/DataTable/shared/columnHelpers.tsx
+++ b/src/components/DataTable/shared/columnHelpers.tsx
@@ -31,7 +31,7 @@ export const numberColumn = <T, >(get: (row: T) => number, options?: ColumnOptio
     render: (_value: unknown, row: T) => renderNumber({value: get(row), locale: options?.locale, localeOptions: options?.localeOptions}),
     isSortable: true,
     sortFn: (a: T, b: T) => get(a) - get(b),
-    align: options?.align ?? 'left'
+    align: options?.align ?? 'right'
 });
 
 export const dateColumn = <T, >(get: (row: T) => Date, options?: ColumnOptions) => ({

--- a/src/components/DataTable/shared/columnHelpers.tsx
+++ b/src/components/DataTable/shared/columnHelpers.tsx
@@ -21,21 +21,21 @@ type ColumnOptions = Omit<LocaleOptions, 'value'> & {
  * ];
  */
 export const stringColumn = <T, >(get: (row: T) => string, options?: ColumnOptions) => ({
-    render: (value: string) => renderString(value),
+    render: (_value: unknown, row: T) => renderString(get(row)),
     isSortable: true,
     sortFn: (a: T, b: T) => get(a).localeCompare(get(b)),
     align: options?.align
 });
 
 export const numberColumn = <T, >(get: (row: T) => number, options?: ColumnOptions) => ({
-    render: (value: number) => renderNumber({value, locale: options?.locale, localeOptions: options?.localeOptions}),
+    render: (_value: unknown, row: T) => renderNumber({value: get(row), locale: options?.locale, localeOptions: options?.localeOptions}),
     isSortable: true,
     sortFn: (a: T, b: T) => get(a) - get(b),
     align: options?.align ?? 'left'
 });
 
 export const dateColumn = <T, >(get: (row: T) => Date, options?: ColumnOptions) => ({
-    render: (value: Date) => renderDate({value, locale: options?.locale, localeOptions: options?.localeOptions}),
+    render: (_value: unknown, row: T) => renderDate({value: get(row), locale: options?.locale, localeOptions: options?.localeOptions}),
     isSortable: true,
     sortFn: (a: T, b: T) => get(a).getTime() - get(b).getTime(),
     align: options?.align ?? 'right'

--- a/src/components/DataTable/shared/shared.spec.tsx
+++ b/src/components/DataTable/shared/shared.spec.tsx
@@ -92,7 +92,7 @@ describe('stringColumn', () => {
         expect(col.isSortable).toBe(true);
         expect(col.align).toBe('center');
 
-        render(<>{col.render('test', {val: 'test'})}</>);
+        render(<>{col.render?.({data: {val: 'test'}})}</>);
         expect(screen.getByText('test')).toBeInTheDocument();
 
         const rowA = {val: 'a'};
@@ -141,7 +141,7 @@ describe('createTableColumns', () => {
                 label: 'Name',
                 isSortable: true,
                 align: 'center',
-                render: (val: string) => val.toUpperCase()
+                render: ({value}) => value.toUpperCase()
             }
         ];
 

--- a/src/components/DataTable/shared/shared.spec.tsx
+++ b/src/components/DataTable/shared/shared.spec.tsx
@@ -107,7 +107,7 @@ describe('numberColumn', () => {
         const get = (row: Row) => row.val;
         const col = numberColumn<Row>(get);
         expect(col.isSortable).toBe(true);
-        expect(col.align).toBe('left');
+        expect(col.align).toBe('right');
 
         const rowA = {val: 10};
         const rowB = {val: 20};

--- a/src/components/DataTable/shared/shared.spec.tsx
+++ b/src/components/DataTable/shared/shared.spec.tsx
@@ -92,7 +92,7 @@ describe('stringColumn', () => {
         expect(col.isSortable).toBe(true);
         expect(col.align).toBe('center');
 
-        render(<>{col.render('test')}</>);
+        render(<>{col.render('test', {val: 'test'})}</>);
         expect(screen.getByText('test')).toBeInTheDocument();
 
         const rowA = {val: 'a'};

--- a/src/components/DataTable/shared/tableHelpers.tsx
+++ b/src/components/DataTable/shared/tableHelpers.tsx
@@ -33,7 +33,16 @@ export const createTableColumns = <T extends Record<string, unknown>>(
             const value = getValue();
 
             if (col.render) {
-                return col.render(value as T[Exclude<keyof T, SubRowKey>], row.original as T);
+                return col.render({
+                    id: row.id,
+                    value: value as T[Exclude<keyof T, SubRowKey>],
+                    data: row.original as T,
+                    meta: {
+                        index: row.index,
+                        isSelected: row.getIsSelected(),
+                        isExpanded: row.getIsExpanded()
+                    }
+                });
             }
 
             return value as React.ReactNode;

--- a/src/components/DataTable/utils/renderCells.tsx
+++ b/src/components/DataTable/utils/renderCells.tsx
@@ -48,12 +48,15 @@ export const renderCell = <T extends NonNullable<unknown>>({
 }: RenderCellProps<T>) => row.getVisibleCells().map((cell, index) => {
         const meta = cell.column.columnDef.meta as CustomColumnMeta | undefined;
         const cellContent = flexRender(cell.column.columnDef.cell, cell.getContext());
+        const cellProps = typeof meta?.cellProps === 'function'
+            ? meta.cellProps(row.original)
+            : meta?.cellProps;
 
         if (isStructured && index === 0) {
             return (
                 <TableStructuredCell
                 key={cell.id}
-                {...meta?.cellProps}
+                {...cellProps}
                 align={meta?.align ?? 'left'}
                 width={meta?.width}
                 depth={row.depth}
@@ -70,7 +73,7 @@ export const renderCell = <T extends NonNullable<unknown>>({
         return (
             <TableCell
             key={cell.id}
-            {...meta?.cellProps}
+            {...cellProps}
             align={meta?.align}
             width={meta?.width}
             isScrollable={meta?.isScrollable}

--- a/src/components/DataTable/utils/renderCells.tsx
+++ b/src/components/DataTable/utils/renderCells.tsx
@@ -45,19 +45,22 @@ export const renderHeadCell = <T extends NonNullable<unknown>>({
 export const renderCell = <T extends NonNullable<unknown>>({
     row,
     isStructured
-}: RenderCellProps<T>) => row.getVisibleCells().map((cell, index) => {
+}: RenderCellProps<T>) => {
+    const rowContext = {
+        id: row.id,
+        data: row.original,
+        meta: {
+            index: row.index,
+            isSelected: row.getIsSelected(),
+            isExpanded: row.getIsExpanded()
+        }
+    };
+
+    return row.getVisibleCells().map((cell, index) => {
         const meta = cell.column.columnDef.meta as CustomColumnMeta<T> | undefined;
         const cellContent = flexRender(cell.column.columnDef.cell, cell.getContext());
         const cellProps = typeof meta?.cellProps === 'function' ?
-            meta.cellProps({
-                id: row.id,
-                data: row.original,
-                meta: {
-                    index: row.index,
-                    isSelected: row.getIsSelected(),
-                    isExpanded: row.getIsExpanded()
-                }
-            }) :
+            meta.cellProps(rowContext) :
             meta?.cellProps;
 
         if (isStructured && index === 0) {
@@ -69,7 +72,7 @@ export const renderCell = <T extends NonNullable<unknown>>({
                     width={meta?.width}
                     depth={row.depth}
                     isExpandable={row.getCanExpand()}
-                    isExpanded={row.getIsExpanded()}
+                    isExpanded={rowContext.meta.isExpanded}
                     isScrollable={meta?.isScrollable}
                     onToggleExpand={row.getToggleExpandedHandler()}
                 >
@@ -90,3 +93,4 @@ export const renderCell = <T extends NonNullable<unknown>>({
             </TableCell>
         );
     });
+};

--- a/src/components/DataTable/utils/renderCells.tsx
+++ b/src/components/DataTable/utils/renderCells.tsx
@@ -14,28 +14,28 @@ export const renderHeadCell = <T extends NonNullable<unknown>>({
     isStructured,
     onClickTableHeadCell
 }: RenderHeadCellProps<T>) => headerGroup.headers.map((header, index) => {
-        const meta = header.column.columnDef.meta as CustomColumnMeta | undefined;
+        const meta = header.column.columnDef.meta as CustomColumnMeta<T> | undefined;
         const isColumnSortable = enableSorting && (meta?.isSortable ?? false);
         const columnSortDirection = header.column.getIsSorted();
 
         return (
             <TableHeadCell
-            key={header.id}
-            width={meta?.width}
-            className={clsx({'moonstone-tableHeadCell_structured': isStructured && index === 0})}
-            sorting={isColumnSortable ? {
-                direction: columnSortDirection === 'desc' ? 'descending' : 'ascending',
-                isActive: Boolean(columnSortDirection)
-            } : undefined}
-            style={{cursor: isColumnSortable ? 'pointer' : 'default'}}
-            align={meta?.align ?? 'left'}
-            onClick={(event: React.MouseEvent<HTMLTableCellElement>) => {
-                if (isColumnSortable) {
-                    header.column.getToggleSortingHandler()?.(event);
-                }
+                key={header.id}
+                width={meta?.width}
+                className={clsx({'moonstone-tableHeadCell_structured': isStructured && index === 0})}
+                sorting={isColumnSortable ? {
+                    direction: columnSortDirection === 'desc' ? 'descending' : 'ascending',
+                    isActive: Boolean(columnSortDirection)
+                } : undefined}
+                style={{cursor: isColumnSortable ? 'pointer' : 'default'}}
+                align={meta?.align ?? 'left'}
+                onClick={(event: React.MouseEvent<HTMLTableCellElement>) => {
+                    if (isColumnSortable) {
+                        header.column.getToggleSortingHandler()?.(event);
+                    }
 
-                onClickTableHeadCell?.(header.id);
-            }}
+                    onClickTableHeadCell?.(header.id);
+                }}
             >
                 {flexRender(header.column.columnDef.header, header.getContext())}
             </TableHeadCell>
@@ -46,7 +46,7 @@ export const renderCell = <T extends NonNullable<unknown>>({
     row,
     isStructured
 }: RenderCellProps<T>) => row.getVisibleCells().map((cell, index) => {
-        const meta = cell.column.columnDef.meta as CustomColumnMeta | undefined;
+        const meta = cell.column.columnDef.meta as CustomColumnMeta<T> | undefined;
         const cellContent = flexRender(cell.column.columnDef.cell, cell.getContext());
         const cellProps = typeof meta?.cellProps === 'function' ?
             meta.cellProps({
@@ -63,15 +63,15 @@ export const renderCell = <T extends NonNullable<unknown>>({
         if (isStructured && index === 0) {
             return (
                 <TableStructuredCell
-                key={cell.id}
-                {...cellProps}
-                align={meta?.align ?? 'left'}
-                width={meta?.width}
-                depth={row.depth}
-                isExpandable={row.getCanExpand()}
-                isExpanded={row.getIsExpanded()}
-                isScrollable={meta?.isScrollable}
-                onToggleExpand={row.getToggleExpandedHandler()}
+                    key={cell.id}
+                    {...cellProps}
+                    align={meta?.align ?? 'left'}
+                    width={meta?.width}
+                    depth={row.depth}
+                    isExpandable={row.getCanExpand()}
+                    isExpanded={row.getIsExpanded()}
+                    isScrollable={meta?.isScrollable}
+                    onToggleExpand={row.getToggleExpandedHandler()}
                 >
                     {cellContent}
                 </TableStructuredCell>
@@ -80,11 +80,11 @@ export const renderCell = <T extends NonNullable<unknown>>({
 
         return (
             <TableCell
-            key={cell.id}
-            {...cellProps}
-            align={meta?.align}
-            width={meta?.width}
-            isScrollable={meta?.isScrollable}
+                key={cell.id}
+                {...cellProps}
+                align={meta?.align}
+                width={meta?.width}
+                isScrollable={meta?.isScrollable}
             >
                 {cellContent}
             </TableCell>

--- a/src/components/DataTable/utils/renderCells.tsx
+++ b/src/components/DataTable/utils/renderCells.tsx
@@ -48,9 +48,9 @@ export const renderCell = <T extends NonNullable<unknown>>({
 }: RenderCellProps<T>) => row.getVisibleCells().map((cell, index) => {
         const meta = cell.column.columnDef.meta as CustomColumnMeta | undefined;
         const cellContent = flexRender(cell.column.columnDef.cell, cell.getContext());
-        const cellProps = typeof meta?.cellProps === 'function'
-            ? meta.cellProps(row.original)
-            : meta?.cellProps;
+        const cellProps = typeof meta?.cellProps === 'function' ?
+            meta.cellProps(row.original) :
+            meta?.cellProps;
 
         if (isStructured && index === 0) {
             return (

--- a/src/components/DataTable/utils/renderCells.tsx
+++ b/src/components/DataTable/utils/renderCells.tsx
@@ -49,7 +49,15 @@ export const renderCell = <T extends NonNullable<unknown>>({
         const meta = cell.column.columnDef.meta as CustomColumnMeta | undefined;
         const cellContent = flexRender(cell.column.columnDef.cell, cell.getContext());
         const cellProps = typeof meta?.cellProps === 'function' ?
-            meta.cellProps(row.original) :
+            meta.cellProps({
+                id: row.id,
+                data: row.original,
+                meta: {
+                    index: row.index,
+                    isSelected: row.getIsSelected(),
+                    isExpanded: row.getIsExpanded()
+                }
+            }) :
             meta?.cellProps;
 
         if (isStructured && index === 0) {

--- a/src/components/DataTable/utils/renderCells.types.ts
+++ b/src/components/DataTable/utils/renderCells.types.ts
@@ -1,15 +1,15 @@
 import type React from 'react';
 import type {HeaderGroup, Row} from '@tanstack/react-table';
-import type {DataTableProps} from '../DataTable.types';
+import type {DataTableProps, RowContext} from '../DataTable.types';
 
-export type CustomColumnMeta = {
+export type CustomColumnMeta<T extends NonNullable<unknown>> = {
     isSortable?: boolean;
     align?: 'left' | 'center' | 'right';
     width?: string;
     isScrollable?: boolean;
     cellProps?:
         | (React.TdHTMLAttributes<HTMLTableCellElement> & Record<string, unknown>)
-        | ((row: unknown) => React.TdHTMLAttributes<HTMLTableCellElement> & Record<string, unknown>);
+    | ((context: RowContext<T>) => React.TdHTMLAttributes<HTMLTableCellElement> & Record<string, unknown>);
 };
 
 export type RenderHeadCellProps<T extends NonNullable<unknown>> = {

--- a/src/components/DataTable/utils/renderCells.types.ts
+++ b/src/components/DataTable/utils/renderCells.types.ts
@@ -7,7 +7,9 @@ export type CustomColumnMeta = {
     align?: 'left' | 'center' | 'right';
     width?: string;
     isScrollable?: boolean;
-    cellProps?: React.TdHTMLAttributes<HTMLTableCellElement> & Record<string, unknown>;
+    cellProps?:
+        | (React.TdHTMLAttributes<HTMLTableCellElement> & Record<string, unknown>)
+        | ((row: unknown) => React.TdHTMLAttributes<HTMLTableCellElement> & Record<string, unknown>);
 };
 
 export type RenderHeadCellProps<T extends NonNullable<unknown>> = {

--- a/src/data/dataTable/columnsUser.tsx
+++ b/src/data/dataTable/columnsUser.tsx
@@ -25,20 +25,20 @@ export const dataColumnsUser: DataTableColumn<DataUser>[] = [
         label: 'User',
         isScrollable: true,
         ...stringColumn<DataUser>(row => row.firstName),
-        render: (value, row) => (
+        render: ({value, data}) => (
             <>
                 <Person/>
-                <Typography isNowrap variant="body">{`${value} ${row.lastName}`}</Typography>
+                <Typography isNowrap variant="body">{`${value} ${data.lastName}`}</Typography>
             </>
         )
     },
     {
         key: 'status',
         label: 'Status',
-        render: (value, row) => (
+        render: ({value, data}) => (
             <Chip
                 label={value as string}
-                color={getStatus(row.status).chipColor}
+                color={getStatus(data.status).chipColor}
             />
         ),
         isSortable: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,10 +14,8 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "lib": [
-      "es6",
       "dom",
-      "es2016",
-      "es2017"
+      "es2019"
     ],
     "baseUrl": "src",
     "paths": {


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description
- **Breaking change**: Introduce a new row context API so row and cell callbacks use stable data instead of exposing TanStack objects.
- Improve controlled DataTable behavior for sorting, pagination, and row expansion to keep state handling consistent and predictable.
- Allow to control which node is expanded by default when the Table is Structured
- Add support for dynamic row and cell props (including custom attributes) for better per-row customization.
- Prevent focus styles when a row is clicked.


## Tests

The following are included in this PR

- [x] Unit Tests
- [ ] Accessibility is OK