### PR TITLE
fix: tooltip overflow

### DIFF
--- a/.chachalog/XI5y5SHd.md
+++ b/.chachalog/XI5y5SHd.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/moonstone": patch
+---
+
+Fix Tooltip truncation in overflow containers (#1393)

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -3,7 +3,7 @@ import type {DataUser, DataUserKeys} from '~/data/dataTable';
 import type {Meta, StoryObj} from '@storybook/react';
 import {DataTable, TableRow, TableCellActions, TableCellStatus} from './index';
 import {useState} from 'react';
-import {Button} from '~/components';
+import {Button, Tooltip} from '~/components';
 import {Visibility, Edit, Delete, MoreVert} from '~/icons';
 
 export default {
@@ -137,9 +137,15 @@ export const InsertCells: Story = {
                                 <TableCellActions
                                     actionsOnHover={
                                         <>
-                                            <Button icon={<Visibility/>} variant="ghost"/>
-                                            <Button icon={<Edit/>} variant="ghost"/>
-                                            <Button icon={<Delete/>} variant="ghost"/>
+                                            <Tooltip label="View">
+                                                <Button icon={<Visibility/>} variant="ghost"/>
+                                            </Tooltip>
+                                            <Tooltip label="Edit">
+                                                <Button icon={<Edit/>} variant="ghost"/>
+                                            </Tooltip>
+                                            <Tooltip label="Delete">
+                                                <Button icon={<Delete/>} variant="ghost"/>
+                                            </Tooltip>
                                         </>
                                     }
                                     actions={<Button icon={<MoreVert/>} variant="ghost" aria-label="Actions"/>}

--- a/src/components/Tooltip/Tooltip.module.scss
+++ b/src/components/Tooltip/Tooltip.module.scss
@@ -1,7 +1,7 @@
 $bgColor: var(--moon-color-gray_dark);
 
 .moonstone-tooltip_label {
-    z-index: 1;
+    z-index: 9100;
 
     width: inherit;
     max-width: 450px;
@@ -14,7 +14,7 @@ $bgColor: var(--moon-color-gray_dark);
 }
 
 .moonstone-tooltip_arrow {
-    z-index: 1;
+    z-index: 9100;
 
     fill: $bgColor;
 }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -68,8 +68,7 @@ export const Tooltip = ({
                                 {label}
                             </Typography>
                         </div>
-                    </FloatingPortal>
-                }
+                    </FloatingPortal>}
             </div>
         );
     }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,7 +1,7 @@
 import React, {useRef, useState} from 'react';
 import clsx from 'clsx';
 import type {TooltipProps} from './Tooltip.types';
-import {useHover, useFloating, useInteractions, arrow, offset, FloatingArrow, flip, shift, useFocus, useDismiss} from '@floating-ui/react';
+import {useHover, useFloating, useInteractions, arrow, offset, FloatingArrow, FloatingPortal, flip, shift, useFocus, useDismiss} from '@floating-ui/react';
 import {Typography} from '~/components';
 import styles from './Tooltip.module.scss';
 
@@ -54,19 +54,22 @@ export const Tooltip = ({
                 'aria-describedby': 'moonstone-tooltip_label'
                 })}
                 {isOpen &&
-                <div
-                    ref={refs.setFloating}
-                    id="moonstone-tooltip_label"
-                    className={clsx('moonstone-tooltip_label', styles['moonstone-tooltip_label'])}
-                    style={floatingStyles}
-                    role="tooltip"
-                    {...getFloatingProps()}
-                >
-                    <FloatingArrow ref={arrowRef} className={clsx('moonstone-tooltip_arrow', styles['moonstone-tooltip_arrow'])} context={context}/>
-                    <Typography>
-                        {label}
-                    </Typography>
-                </div>}
+                    <FloatingPortal>
+                        <div
+                            ref={refs.setFloating}
+                            id="moonstone-tooltip_label"
+                            className={clsx('moonstone-tooltip_label', styles['moonstone-tooltip_label'])}
+                            style={floatingStyles}
+                            role="tooltip"
+                            {...getFloatingProps()}
+                        >
+                            <FloatingArrow ref={arrowRef} className={clsx('moonstone-tooltip_arrow', styles['moonstone-tooltip_arrow'])} context={context}/>
+                            <Typography>
+                                {label}
+                            </Typography>
+                        </div>
+                    </FloatingPortal>
+                }
             </div>
         );
     }


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description
Issue: When the Tooltip is displayed in an overflow context, the tooltip was truncated.
Solution: Use `FloatingPortal` to display the tooltip in the HTML body element instead of the parent element.


## Description
Issue: When the Tooltip is rendered in an overflow context like a DataTable cell, it is truncated.

Solution:
- Use `FloatingPortal` to render the tooltip in the `<body>` element instead of inline in the parent.
- Raise the tooltip `z-index` to `9100` so it sits above the highest current layer (`9000`). The `z-index` values will be improved with https://github.com/Jahia/moonstone/issues/634

## Tests

The following are included in this PR

- [ ] Unit Tests
- [ ] Accessibility is OK


## Checklist
<!--
This section contains a set of non-automated checks; it serves to remind you to consider some business-critical topics.
 - If any are not applicable, they can simply be deleted.
 - If you need to provide more details, please use the description section.
-->

- [ ] All files present (component - scss - spec - stories)
- [ ] All props ok and documented (typescript types)
- [ ] Required props, default values, variants and colors
- [ ] Example in storybook
- [ ] Reversed style (light/dark mode)
- [ ] Allows custom props
