### PR TITLE
feat: add content props to Pill component and deprecate label  

### DIFF
--- a/.chachalog/VGJDd3rU.md
+++ b/.chachalog/VGJDd3rU.md
@@ -3,4 +3,4 @@
 "@jahia/moonstone": minor
 ---
 
-Add content props to Pill component and deprecate label  (#1404)
+Add the prop `content` to the Pill component to allow more than just text, the prop label becomes deprecated (#1404)

--- a/.chachalog/VGJDd3rU.md
+++ b/.chachalog/VGJDd3rU.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/moonstone": minor
+---
+
+Add content props to Pill component and deprecate label  (#1404)

--- a/.chachalog/VGJDd3rU.md
+++ b/.chachalog/VGJDd3rU.md
@@ -3,4 +3,4 @@
 "@jahia/moonstone": minor
 ---
 
-Add the prop `content` to the Pill component to allow more than just text, the prop label becomes deprecated (#1404)
+Add the prop `content` to the `Pill` component to allow more than just text, the prop `label` becomes deprecated (#1404)

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -40,7 +40,7 @@ export const FlatData = {
         const [currentPill, setCurrentPill] = useState<DropdownDataOption>({
             label: 'French',
             value: 'fr',
-            iconEnd: <Pill label="FR"/>
+            iconEnd: <Pill content="FR"/>
         });
 
         const handleOnChange = (e: React.MouseEvent, item: DropdownDataOption) => {

--- a/src/components/Pill/Pill.module.scss
+++ b/src/components/Pill/Pill.module.scss
@@ -1,7 +1,7 @@
 // We have to double the selector for specificy issue with Typography
 .moonstone-pill.moonstone-pill {
     width: auto;
-    height: auto;
+    min-height: 16px;
     padding: 0 var(--moon-spacing-nano);
 
     border-radius: var(--moon-radius_small);

--- a/src/components/Pill/Pill.module.scss
+++ b/src/components/Pill/Pill.module.scss
@@ -1,5 +1,7 @@
 // We have to double the selector for specificy issue with Typography
 .moonstone-pill.moonstone-pill {
+    display: flex;
+    align-items: center;
     width: auto;
     min-height: 16px;
     padding: 0 var(--moon-spacing-nano);

--- a/src/components/Pill/Pill.spec.tsx
+++ b/src/components/Pill/Pill.spec.tsx
@@ -23,12 +23,4 @@ describe('Pill', () => {
         render(<Pill content={<Cloud data-testid="moonstone-pill-icon"/>}/>);
         expect(screen.getByTestId('moonstone-pill-icon')).toBeInTheDocument();
     });
-
-    it('should still display label and warn when using the deprecated label prop', () => {
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => vi.fn());
-        render(<Pill label="Say my name"/>);
-        expect(screen.getByText('Say my name')).toBeInTheDocument();
-        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('deprecated'));
-        warnSpy.mockRestore();
-    });
 });

--- a/src/components/Pill/Pill.spec.tsx
+++ b/src/components/Pill/Pill.spec.tsx
@@ -4,18 +4,18 @@ import {Cloud} from '~/icons';
 
 describe('Pill', () => {
     it('should display content', () => {
-        render(<Pill content={<>Say my name</>}/>);
+        render(<Pill content="Say my name"/>);
         expect(screen.getByText('Say my name')).toBeInTheDocument();
     });
 
     it('should add additional class names', () => {
         const testClassName = 'hello';
-        render(<Pill data-testid="moonstone-listItemChip" className={testClassName} content={<>Say my name</>}/>);
+        render(<Pill data-testid="moonstone-listItemChip" className={testClassName} content="Say my name"/>);
         expect(screen.getByTestId('moonstone-listItemChip')).toHaveClass(testClassName);
     });
 
     it('should add additional attribute', () => {
-        render(<Pill data-testid="moonstone-listItemChip" content={<>Say my name</>}/>);
+        render(<Pill data-testid="moonstone-listItemChip" content="Say my name"/>);
         expect(screen.getByTestId('moonstone-listItemChip')).toBeInTheDocument();
     });
 

--- a/src/components/Pill/Pill.spec.tsx
+++ b/src/components/Pill/Pill.spec.tsx
@@ -20,7 +20,7 @@ describe('Pill', () => {
     });
 
     it('should display an icon when content is an icon element', () => {
-        render(<Pill data-testid="moonstone-pill" content={<Cloud data-testid="moonstone-pill-icon"/>}/>);
+        render(<Pill content={<Cloud data-testid="moonstone-pill-icon"/>}/>);
         expect(screen.getByTestId('moonstone-pill-icon')).toBeInTheDocument();
     });
 

--- a/src/components/Pill/Pill.spec.tsx
+++ b/src/components/Pill/Pill.spec.tsx
@@ -1,20 +1,34 @@
 import {render, screen} from '@testing-library/react';
 import {Pill} from './index';
+import {Cloud} from '~/icons';
 
 describe('Pill', () => {
-    it('should display label', () => {
-        render(<Pill label="Say my name"/>);
+    it('should display content', () => {
+        render(<Pill content={<>Say my name</>}/>);
         expect(screen.getByText('Say my name')).toBeInTheDocument();
     });
 
     it('should add additional class names', () => {
         const testClassName = 'hello';
-        render(<Pill data-testid="moonstone-listItemChip" className={testClassName} label="Say my name"/>);
+        render(<Pill data-testid="moonstone-listItemChip" className={testClassName} content={<>Say my name</>}/>);
         expect(screen.getByTestId('moonstone-listItemChip')).toHaveClass(testClassName);
     });
 
     it('should add additional attribute', () => {
-        render(<Pill data-testid="moonstone-listItemChip" label="Say my name"/>);
+        render(<Pill data-testid="moonstone-listItemChip" content={<>Say my name</>}/>);
         expect(screen.getByTestId('moonstone-listItemChip')).toBeInTheDocument();
+    });
+
+    it('should display an icon when content is an icon element', () => {
+        render(<Pill data-testid="moonstone-pill" content={<Cloud data-testid="moonstone-pill-icon"/>}/>);
+        expect(screen.getByTestId('moonstone-pill-icon')).toBeInTheDocument();
+    });
+
+    it('should still display label and warn when using the deprecated label prop', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => vi.fn());
+        render(<Pill label="Say my name"/>);
+        expect(screen.getByText('Say my name')).toBeInTheDocument();
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('deprecated'));
+        warnSpy.mockRestore();
     });
 });

--- a/src/components/Pill/Pill.stories.tsx
+++ b/src/components/Pill/Pill.stories.tsx
@@ -24,6 +24,6 @@ export const Default: StoryObj<PillProps> = {
 
 export const IconContent: StoryObj<PillProps> = {
     args: {
-        content: <Language/>
+        content: <Language size="small"/>
     }
 };

--- a/src/components/Pill/Pill.stories.tsx
+++ b/src/components/Pill/Pill.stories.tsx
@@ -4,6 +4,8 @@ import markdownNotes from './Pill.md';
 import {Pill} from './index';
 import type {PillProps} from './Pill.types';
 
+import {Cloud} from '~/icons';
+
 export default {
     title: 'Components/Pill',
     component: Pill,
@@ -16,6 +18,12 @@ export default {
 
 export const Default: StoryObj<PillProps> = {
     args: {
-        label: 'ListItem label'
+        content: 'ListItem label'
+    }
+};
+
+export const IconContent: StoryObj<PillProps> = {
+    args: {
+        content: <Cloud/>
     }
 };

--- a/src/components/Pill/Pill.stories.tsx
+++ b/src/components/Pill/Pill.stories.tsx
@@ -4,7 +4,7 @@ import markdownNotes from './Pill.md';
 import {Pill} from './index';
 import type {PillProps} from './Pill.types';
 
-import {Cloud} from '~/icons';
+import {Language} from '~/icons';
 
 export default {
     title: 'Components/Pill',
@@ -24,6 +24,6 @@ export const Default: StoryObj<PillProps> = {
 
 export const IconContent: StoryObj<PillProps> = {
     args: {
-        content: <Cloud/>
+        content: <Language/>
     }
 };

--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -8,10 +8,15 @@ import styles from './Pill.module.scss';
 
 export const Pill: React.FC<PillProps> = ({
     label,
+    content,
     className,
     isReversed,
     ...props
 }) => {
+    if (label !== undefined) {
+        console.warn('The property `label` is deprecated in the Pill component. Use `content` instead.');
+    }
+
     return (
         <Typography
             component="span"
@@ -24,7 +29,7 @@ export const Pill: React.FC<PillProps> = ({
             )}
             {...props}
         >
-            {label}
+            {content ?? label}
         </Typography>
     );
 };

--- a/src/components/Pill/Pill.types.ts
+++ b/src/components/Pill/Pill.types.ts
@@ -1,4 +1,4 @@
-export type PillProps = Omit<React.ComponentPropsWithoutRef<'span'>, 'className'> & {
+export type PillProps = Omit<React.ComponentPropsWithoutRef<'span'>, 'className' | 'content'> & {
     /**
      * ListItem label
      * @deprecated label is deprecated and will be removed in a future release. Use `content` instead.
@@ -8,7 +8,7 @@ export type PillProps = Omit<React.ComponentPropsWithoutRef<'span'>, 'className'
     /**
      * Content of the Pill (text or icon element)
      */
-    content?: React.ReactElement;
+    content?: React.ReactElement | string;
 
     /**
      * Whether the component should use reversed colors, it useful with dark background

--- a/src/components/Pill/Pill.types.ts
+++ b/src/components/Pill/Pill.types.ts
@@ -8,7 +8,7 @@ export type PillProps = Omit<React.ComponentPropsWithoutRef<'span'>, 'className'
     /**
      * Content of the Pill (text or icon element)
      */
-    content?: React.ReactElement | string;
+    content: React.ReactElement | string;
 
     /**
      * Whether the component should use reversed colors, it useful with dark background

--- a/src/components/Pill/Pill.types.ts
+++ b/src/components/Pill/Pill.types.ts
@@ -1,8 +1,14 @@
 export type PillProps = Omit<React.ComponentPropsWithoutRef<'span'>, 'className'> & {
     /**
      * ListItem label
+     * @deprecated label is deprecated and will be removed in a future release. Use `content` instead.
      */
-    label: string;
+    label?: string;
+
+    /**
+     * Content of the Pill (text or icon element)
+     */
+    content?: React.ReactElement;
 
     /**
      * Whether the component should use reversed colors, it useful with dark background

--- a/src/data/dropdownDataGroupedPill.tsx
+++ b/src/data/dropdownDataGroupedPill.tsx
@@ -8,12 +8,12 @@ export const dropdownDataGroupedPill: DropdownDataGrouped[] = [
             {
                 label: 'French',
                 value: 'fr',
-                iconEnd: <Pill label="FR"/>
+                iconEnd: <Pill content="FR"/>
             },
             {
                 label: '[translate:French (Canadian)]',
                 value: 'fr_ca',
-                iconEnd: <Pill label="FR_CA"/>
+                iconEnd: <Pill content="FR_CA"/>
             }
         ]
     },
@@ -23,12 +23,12 @@ export const dropdownDataGroupedPill: DropdownDataGrouped[] = [
             {
                 label: '[translate:Language with very long long label label label label label label label name (country name)]',
                 value: 'es',
-                iconEnd: <Pill label="ES"/>
+                iconEnd: <Pill content="ES"/>
             },
             {
                 label: 'English (disabled)',
                 value: 'en',
-                iconEnd: <Pill label="EN"/>,
+                iconEnd: <Pill content="EN"/>,
                 isDisabled: true
             }
         ]

--- a/src/data/dropdownDataPill.tsx
+++ b/src/data/dropdownDataPill.tsx
@@ -5,22 +5,22 @@ export const dropdownDataPill : DropdownDataOption[] = [
     {
         label: 'French',
         value: 'fr',
-        iconEnd: <Pill label="FR"/>
+        iconEnd: <Pill content="FR"/>
     },
     {
         label: 'French (Canadian)',
         value: 'fr_ca',
-        iconEnd: <Pill label="FR_CA"/>
+        iconEnd: <Pill content="FR_CA"/>
     },
     {
         label: 'Language with very long long label label label label label label label name (country name)',
         value: 'es',
-        iconEnd: <Pill label="ES"/>
+        iconEnd: <Pill content="ES"/>
     },
     {
         label: 'English (disabled)',
         value: 'en',
-        iconEnd: <Pill label="EN"/>,
+        iconEnd: <Pill content="EN"/>,
         isDisabled: true
     }
 ];

--- a/src/data/dropdownDataTreePill.tsx
+++ b/src/data/dropdownDataTreePill.tsx
@@ -6,13 +6,13 @@ export const dropdownDataTreePill: TreeViewData[] = [
         id: 'fr',
         label: 'French',
         value: 'fr',
-        iconEnd: <Pill label="FR"/>,
+        iconEnd: <Pill content="FR"/>,
         children: [
             {
                 id: 'fr_ca',
                 label: 'French (Canadian)',
                 value: 'fr_ca',
-                iconEnd: <Pill label="FR_CA"/>
+                iconEnd: <Pill content="FR_CA"/>
             }
         ]
     },
@@ -20,13 +20,13 @@ export const dropdownDataTreePill: TreeViewData[] = [
         id: 'es',
         label: 'Label with very long long label label label label label label label name (country name)',
         value: 'es',
-        iconEnd: <Pill label="ES"/>
+        iconEnd: <Pill content="ES"/>
     },
     {
         id: 'en',
         label: 'English (disabled)',
         value: 'en',
         isDisabled: true,
-        iconEnd: <Pill label="EN"/>
+        iconEnd: <Pill content="EN"/>
     }
 ];


### PR DESCRIPTION
- Added content prop (text or icon) to Pill
- Deprecated label prop
- The choice to type like this `React.ReactElement | string` is because ReactElement accept only an object so it's not possible to have a string with only this type 