### PR TITLE
feat: allow Drawer to accept Paper props and customizable HTML tag

### DIFF
--- a/.chachalog/61tvA4gq.md
+++ b/.chachalog/61tvA4gq.md
@@ -1,6 +1,6 @@
 ---
 # Allowed version bumps: patch, minor, major
-"@jahia/moonstone": minor
+"@jahia/moonstone": patch
 ---
 
 Allow Drawer to accept Paper props and customizable HTML tag (#1406)

--- a/.chachalog/61tvA4gq.md
+++ b/.chachalog/61tvA4gq.md
@@ -3,4 +3,4 @@
 "@jahia/moonstone": patch
 ---
 
-Allow Drawer to accept Paper props and customizable HTML tag (#1406)
+Allow `Drawer` to accept Paper's props and a customizable HTML tag for rendering (#1406)

--- a/.chachalog/61tvA4gq.md
+++ b/.chachalog/61tvA4gq.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/moonstone": minor
+---
+
+Allow Drawer to accept Paper props and customizable HTML tag (#1406)

--- a/src/components/Drawer/Drawer.spec.tsx
+++ b/src/components/Drawer/Drawer.spec.tsx
@@ -32,11 +32,6 @@ describe('Drawer', () => {
         expect(screen.getByTestId('moonstone-drawer')).not.toHaveAttribute('aria-modal');
     });
 
-    it('should forward Paper props such as hasPadding', () => {
-        render(<Drawer isOpen hasPadding={false} data-testid="moonstone-drawer">Drawer content</Drawer>);
-        expect(screen.getByTestId('moonstone-drawer')).not.toHaveClass('moonstone-paper_padding');
-    });
-
     it('should render as an aside by default', () => {
         render(<Drawer isOpen data-testid="moonstone-drawer">Drawer content</Drawer>);
         expect(screen.getByTestId('moonstone-drawer').tagName).toBe('ASIDE');

--- a/src/components/Drawer/Drawer.spec.tsx
+++ b/src/components/Drawer/Drawer.spec.tsx
@@ -36,4 +36,14 @@ describe('Drawer', () => {
         render(<Drawer isOpen hasPadding={false} data-testid="moonstone-drawer">Drawer content</Drawer>);
         expect(screen.getByTestId('moonstone-drawer')).not.toHaveClass('moonstone-paper_padding');
     });
+
+    it('should render as an aside by default', () => {
+        render(<Drawer isOpen data-testid="moonstone-drawer">Drawer content</Drawer>);
+        expect(screen.getByTestId('moonstone-drawer').tagName).toBe('ASIDE');
+    });
+
+    it('should render as the given component', () => {
+        render(<Drawer isOpen component="div" data-testid="moonstone-drawer">Drawer content</Drawer>);
+        expect(screen.getByTestId('moonstone-drawer').tagName).toBe('DIV');
+    });
 });

--- a/src/components/Drawer/Drawer.spec.tsx
+++ b/src/components/Drawer/Drawer.spec.tsx
@@ -31,4 +31,9 @@ describe('Drawer', () => {
         render(<Drawer isOpen data-testid="moonstone-drawer">Drawer content</Drawer>);
         expect(screen.getByTestId('moonstone-drawer')).not.toHaveAttribute('aria-modal');
     });
+
+    it('should forward Paper props such as hasPadding', () => {
+        render(<Drawer isOpen hasPadding={false} data-testid="moonstone-drawer">Drawer content</Drawer>);
+        expect(screen.getByTestId('moonstone-drawer')).not.toHaveClass('moonstone-paper_padding');
+    });
 });

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import clsx from 'clsx';
 import type {PolymorphicComponent} from '~/types/Polymorphic.types';
-import type {PaperProps} from '~/components/Paper/Paper.types';
+import type {BasicPaperProps, PaperProps} from '~/components/Paper/Paper.types';
 import type {BasicDrawerProps, DrawerProps} from './Drawer.types';
 import {Paper} from '~/components/Paper';
 import {usePresence} from '~/hooks';
@@ -22,19 +22,20 @@ export const Drawer = React.forwardRef(<C extends React.ElementType = 'aside'>({
     ref: React.Ref<HTMLElement>) => {
     const {isPresent, state} = usePresence(isOpen, ANIMATION_DURATION);
 
+    // The <C> resolved by Drawer's own polymorphism can't be statically verified against Paper's
+    // independent <C> at the same time, so the merged prop bag is cast once as an escape hatch.
+    const paperProps = {
+        ref,
+        component: component || 'aside',
+        className: clsx(styles.drawer, className),
+        ...props as BasicPaperProps,
+        style: {...style, '--drawer-animation-duration': `${ANIMATION_DURATION}ms`} as React.CSSProperties,
+        'data-state': state,
+        children
+    } as unknown as PaperProps<C>;
+
     return (
-        isPresent && (
-            <Paper
-                ref={ref}
-                component={component || 'aside'}
-                className={clsx(styles.drawer, className)}
-                {...props as PaperProps}
-                style={{...style, '--drawer-animation-duration': `${ANIMATION_DURATION}ms`} as React.CSSProperties}
-                data-state={state}
-            >
-                {children}
-            </Paper>
-        )
+        isPresent && <Paper {...paperProps}/>
     );
 }) as unknown as PolymorphicComponent<'aside', BasicDrawerProps>;
 

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -7,14 +7,21 @@ import {Paper} from '~/components/Paper';
 import {usePresence} from '~/hooks';
 import styles from './Drawer.module.scss';
 
+// Duration of the slide animation, in ms.
+// Feeds both the usePresence unmount delay and the CSS (via the --drawer-animation-duration custom property)
+const ANIMATION_DURATION = 400;
+
 export const Drawer = React.forwardRef(<C extends React.ElementType = 'aside'>({
     className,
     isOpen = false,
     children,
     component,
+    style,
     ...props
 }: DrawerProps<C>,
     ref: React.Ref<HTMLElement>) => {
+    const {isPresent, state} = usePresence(isOpen, ANIMATION_DURATION);
+
     return (
         isPresent && (
             <Paper
@@ -22,6 +29,8 @@ export const Drawer = React.forwardRef(<C extends React.ElementType = 'aside'>({
                 component={component || 'aside'}
                 className={clsx(styles.drawer, className)}
                 {...props as PaperProps}
+                style={{...style, '--drawer-animation-duration': `${ANIMATION_DURATION}ms`} as React.CSSProperties}
+                data-state={state}
             >
                 {children}
             </Paper>

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,28 +1,31 @@
 import React from 'react';
 import clsx from 'clsx';
-import type {DrawerProps} from './Drawer.types';
+import type {PolymorphicComponent} from '~/types/Polymorphic.types';
+import type {PaperProps} from '~/components/Paper/Paper.types';
+import type {BasicDrawerProps, DrawerProps} from './Drawer.types';
 import {Paper} from '~/components/Paper';
 import styles from './Drawer.module.scss';
 
-export const Drawer = React.forwardRef<HTMLElement, DrawerProps>(({
+export const Drawer = React.forwardRef(<C extends React.ElementType = 'aside'>({
     className,
     isOpen = false,
     children,
-    component = 'aside',
+    component,
     ...props
-}, ref) => {
+}: DrawerProps<C>,
+    ref: React.Ref<HTMLElement>) => {
     return (
         isOpen && (
             <Paper
                 ref={ref}
-                component={component}
+                component={component || 'aside'}
                 className={clsx(styles.drawer, className)}
-                {...props}
+                {...props as PaperProps}
             >
                 {children}
             </Paper>
         )
     );
-});
+}) as unknown as PolymorphicComponent<'aside', BasicDrawerProps>;
 
 Drawer.displayName = 'Drawer';

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -8,12 +8,14 @@ export const Drawer = React.forwardRef<HTMLElement, DrawerProps>(({
     className,
     isOpen = false,
     children,
+    component = 'aside',
     ...props
 }, ref) => {
     return (
         isOpen && (
             <Paper
                 ref={ref}
+                component={component}
                 className={clsx(styles.drawer, className)}
                 {...props}
             >

--- a/src/components/Drawer/Drawer.types.ts
+++ b/src/components/Drawer/Drawer.types.ts
@@ -1,7 +1,11 @@
-import {ReactNode} from 'react';
+import React, {ReactNode} from 'react';
+import type {PolymorphicPropsWithRef} from '~/types/Polymorphic.types';
 import type {PaperProps} from '~/components/Paper/Paper.types';
 
-export type DrawerProps = Omit<PaperProps, 'className' | 'children'> & {
+// inherits future Paper props without needing manual updates here.
+type PaperCustomProps = Omit<PaperProps, 'component' | 'children' | 'className' | keyof React.ComponentPropsWithRef<'section'>>;
+
+export type BasicDrawerProps = PaperCustomProps & {
     /**
      * Content of the Drawer
      */
@@ -16,4 +20,6 @@ export type DrawerProps = Omit<PaperProps, 'className' | 'children'> & {
      * Additional classname
      */
     className?: string;
-}
+};
+
+export type DrawerProps<C extends React.ElementType> = PolymorphicPropsWithRef<C, BasicDrawerProps>;

--- a/src/components/Drawer/Drawer.types.ts
+++ b/src/components/Drawer/Drawer.types.ts
@@ -2,7 +2,7 @@ import React, {ReactNode} from 'react';
 import type {PolymorphicPropsWithRef} from '~/types/Polymorphic.types';
 import type {PaperProps} from '~/components/Paper/Paper.types';
 
-// inherits future Paper props without needing manual updates here.
+// Inherits future Paper props without needing manual updates here.
 type PaperCustomProps = Omit<PaperProps, 'component' | 'children' | 'className' | keyof React.ComponentPropsWithRef<'section'>>;
 
 export type BasicDrawerProps = PaperCustomProps & {

--- a/src/components/Drawer/Drawer.types.ts
+++ b/src/components/Drawer/Drawer.types.ts
@@ -1,9 +1,9 @@
 import React, {ReactNode} from 'react';
 import type {PolymorphicPropsWithRef} from '~/types/Polymorphic.types';
-import type {PaperProps} from '~/components/Paper/Paper.types';
+import type {BasicPaperProps} from '~/components/Paper/Paper.types';
 
 // Inherits future Paper props without needing manual updates here.
-type PaperCustomProps = Omit<PaperProps, 'component' | 'children' | 'className' | keyof React.ComponentPropsWithRef<'section'>>;
+type PaperCustomProps = Omit<BasicPaperProps, 'children' | 'className'>;
 
 export type BasicDrawerProps = PaperCustomProps & {
     /**

--- a/src/components/Drawer/Drawer.types.ts
+++ b/src/components/Drawer/Drawer.types.ts
@@ -1,6 +1,7 @@
 import {ReactNode} from 'react';
+import type {PaperProps} from '~/components/Paper/Paper.types';
 
-export type DrawerProps = Omit<React.ComponentPropsWithRef<'section'>, 'className' | 'children'> & {
+export type DrawerProps = Omit<PaperProps, 'className' | 'children'> & {
     /**
      * Content of the Drawer
      */

--- a/src/components/Paper/Paper.spec.tsx
+++ b/src/components/Paper/Paper.spec.tsx
@@ -29,4 +29,9 @@ describe('Paper', () => {
         render(<Paper ref={ref} data-testid="moonstone-paper">Content here</Paper>);
         expect(ref.current).toBe(screen.getByTestId('moonstone-paper'));
     });
+
+    it('should render as the given component', () => {
+        render(<Paper component="div" data-testid="moonstone-paper">Content here</Paper>);
+        expect(screen.getByTestId('moonstone-paper').tagName).toBe('DIV');
+    });
 });

--- a/src/components/Paper/Paper.stories.tsx
+++ b/src/components/Paper/Paper.stories.tsx
@@ -1,18 +1,17 @@
 import {StoryObj} from '@storybook/react-vite';
 
 import {Paper} from './index';
-import type {PaperProps} from './Paper.types';
 
 export default {
     title: 'Components/Paper',
     component: Paper
 };
 
-export const Default: StoryObj<PaperProps> = {
+export const Default: StoryObj<typeof Paper> = {
     render: args => <Paper {...args}>Content here</Paper>
 };
 
-export const NoPadding: StoryObj<PaperProps> = {
+export const NoPadding: StoryObj<typeof Paper> = {
     render: args => <Paper {...args}>Content here</Paper>,
     args: {hasPadding: false}
 };

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import clsx from 'clsx';
-import type {PaperProps} from './Paper.types';
+import type {PolymorphicComponent} from '~/types/Polymorphic.types';
+import type {BasicPaperProps, PaperProps} from './Paper.types';
 import styles from './Paper.module.scss';
 
-export const Paper = React.forwardRef<HTMLElement, PaperProps>(({
+export const Paper = React.forwardRef(<C extends React.ElementType = 'section'>({
     children,
     hasPadding = true,
     className,
     component,
     ...props
-}, ref) => {
+}: PaperProps<C>,
+    ref: React.Ref<Element>) => {
     const classNameProps = clsx(
         ['moonstone-paper', styles['moonstone-paper']],
         hasPadding && ['moonstone-paper_padding', styles['moonstone-paper_padding']],
@@ -27,6 +29,6 @@ export const Paper = React.forwardRef<HTMLElement, PaperProps>(({
             {children}
         </Component>
     );
-});
+}) as unknown as PolymorphicComponent<'section', BasicPaperProps>;
 
 Paper.displayName = 'Paper';

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -7,6 +7,7 @@ export const Paper = React.forwardRef<HTMLElement, PaperProps>(({
     children,
     hasPadding = true,
     className,
+    component,
     ...props
 }, ref) => {
     const classNameProps = clsx(
@@ -19,10 +20,12 @@ export const Paper = React.forwardRef<HTMLElement, PaperProps>(({
         return null;
     }
 
+    const Component = component ?? 'section';
+
     return (
-        <section ref={ref} className={classNameProps} {...props}>
+        <Component ref={ref} className={classNameProps} {...props}>
             {children}
-        </section>
+        </Component>
     );
 });
 

--- a/src/components/Paper/Paper.types.ts
+++ b/src/components/Paper/Paper.types.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 export type PaperProps = Omit<React.ComponentPropsWithRef<'section'>, 'children' | 'className'> & {
     /**
-     * HTML tag to render
+     * HTML tag to render (default: 'section')
      */
     component?: React.ElementType;
 

--- a/src/components/Paper/Paper.types.ts
+++ b/src/components/Paper/Paper.types.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 export type PaperProps = Omit<React.ComponentPropsWithRef<'section'>, 'children' | 'className'> & {
     /**
-     * HTML tag or component to render (default: 'section')
+     * HTML tag to render
      */
     component?: React.ElementType;
 

--- a/src/components/Paper/Paper.types.ts
+++ b/src/components/Paper/Paper.types.ts
@@ -1,11 +1,7 @@
 import React from 'react';
+import type {PolymorphicPropsWithRef} from '~/types/Polymorphic.types';
 
-export type PaperProps = Omit<React.ComponentPropsWithRef<'section'>, 'children' | 'className'> & {
-    /**
-     * HTML tag to render (default: 'section')
-     */
-    component?: React.ElementType;
-
+export type BasicPaperProps = {
     /**
      * Define if the component has padding
      */
@@ -20,4 +16,6 @@ export type PaperProps = Omit<React.ComponentPropsWithRef<'section'>, 'children'
      * Additional classname
      */
     className?: string;
-}
+};
+
+export type PaperProps<C extends React.ElementType> = PolymorphicPropsWithRef<C, BasicPaperProps>;

--- a/src/components/Paper/Paper.types.ts
+++ b/src/components/Paper/Paper.types.ts
@@ -2,6 +2,11 @@ import React from 'react';
 
 export type PaperProps = Omit<React.ComponentPropsWithRef<'section'>, 'children' | 'className'> & {
     /**
+     * HTML tag or component to render (default: 'section')
+     */
+    component?: React.ElementType;
+
+    /**
      * Define if the component has padding
      */
     hasPadding?: boolean;


### PR DESCRIPTION
- Add component prop to Paper to customize the rendered HTML tag
- Drawer now forwards component to Paper, defaulting to aside instead of section
- DrawerProps now extends PaperProps, exposing all Paper props on Drawer