### PR TITLE
feat: add animation to Drawer

### DIFF
--- a/.chachalog/K_S0_Gu4.md
+++ b/.chachalog/K_S0_Gu4.md
@@ -1,0 +1,5 @@
+---
+"@jahia/moonstone": patch
+---
+
+feat: add animation to Drawer

--- a/.chachalog/K_S0_Gu4.md
+++ b/.chachalog/K_S0_Gu4.md
@@ -2,4 +2,4 @@
 "@jahia/moonstone": patch
 ---
 
-feat: add animation to Drawer
+Add animation to Drawer

--- a/src/components/Drawer/Drawer.module.scss
+++ b/src/components/Drawer/Drawer.module.scss
@@ -6,3 +6,39 @@
     min-height: 0;
     overflow-y: auto;
 }
+
+.drawer[data-state='open'] {
+    animation: slide-in var(--drawer-animation-duration) cubic-bezier(0.39, 0.575, 0.565, 1) both; // easeOutSine
+}
+
+.drawer[data-state='closed'] {
+    animation: slide-out var(--drawer-animation-duration) cubic-bezier(0.39, 0.575, 0.565, 1) both; // easeOutSine
+}
+
+@keyframes slide-in {
+    from {
+        transform: translateX(100%);
+    }
+
+    to {
+        transform: translateX(0);
+    }
+}
+
+@keyframes slide-out {
+    from {
+        transform: translateX(0);
+    }
+
+    to {
+        transform: translateX(100%);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+    .drawer[data-state='open'],
+    .drawer[data-state='closed'] {
+        animation: none;
+    }
+}

--- a/src/components/Drawer/Drawer.module.scss
+++ b/src/components/Drawer/Drawer.module.scss
@@ -1,6 +1,7 @@
 .drawer {
     display: flex;
     flex-direction: column;
+    min-width: 100%;
 
     height: stretch;
     min-height: 0;

--- a/src/components/Drawer/Drawer.module.scss
+++ b/src/components/Drawer/Drawer.module.scss
@@ -37,7 +37,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-
     .drawer[data-state='open'],
     .drawer[data-state='closed'] {
         animation: none;

--- a/src/components/Drawer/Drawer.spec.tsx
+++ b/src/components/Drawer/Drawer.spec.tsx
@@ -1,10 +1,21 @@
-import {render, screen} from '@testing-library/react';
+import {render, screen, waitForElementToBeRemoved} from '@testing-library/react';
 import {Drawer} from './index';
 
 describe('Drawer', () => {
     it('should display content when open', () => {
         render(<Drawer isOpen data-testid="moonstone-drawer">Drawer content</Drawer>);
         expect(screen.getByText('Drawer content')).toBeInTheDocument();
+    });
+
+    it('should keep content mounted while closing, then remove it', async () => {
+        const {rerender} = render(<Drawer isOpen data-testid="moonstone-drawer">Drawer content</Drawer>);
+
+        rerender(<Drawer isOpen={false} data-testid="moonstone-drawer">Drawer content</Drawer>);
+        // Stays in the DOM in the closed state while the exit animation plays...
+        expect(screen.getByTestId('moonstone-drawer')).toHaveAttribute('data-state', 'closed');
+
+        // ...then unmounts once the animation completes.
+        await waitForElementToBeRemoved(() => screen.queryByText('Drawer content'));
     });
 
     it('should not display content by default', () => {

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -19,21 +19,19 @@ export const Playground: Story = {
     render: args => {
         const [open, setOpen] = useState(false);
         return (
-            <div style={{display: 'flex', minHeight: '320px'}}>
+            <div style={{display: 'flex', minHeight: '320px', overflow: 'hidden'}}>
                 <div style={{flex: 1, padding: 'var(--moon-spacing-medium)'}}>
-                    <Button label="Open drawer" onClick={() => setOpen(true)}/>
+                    <Button label="Toggle drawer" onClick={() => setOpen(!open)}/>
                 </div>
                 <Drawer {...args} isOpen={open} style={{width: '320px'}}>
-                    <div style={{padding: 'var(--moon-spacing-medium)'}}>
-                        <Typography variant="heading" weight="bold" component="h2">
-                            Drawer title
-                        </Typography>
-                        <Typography>
-                            This is the drawer content. You can put anything here.
-                        </Typography>
-                        <div style={{marginTop: 'var(--moon-spacing-medium)'}}>
-                            <Button label="Close" onClick={() => setOpen(false)}/>
-                        </div>
+                    <Typography variant="heading" weight="bold" component="h2">
+                        Drawer title
+                    </Typography>
+                    <Typography>
+                        This is the drawer content. You can put anything here.
+                    </Typography>
+                    <div style={{marginTop: 'var(--moon-spacing-medium)'}}>
+                        <Button label="Close" onClick={() => setOpen(false)}/>
                     </div>
                 </Drawer>
             </div>

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -2,20 +2,30 @@ import React from 'react';
 import clsx from 'clsx';
 import type {DrawerProps} from './Drawer.types';
 import {Paper} from '~/components/Paper';
+import {usePresence} from '~/hooks';
 import styles from './Drawer.module.scss';
+
+// Duration of the slide animation, in ms.
+// Feeds both the usePresence unmount delay and the CSS (via the --drawer-animation-duration custom property)
+const ANIMATION_DURATION = 400;
 
 export const Drawer = React.forwardRef<HTMLElement, DrawerProps>(({
     className,
     isOpen = false,
     children,
+    style,
     ...props
 }, ref) => {
+    const {isPresent, state} = usePresence(isOpen, ANIMATION_DURATION);
+
     return (
-        isOpen && (
+        isPresent && (
             <Paper
                 ref={ref}
                 className={clsx(styles.drawer, className)}
                 {...props}
+                style={{...style, '--drawer-animation-duration': `${ANIMATION_DURATION}ms`} as React.CSSProperties}
+                data-state={state}
             >
                 {children}
             </Paper>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,4 +4,5 @@ export * from './onArrowNavigation';
 export * from './useAccessibleClick';
 export * from './useEnterExitCallbacks';
 export * from './usePositioning';
+export * from './usePresence';
 export * from './useToggleNode';

--- a/src/hooks/usePresence.spec.tsx
+++ b/src/hooks/usePresence.spec.tsx
@@ -1,0 +1,40 @@
+import {render, screen, waitForElementToBeRemoved} from '@testing-library/react';
+import {usePresence} from './usePresence';
+
+describe('usePresence', () => {
+    const exitDuration = 50;
+
+    const Harness = ({isOpen}: {readonly isOpen: boolean}) => {
+        const {isPresent, state} = usePresence(isOpen, exitDuration);
+        return isPresent ? <div data-state={state}>content</div> : null;
+    };
+
+    it('should render nothing when closed from the start', () => {
+        render(<Harness isOpen={false}/>);
+        expect(screen.queryByText('content')).not.toBeInTheDocument();
+    });
+
+    it('should render in the open state when open', () => {
+        render(<Harness isOpen/>);
+        expect(screen.getByText('content')).toHaveAttribute('data-state', 'open');
+    });
+
+    it('should stay present in the closed state while exiting, then unmount', async () => {
+        const {rerender} = render(<Harness isOpen/>);
+
+        rerender(<Harness isOpen={false}/>);
+        expect(screen.getByText('content')).toHaveAttribute('data-state', 'closed');
+
+        await waitForElementToBeRemoved(() => screen.queryByText('content'));
+    });
+
+    it('should return to the open state when reopened during the exit', () => {
+        const {rerender} = render(<Harness isOpen/>);
+
+        rerender(<Harness isOpen={false}/>);
+        expect(screen.getByText('content')).toHaveAttribute('data-state', 'closed');
+
+        rerender(<Harness isOpen/>);
+        expect(screen.getByText('content')).toHaveAttribute('data-state', 'open');
+    });
+});

--- a/src/hooks/usePresence.tsx
+++ b/src/hooks/usePresence.tsx
@@ -1,0 +1,32 @@
+import {useEffect, useState} from 'react';
+
+/**
+ * Keeps a component present in the DOM while its exit animation plays.
+ *
+ * React removes an element as soon as you stop rendering it, so a CSS exit
+ * animation never gets the chance to run. This hook delays the removal by
+ * `exitDuration` ms after `isOpen` turns false, and exposes an `open`/`closed`
+ * state to drive the enter/exit animation from CSS.
+ *
+ * Render the element while `isPresent` is true and spread `state` onto it as a
+ * `data-state` attribute; let CSS animate `[data-state='open']` on enter and
+ * `[data-state='closed']` on exit.
+ *
+ * @param isOpen - whether the component should be shown
+ * @param exitDuration - exit animation duration in ms; keep in sync with the CSS
+ * @returns `isPresent` (render the element while true) and `state` ('open' while shown, 'closed' while exiting)
+ */
+export const usePresence = (isOpen: boolean, exitDuration: number) => {
+    const [isPresent, setIsPresent] = useState(isOpen);
+
+    useEffect(() => {
+        if (isOpen) {
+            setIsPresent(true);
+        } else if (isPresent) {
+            const timer = setTimeout(() => setIsPresent(false), exitDuration);
+            return () => clearTimeout(timer);
+        }
+    }, [isOpen, isPresent, exitDuration]);
+
+    return {isPresent, state: isOpen ? 'open' : 'closed'};
+};


### PR DESCRIPTION
<!--
When lists are present, items can be:
 - Deleted: The item is not applicable to the PR.
 - Unchecked: The item is not yet complete, but should be done as part of the PR.
 - Checked: The item has been completed.
-->

## Description
- Add animation to display and close the `Drawer`
- Add the hook `usePresence` that helps to animate elements in and out of the DOM. It keeps elements mounted during exit animations and provides a present state

## Tests

The following are included in this PR

- [ ] Unit Tests
- [ ] Accessibility is OK


## Checklist
<!--
This section contains a set of non-automated checks; it serves to remind you to consider some business-critical topics.
 - If any are not applicable, they can simply be deleted.
 - If you need to provide more details, please use the description section.
-->

- [ ] All files present (component - scss - spec - stories)
- [ ] All props ok and documented (typescript types)
- [ ] Required props, default values, variants and colors
- [ ] Example in storybook
- [ ] Reversed style (light/dark mode)
- [ ] Allows custom props
