### PR TITLE
feat: allow searching in the DataTable

### DIFF
--- a/.chachalog/Rk9pQ2vX.md
+++ b/.chachalog/Rk9pQ2vX.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/moonstone": minor
+---
+
+Add search to the `DataTable` component 

--- a/src/components/DataTable/DataTable.module.scss
+++ b/src/components/DataTable/DataTable.module.scss
@@ -1,5 +1,4 @@
 .search {
-    // Narrow, left-aligned field above the table, matching the design reference
     max-width: 250px;
     margin-top: var(--moon-spacing-small);
     margin-bottom: var(--moon-spacing-small);

--- a/src/components/DataTable/DataTable.module.scss
+++ b/src/components/DataTable/DataTable.module.scss
@@ -1,0 +1,6 @@
+.search {
+    // Narrow, left-aligned field above the table, matching the design reference
+    max-width: 250px;
+    margin-top: var(--moon-spacing-small);
+    margin-bottom: var(--moon-spacing-small);
+}

--- a/src/components/DataTable/DataTable.spec.tsx
+++ b/src/components/DataTable/DataTable.spec.tsx
@@ -962,3 +962,232 @@ describe('DataTable custom cells', () => {
         expect(firstHeadCell).toHaveStyle({padding: '0'});
     });
 });
+
+describe('DataTable search', () => {
+    it('should not render a search field by default', () => {
+        render(
+            <DataTable<TestData>
+                data={data}
+                columns={columns}
+                primaryKey="id"
+            />
+        );
+
+        expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
+    });
+
+    it('should filter rows on the searchable columns, ignoring case', async () => {
+        const user = userEvent.setup();
+        render(
+            <DataTable<TestData>
+                enableSearch
+                data={data}
+                columns={columns}
+                primaryKey="id"
+                searchColumns={['name']}
+            />
+        );
+
+        await user.type(screen.getByRole('searchbox'), 'ALI');
+
+        expect(screen.getByText('Alice')).toBeInTheDocument();
+        expect(screen.queryByText('Bob')).not.toBeInTheDocument();
+        expect(screen.queryByText('Charlie')).not.toBeInTheDocument();
+    });
+
+    it('should ignore columns left out of searchColumns', async () => {
+        const user = userEvent.setup();
+        render(
+            <DataTable<TestData>
+                enableSearch
+                data={data}
+                columns={columns}
+                primaryKey="id"
+                searchColumns={['name']}
+            />
+        );
+
+        // 25 is the age of Bob, but the age column is not searchable
+        await user.type(screen.getByRole('searchbox'), '25');
+
+        expect(screen.queryByText('Bob')).not.toBeInTheDocument();
+    });
+
+    it('should report the query through onSearchChange', async () => {
+        const user = userEvent.setup();
+        const onSearchChange = vi.fn();
+        render(
+            <DataTable<TestData>
+                enableSearch
+                data={data}
+                columns={columns}
+                primaryKey="id"
+                searchColumns={['name']}
+                searchValue=""
+                onSearchChange={onSearchChange}
+            />
+        );
+
+        await user.type(screen.getByRole('searchbox'), 'a');
+
+        expect(onSearchChange).toHaveBeenCalledWith('a');
+    });
+
+    it('should restore every row when the search field is cleared', async () => {
+        const user = userEvent.setup();
+        render(
+            <DataTable<TestData>
+                enableSearch
+                data={data}
+                columns={columns}
+                primaryKey="id"
+                searchColumns={['name']}
+            />
+        );
+
+        await user.type(screen.getByRole('searchbox'), 'alice');
+        expect(screen.queryByText('Bob')).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', {name: 'Reset'}));
+
+        expect(screen.getByText('Bob')).toBeInTheDocument();
+        expect(screen.getByRole('searchbox')).toHaveValue('');
+    });
+
+    it('should honour a controlled searchValue', () => {
+        render(
+            <DataTable<TestData>
+                enableSearch
+                data={data}
+                columns={columns}
+                primaryKey="id"
+                searchColumns={['name']}
+                searchValue="bob"
+                onSearchChange={() => { }}
+            />
+        );
+
+        expect(screen.getByRole('searchbox')).toHaveValue('bob');
+        expect(screen.getByText('Bob')).toBeInTheDocument();
+        expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+    });
+
+    it('should not filter anything when searchColumns is omitted (server-side search)', () => {
+        // No searchColumns: the consumer already filtered `data`, the table must render it as-is
+        render(
+            <DataTable<TestData>
+                enableSearch
+                data={data}
+                columns={columns}
+                primaryKey="id"
+                searchValue="nothing matches this"
+                onSearchChange={() => { }}
+            />
+        );
+
+        expect(screen.getByText('Alice')).toBeInTheDocument();
+        expect(screen.getByText('Bob')).toBeInTheDocument();
+        expect(screen.getByText('Charlie')).toBeInTheDocument();
+    });
+
+    it('should keep the search field mounted when data is empty', () => {
+        // Regression: a server-side query with no result used to unmount the whole component,
+        // leaving the user unable to clear their own query
+        render(
+            <DataTable<TestData>
+                enableSearch
+                data={[]}
+                columns={columns}
+                primaryKey="id"
+                searchValue="no result"
+                onSearchChange={() => { }}
+            />
+        );
+
+        expect(screen.getByRole('searchbox')).toHaveValue('no result');
+    });
+
+    it('should go back to the first page and recount when the query changes', async () => {
+        const user = userEvent.setup();
+        render(
+            <DataTable<TestData>
+                enableSearch
+                enablePagination
+                data={data}
+                columns={columns}
+                primaryKey="id"
+                searchColumns={['name']}
+                itemsPerPageOptions={[1, 5]}
+                defaultCurrentPage={2}
+                defaultItemsPerPage={1}
+            />
+        );
+
+        expect(screen.getByText('Bob')).toBeInTheDocument();
+
+        // Alice and Charlie match, Bob does not
+        await user.type(screen.getByRole('searchbox'), 'a');
+
+        expect(screen.getByText('Alice')).toBeInTheDocument();
+        expect(screen.queryByText('Bob')).not.toBeInTheDocument();
+        expect(screen.getByText('1-1 of 2')).toBeInTheDocument();
+    });
+
+    it('should keep the ancestors of a matching nested row visible', async () => {
+        const user = userEvent.setup();
+        render(
+            <DataTable<TestData>
+                isStructured
+                enableSearch
+                data={structuredData}
+                columns={columns}
+                primaryKey="id"
+                searchColumns={['name']}
+            />
+        );
+
+        await user.type(screen.getByRole('searchbox'), 'child');
+
+        expect(screen.getByText('Child')).toBeInTheDocument();
+        expect(screen.getByText('Parent')).toBeInTheDocument();
+    });
+
+    it('should keep a row selected after it has been filtered out of view', async () => {
+        const user = userEvent.setup();
+        render(
+            <DataTable<TestData>
+                enableSearch
+                enableSelection
+                data={data}
+                columns={columns}
+                primaryKey="id"
+                searchColumns={['name']}
+                defaultSelection={['2']}
+            />
+        );
+
+        await user.type(screen.getByRole('searchbox'), 'alice');
+        expect(screen.queryByText('Bob')).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', {name: 'Reset'}));
+
+        // The index of the first row checkbox is index 1, as 0 is the header
+        expect(screen.getAllByRole('checkbox')[2]).toBeChecked();
+    });
+
+    it('should allow custom attributes on the SearchInput', () => {
+        render(
+            <DataTable<TestData>
+                enableSearch
+                data={data}
+                columns={columns}
+                primaryKey="id"
+                searchColumns={['name']}
+                searchInputProps={{placeholder: 'Find a user', className: 'custom-search'}}
+            />
+        );
+
+        expect(screen.getByPlaceholderText('Find a user')).toBeInTheDocument();
+        expect(screen.getByRole('search')).toHaveClass('custom-search');
+    });
+});

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -18,7 +18,9 @@ export default {
         enablePagination: {control: 'boolean'},
         defaultItemsPerPage: {control: 'number'},
         itemsPerPageOptions: {control: 'object'},
-        i18n: {control: 'object'}
+        i18n: {control: 'object'},
+        enableSearch: {control: 'boolean'},
+        searchColumns: {control: 'object'}
     }
 } satisfies Meta<typeof DataTable<DataUser>>;
 
@@ -114,6 +116,75 @@ export const ControlledDataTable: Story = {
         );
     },
     name: 'Controlled DataTable'
+};
+
+export const SearchableDataTable: Story = {
+    render: args => {
+        return <DataTable {...args}/>;
+    },
+    args: {
+        data: tableFlat,
+        columns: dataColumnsUser,
+        primaryKey: 'id',
+        enableSearch: true,
+        searchColumns: ['firstName', 'status', 'progress'],
+        searchInputProps: {placeholder: 'Search by user, status or progress'}
+    },
+    name: 'Searchable DataTable (uncontrolled)'
+};
+
+export const ControlledSearchDataTable: Story = {
+    render: () => {
+        const [searchValue, setSearchValue] = useState('');
+
+        return (
+            <DataTable
+                enableSearch
+                data={tableFlat}
+                columns={dataColumnsUser}
+                primaryKey="id"
+                searchColumns={['firstName', 'status', 'progress']}
+                searchValue={searchValue}
+                onSearchChange={setSearchValue}
+            />
+        );
+    },
+    name: 'Controlled search (the table filters)'
+};
+
+export const ServerSideSearchDataTable: Story = {
+    render: () => {
+        const [searchValue, setSearchValue] = useState('');
+        const [currentPage, setCurrentPage] = useState(1);
+        const [itemsPerPage, setItemsPerPage] = useState(10);
+
+        const query = searchValue.toLowerCase();
+        const matchingRows = tableFlat.filter(row => `${row.firstName} ${row.lastName}`.toLowerCase().includes(query));
+        const pageRows = matchingRows.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
+
+        return (
+            <DataTable
+                enableSearch
+                enablePagination
+                enableSorting={false}
+                data={pageRows}
+                columns={dataColumnsUser}
+                primaryKey="id"
+                searchValue={searchValue}
+                currentPage={currentPage}
+                itemsPerPage={itemsPerPage}
+                totalItems={matchingRows.length}
+                searchInputProps={{placeholder: 'Search on the server'}}
+                onSearchChange={value => {
+                    setSearchValue(value);
+                    setCurrentPage(1);
+                }}
+                onPageChange={setCurrentPage}
+                onItemsPerPageChange={setItemsPerPage}
+            />
+        );
+    },
+    name: 'Server-side search (the consumer filters)'
 };
 
 export const InsertCells: Story = {

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -133,25 +133,6 @@ export const SearchableDataTable: Story = {
     name: 'Searchable DataTable (uncontrolled)'
 };
 
-export const ControlledSearchDataTable: Story = {
-    render: () => {
-        const [searchValue, setSearchValue] = useState('');
-
-        return (
-            <DataTable
-                enableSearch
-                data={tableFlat}
-                columns={dataColumnsUser}
-                primaryKey="id"
-                searchColumns={['firstName', 'status', 'progress']}
-                searchValue={searchValue}
-                onSearchChange={setSearchValue}
-            />
-        );
-    },
-    name: 'Controlled search (the table filters)'
-};
-
 export const ServerSideSearchDataTable: Story = {
     render: () => {
         const [searchValue, setSearchValue] = useState('');

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -2,9 +2,11 @@ import {
     useReactTable,
     getCoreRowModel,
     getExpandedRowModel,
+    getFilteredRowModel,
     getSortedRowModel,
     getPaginationRowModel
 } from '@tanstack/react-table';
+import clsx from 'clsx';
 import {toNodeArray} from '~/utils/helpers';
 import type {Row} from '@tanstack/react-table';
 import React, {useMemo, useCallback} from 'react';
@@ -13,7 +15,9 @@ import type {DataTableProps, RenderOptions} from './DataTable.types';
 import {createTableColumns} from './shared';
 import {renderCell, renderHeadCell} from './utils';
 import {Checkbox} from '~/components';
+import {SearchInput} from '~/components/Input';
 import {Pagination} from '~/components/Pagination';
+import styles from './DataTable.module.scss';
 import {
     Table,
     TableRow,
@@ -60,6 +64,11 @@ export const DataTable = <T extends NonNullable<unknown>>({
     totalItems,
     i18n,
     paginationProps,
+    enableSearch = false,
+    searchColumns,
+    searchValue,
+    onSearchChange,
+    searchInputProps,
     rowProps,
     ...props
 }: DataTableProps<T>) => {
@@ -114,7 +123,8 @@ export const DataTable = <T extends NonNullable<unknown>>({
             expanded,
             rowSelection,
             sorting,
-            ...(enablePagination && {pagination})
+            ...(enablePagination && {pagination}),
+            ...(searchValue !== undefined && {globalFilter: searchValue})
         },
         onSortingChange: handleSortingChange,
         onExpandedChange: handleExpandedChange,
@@ -122,6 +132,10 @@ export const DataTable = <T extends NonNullable<unknown>>({
         getCoreRowModel: getCoreRowModel(),
         getSortedRowModel: enableSorting ? getSortedRowModel() : undefined,
         manualSorting: isSortingControlled,
+        getFilteredRowModel: enableSearch ? getFilteredRowModel() : undefined,
+        globalFilterFn: 'includesString',
+        getColumnCanGlobalFilter: column => Boolean(searchColumns?.some(key => key === column.id)),
+        filterFromLeafRows: isStructured,
         getExpandedRowModel: getExpandedRowModel(),
         getPaginationRowModel: enablePagination ? getPaginationRowModel() : undefined,
         manualPagination: isPaginationControlled,
@@ -202,12 +216,27 @@ export const DataTable = <T extends NonNullable<unknown>>({
         [renderRow, renderRowContent, rowProps]
     );
 
-    if (!data || !Array.isArray(data) || data.length === 0) {
+    const isEmpty = !data || !Array.isArray(data) || data.length === 0;
+
+    const searchQuery = String(table.getState().globalFilter ?? '');
+    const setSearchQuery: (value: string) => void = onSearchChange ?? table.setGlobalFilter;
+
+    if (isEmpty && !enableSearch) {
         return null;
     }
 
     return (
         <>
+            {enableSearch && (
+                <SearchInput
+                    variant="outlined"
+                    value={searchQuery}
+                    onChange={event => setSearchQuery(event.target.value)}
+                    onClear={() => setSearchQuery('')}
+                    {...searchInputProps}
+                    className={clsx(styles.search, searchInputProps?.className)}
+                />
+            )}
             <Table className={className} {...props}>
                 <TableHead>
                     {table.getHeaderGroups().map(headerGroup => (

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -119,6 +119,7 @@ export const DataTable = <T extends NonNullable<unknown>>({
     const table = useReactTable({
         data,
         columns: tableColumns,
+        initialState: {globalFilter: ''},
         state: {
             expanded,
             rowSelection,
@@ -218,8 +219,9 @@ export const DataTable = <T extends NonNullable<unknown>>({
 
     const isEmpty = !data || !Array.isArray(data) || data.length === 0;
 
-    const searchQuery = String(table.getState().globalFilter ?? '');
+    const searchQuery = String(table.getState().globalFilter);
     const setSearchQuery: (value: string) => void = onSearchChange ?? table.setGlobalFilter;
+    const searchLabel = searchInputProps?.placeholder ?? 'Search';
 
     if (isEmpty && !enableSearch) {
         return null;
@@ -231,6 +233,8 @@ export const DataTable = <T extends NonNullable<unknown>>({
                 <SearchInput
                     variant="outlined"
                     value={searchQuery}
+                    aria-label={searchLabel}
+                    placeholder={searchLabel}
                     onChange={event => setSearchQuery(event.target.value)}
                     onClear={() => setSearchQuery('')}
                     {...searchInputProps}

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -191,9 +191,11 @@ type SearchProps<T extends NonNullable<unknown>> =
           /** Enable search for the table */
           enableSearch: true;
           /**
-           * Keys of the columns the table searches into, matched with a case-insensitive
-           * substring comparison. Omit it when `data` is already filtered by the consumer
-           * (server-side search): the table then renders the input without filtering.
+           * Keys of the columns the table searches into. The match is a case-insensitive
+           * substring comparison against the raw row value, not the rendered cell content,
+           * so a column displaying a formatted date is matched on its underlying value.
+           * Leaving it out makes the table render the input without filtering anything,
+           * which is what server-side search needs.
            */
           searchColumns?: SearchColumns<T>;
           /** Current search query (controlled) */
@@ -207,9 +209,11 @@ type SearchProps<T extends NonNullable<unknown>> =
           /** Enable search for the table */
           enableSearch: true;
           /**
-           * Keys of the columns the table searches into, matched with a case-insensitive
-           * substring comparison against the raw row value, not the rendered cell content:
-           * a column rendering a formatted date is matched on its underlying value.
+           * Keys of the columns the table searches into. The match is a case-insensitive
+           * substring comparison against the raw row value, not the rendered cell content,
+           * so a column displaying a formatted date is matched on its underlying value.
+           * Leaving it out makes the table render the input without filtering anything,
+           * which is what server-side search needs.
            */
           searchColumns: SearchColumns<T>;
           searchValue?: never;

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -202,7 +202,10 @@ type SearchProps<T extends NonNullable<unknown>> =
           searchValue: string;
           /** Callback when the search query changes */
           onSearchChange: (searchValue: string) => void;
-          /** Custom attributes added to the SearchInput element */
+          /**
+           * Custom attributes added to the SearchInput element.
+           * Passing `placeholder` also localizes the field, as it is reused as the default `aria-label`.
+           */
           searchInputProps?: SearchInputAttributes;
       }
     | {
@@ -218,7 +221,10 @@ type SearchProps<T extends NonNullable<unknown>> =
           searchColumns: SearchColumns<T>;
           searchValue?: never;
           onSearchChange?: never;
-          /** Custom attributes added to the SearchInput element */
+          /**
+           * Custom attributes added to the SearchInput element.
+           * Passing `placeholder` also localizes the field, as it is reused as the default `aria-label`.
+           */
           searchInputProps?: SearchInputAttributes;
       }
     | {

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -190,41 +190,23 @@ type SearchProps<T extends NonNullable<unknown>> =
     | {
           /** Enable search for the table */
           enableSearch: true;
-          /**
-           * Keys of the columns the table searches into. The match is a case-insensitive
-           * substring comparison against the raw row value, not the rendered cell content,
-           * so a column displaying a formatted date is matched on its underlying value.
-           * Leaving it out makes the table render the input without filtering anything,
-           * which is what server-side search needs.
-           */
+          /** Columns to search (case-insensitive substring match on the raw value). Omit for server-side search. */
           searchColumns?: SearchColumns<T>;
           /** Current search query (controlled) */
           searchValue: string;
           /** Callback when the search query changes */
           onSearchChange: (searchValue: string) => void;
-          /**
-           * Custom attributes added to the SearchInput element.
-           * Passing `placeholder` also localizes the field, as it is reused as the default `aria-label`.
-           */
+          /** Custom attributes added to the SearchInput element (pass `placeholder` to localize it) */
           searchInputProps?: SearchInputAttributes;
       }
     | {
           /** Enable search for the table */
           enableSearch: true;
-          /**
-           * Keys of the columns the table searches into. The match is a case-insensitive
-           * substring comparison against the raw row value, not the rendered cell content,
-           * so a column displaying a formatted date is matched on its underlying value.
-           * Leaving it out makes the table render the input without filtering anything,
-           * which is what server-side search needs.
-           */
+          /** Columns to search (case-insensitive substring match on the raw value). Omit for server-side search. */
           searchColumns: SearchColumns<T>;
           searchValue?: never;
           onSearchChange?: never;
-          /**
-           * Custom attributes added to the SearchInput element.
-           * Passing `placeholder` also localizes the field, as it is reused as the default `aria-label`.
-           */
+          /** Custom attributes added to the SearchInput element (pass `placeholder` to localize it) */
           searchInputProps?: SearchInputAttributes;
       }
     | {

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import type {TableCellProps} from '~/components/DataTable/cells';
+import type {SearchInputProps} from '~/components/Input/SearchInput/SearchInput.types';
 import type {DataTablePaginationProps} from './pagination';
 export type {PaginationUncontrolledProps} from './pagination';
 
@@ -181,6 +182,49 @@ export type SelectionProps =
           selectionCellProps?: never;
       };
 
+type SearchColumns<T extends NonNullable<unknown>> = Array<Extract<Exclude<keyof T, SubRowKey>, string>>;
+
+type SearchInputAttributes = Omit<SearchInputProps, 'value' | 'defaultValue' | 'onChange' | 'onClear'>;
+
+type SearchProps<T extends NonNullable<unknown>> =
+    | {
+          /** Enable search for the table */
+          enableSearch: true;
+          /**
+           * Keys of the columns the table searches into, matched with a case-insensitive
+           * substring comparison. Omit it when `data` is already filtered by the consumer
+           * (server-side search): the table then renders the input without filtering.
+           */
+          searchColumns?: SearchColumns<T>;
+          /** Current search query (controlled) */
+          searchValue: string;
+          /** Callback when the search query changes */
+          onSearchChange: (searchValue: string) => void;
+          /** Custom attributes added to the SearchInput element */
+          searchInputProps?: SearchInputAttributes;
+      }
+    | {
+          /** Enable search for the table */
+          enableSearch: true;
+          /**
+           * Keys of the columns the table searches into, matched with a case-insensitive
+           * substring comparison against the raw row value, not the rendered cell content:
+           * a column rendering a formatted date is matched on its underlying value.
+           */
+          searchColumns: SearchColumns<T>;
+          searchValue?: never;
+          onSearchChange?: never;
+          /** Custom attributes added to the SearchInput element */
+          searchInputProps?: SearchInputAttributes;
+      }
+    | {
+          enableSearch?: false;
+          searchColumns?: never;
+          searchValue?: never;
+          onSearchChange?: never;
+          searchInputProps?: never;
+      };
+
 export type RenderOptions = {
     /**
      * Custom cells to render before the data cells (selection + columns).
@@ -247,6 +291,7 @@ export type DataTableProps<T extends NonNullable<unknown>> = Omit<TableProps, 'c
     DataTableBaseProps<T> &
     SortingProps<T> &
     SelectionProps &
+    SearchProps<T> &
     StructuredProps &
     RenderRowProps<T> &
     DataTablePaginationProps;


### PR DESCRIPTION
- The Datatable can now display a search field that filters its rows as the user types, ignoring case.
- You choose which columns the search looks into.
- The search can also be handed off to the server: pass a controlled searchValue/onSearchChange (and skip searchColumns) if you filter the data yourself.
- A search returning no result no longer hides the search field, so it can always be cleared.